### PR TITLE
feat: add linkedin-search and x-search skills for reading/searching social job posts

### DIFF
--- a/.claude/skills/linkedin-search/SKILL.md
+++ b/.claude/skills/linkedin-search/SKILL.md
@@ -1,0 +1,203 @@
+# LinkedIn Search
+
+**name:** linkedin-search
+**description:** Searches and reads LinkedIn job postings (any country). Reads a specific LinkedIn job URL, or searches LinkedIn jobs by keyword + location. Deduplicates across runs. Triggers on: linkedin job, read this linkedin post, linkedin search, search linkedin, find linkedin jobs, "read this <linkedin.com/jobs/view/...> URL".
+**allowed-tools:** Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, Agent, AskUserQuestion
+
+---
+
+## How It Works
+
+LinkedIn has no public job API, but individual job postings are public at
+`linkedin.com/jobs/view/<id>` and are readable with **WebFetch**. Listings are
+discovered with **WebSearch** scoped to `linkedin.com/jobs/view` rather than
+scraped from LinkedIn's JS-heavy search pages.
+
+This skill therefore uses two primitives only — the same ones `job-scraper`
+relies on, so there is no fragile external dependency:
+
+- **WebSearch** to *discover* job-posting URLs
+- **WebFetch** to *read* each posting in full
+
+> **Note:** `mcp__exa__linkedin_search_exa` is **not** used here — it is
+> deprecated and searches *people/profiles*, not job postings. If an Exa web
+> search MCP tool is connected it can substitute for WebSearch in Mode B
+> discovery, but WebSearch is the default and requires no MCP server.
+
+This skill is **country-agnostic** by design (unlike the Danish portal CLIs in
+`.agents/skills/`). Pass a location and it scopes the search accordingly —
+LinkedIn serves country jobs from the `<cc>.linkedin.com` subdomain (e.g.
+`au.linkedin.com`, `dk.linkedin.com`).
+
+## Invocation
+
+Two modes, auto-detected from the user's input:
+
+### Mode A — Read a specific posting (URL given)
+Triggered when the input contains a `linkedin.com/jobs/view/...` URL.
+> "read this linkedin post — https://www.linkedin.com/jobs/view/4393056776"
+
+### Mode B — Search postings (keywords given)
+Triggered when the input is a query, not a URL.
+> "find AI engineer jobs on linkedin in Sydney"
+> "/linkedin staff data scientist remote"
+
+Optional arguments for Mode B:
+- A location, e.g. "in Sydney" / "remote" / "Copenhagen" (defaults to the
+  candidate's configured location in `CLAUDE.md`)
+- A recency hint, e.g. "this week" / "last month"
+
+---
+
+## Execution Steps
+
+### Step 0: Load State (both modes)
+
+1. Read `job_scraper/seen_jobs.json` (create `{"seen": {}}` if missing).
+2. Read `job_search_tracker.csv` to know which company+role pairs are already
+   tracked.
+
+---
+
+### Mode A — Read a specific posting
+
+1. **WebFetch** the URL with a prompt that extracts: job title, company,
+   location, posting date, employment type, seniority level, full description,
+   requirements/qualifications, salary (if listed), and application deadline.
+   - If the URL is `www.linkedin.com/...` and returns thin content, retry with
+     the country subdomain form `au.linkedin.com/...` (or the relevant `<cc>`).
+2. Present the posting in a clean summary (title, company, location, type,
+   posted, salary, deadline, then responsibilities / requirements / benefits).
+3. Record it in `seen_jobs.json` (see Step 4).
+4. Offer next step: a full fit evaluation via **`/apply <url>`** — but only if a
+   real profile exists (`CLAUDE.md` has no `[YOUR_...]` placeholders). If the
+   profile is still a template, say so plainly and do **not** fabricate a fit
+   score.
+
+---
+
+### Mode B — Search postings
+
+#### Step 1: Build the search
+
+Compose one or more WebSearch queries of the form:
+
+```
+site:linkedin.com/jobs/view <role / skill keywords> <location>
+```
+
+Call **WebSearch** with `allowed_domains: ["linkedin.com"]` to keep results on
+LinkedIn. Run 2–4 query variants in parallel (role synonyms, with/without
+location) for broader coverage. For a specific country, include the country
+name in the query; results commonly come back on the `<cc>.linkedin.com`
+subdomain.
+
+#### Step 2: Pre-filter, then fetch
+
+- From the search result titles/URLs, drop anything already in
+  `seen_jobs.json` or already tracked in `job_search_tracker.csv`.
+- **WebFetch** each remaining `jobs/view` URL to extract the fields listed in
+  Mode A step 1. Don't fetch every result — prioritise the most relevant
+  titles to stay token-efficient.
+
+#### Step 3: Quick fit assessment
+
+For each new job, a rapid signal only (not the full `/apply` evaluation):
+- **High** — role directly matches the candidate's core skills
+- **Medium** — adjacent to the candidate's experience
+- **Low** — requires significant missing skills
+
+If the profile is still a template (placeholders present), skip scoring and say
+the profile must be set up first (`/setup`).
+
+---
+
+### Step 4: Deduplicate & Store (both modes)
+
+Add every fetched job (presented or skipped) to `job_scraper/seen_jobs.json`:
+
+```json
+{
+  "seen": {
+    "<jobs-view-id-or-url>": {
+      "title": "...",
+      "company": "...",
+      "location": "...",
+      "url": "https://.../jobs/view/...",
+      "source": "linkedin",
+      "first_seen": "YYYY-MM-DD",
+      "fit": "high|medium|low|unknown",
+      "status": "new|skipped|evaluated"
+    }
+  }
+}
+```
+
+Use today's date from the session context for `first_seen`. Only present jobs
+not already seen or tracked.
+
+### Step 5: Present Results (Mode B)
+
+Sort by fit (high first):
+
+```
+## New LinkedIn Matches — YYYY-MM-DD
+
+Found X new postings (Y high, Z medium, W low).
+
+| # | Fit | Title | Company | Location | Posted | URL |
+|---|-----|-------|---------|----------|--------|-----|
+| 1 | High | ... | ... | ... | ... | [Link](...) |
+```
+
+For each high-match job add 2–3 bullets: why it matches, key requirements to
+check, any red flags (e.g. location outside the candidate's commute range).
+
+Then ask:
+> "Want a full evaluation of any of these? Give me the number(s) and I'll run
+> `/apply` on it."
+
+### Step 6: Hand off
+
+If the user picks a job, invoke **`/apply <url>`** (fit evaluation first, then
+CV + cover letter if approved). If they decide to apply, add a row to
+`job_search_tracker.csv` with `source` = `linkedin`.
+
+---
+
+## Important Rules
+
+1. **Never fabricate postings or fit scores.** Only present jobs returned by
+   real WebSearch/WebFetch calls, and only score fit against a real profile.
+2. **Respect deduplication.** Check `seen_jobs.json` *and*
+   `job_search_tracker.csv` before presenting.
+3. **Honour location.** Flag (don't silently drop) jobs outside the
+   candidate's commute range; remote/hybrid jobs override a location mismatch.
+4. **Only open positions.** Skip postings marked closed or past deadline.
+5. **Be token-efficient.** Pre-filter on titles before WebFetch; don't fetch
+   every search hit.
+6. **Parallelise.** Run discovery WebSearch variants and detail WebFetch calls
+   in parallel where possible.
+
+---
+
+## Usage Examples
+
+### Read one posting
+```
+read this linkedin post https://www.linkedin.com/jobs/view/4393056776
+```
+→ Mode A: WebFetch the URL, summarise, offer `/apply`.
+
+### Search by role + city
+```
+/linkedin AI engineer Sydney
+```
+→ Mode B: `WebSearch site:linkedin.com/jobs/view AI engineer Sydney`
+(`allowed_domains: ["linkedin.com"]`) → fetch top hits → dedup → table.
+
+### Search remote roles this week
+```
+find remote applied AI / agents jobs on linkedin posted this week
+```
+→ Mode B with location "remote" and a recency hint in the query.

--- a/.claude/skills/x-search/SKILL.md
+++ b/.claude/skills/x-search/SKILL.md
@@ -1,0 +1,229 @@
+# X (Twitter) Search
+
+**name:** x-search
+**description:** Reads and searches job/hiring posts on X (Twitter) via the llm-cli-gateway using Grok as the model. Reads a specific X post URL, or searches X for hiring posts by keyword/location/handle. Deduplicates across runs. Triggers on: x post, twitter job, read this x post, read this tweet, search x, find jobs on x, who is hiring on twitter, x.com/<...>/status/<...>.
+**allowed-tools:** Read, Write, Edit, Glob, Grep, Skill, AskUserQuestion
+
+---
+
+## How It Works
+
+Unlike LinkedIn (whose public job pages are readable with plain WebFetch — see
+the `linkedin-search` skill), **X is auth-walled and JS-heavy**: `WebFetch`,
+Exa `crawling_exa`/`web_fetch_exa`, and reader proxies all fail or return error
+pages for `x.com` URLs.
+
+The working mechanism is the **multi-LLM gateway (`gtwy` /
+`llm-cli-gateway`) with Grok as the model** — Grok has native, live access to
+X's search and post data. All X reads and searches in this skill go through
+`mcp__gtwy__grok_request` (or `..._async` for long searches). No WebFetch, no
+Exa for the X content itself.
+
+> If the `gtwy` MCP server is not connected, this skill cannot run — tell the
+> user X access requires the llm-cli-gateway + Grok and stop. Do **not** silently
+> fall back to WebFetch/Exa on `x.com`; they do not work.
+
+This skill is country-agnostic; pass a location in the query and Grok scopes
+the X search accordingly.
+
+### Grok call mechanics (learned the hard way — follow exactly)
+
+1. **Do NOT pass `effort` / `reasoningEffort`.** The default Grok model
+   (`grok-build`) rejects it with `400 ... does not support parameter
+   reasoningEffort`. Send a plain `prompt` only.
+2. **The sync response envelope often returns metadata only** (model,
+   `correlationId`, `durationMs`, `exitCode`) with no visible text. When that
+   happens, read the actual answer back with
+   `mcp__gtwy__llm_request_result` using the returned `correlationId`. This also
+   recovers the `"orphaned after gateway restart"` case — the response is still
+   persisted in the flight recorder.
+3. **Latency is ~30–45s.** `grok_request` auto-defers to a pollable job past the
+   sync deadline. For multi-query searches, prefer
+   `mcp__gtwy__grok_request_async` and poll with `llm_job_status` /
+   `llm_job_result`.
+4. **Grok cites posts as `[[n]](https://x.com/<handle>/status/<id>)`.** Capture
+   those `status` URLs — they are the canonical post links you store and pass to
+   `/apply`.
+
+---
+
+## Invocation
+
+Two modes, auto-detected from the user's input:
+
+### Mode A — Read a specific X post (URL given)
+Triggered when the input contains an `x.com/.../status/...` (or
+`twitter.com/...`) URL.
+> "read this x post — https://x.com/HarshalCh8411/status/2064033788804661635"
+
+### Mode B — Search X for hiring posts (query given)
+Triggered when the input is a query, not a URL.
+> "who's hiring AI engineers on X in Sydney"
+> "/x staff ML engineer remote #hiring"
+> "find recent founder 'we're hiring' posts for RAG / agents roles"
+
+Optional Mode B arguments:
+- A location (e.g. "Sydney" / "remote AUS") — defaults to the candidate's
+  location in `CLAUDE.md`.
+- A handle to scope to (e.g. "from:@someVC") or a hashtag (`#hiring`).
+- A recency hint ("this week", "today").
+
+---
+
+## Execution Steps
+
+### Step 0: Preconditions & State (both modes)
+
+1. Confirm the `gtwy` MCP server is available (a `mcp__gtwy__grok_request` tool
+   exists). If not, stop with the message above.
+2. Read `job_scraper/seen_jobs.json` (create `{"seen": {}}` if missing).
+3. Read `job_search_tracker.csv` to know which company+role pairs are tracked.
+
+---
+
+### Mode A — Read a specific X post
+
+1. Call `mcp__gtwy__grok_request` with a plain prompt (no `effort`):
+
+   > "Fetch this live X post: <URL>. Return as structured fields: author handle,
+   > post date, the full post text verbatim, whether it is a job/hiring post,
+   > and — if it is — the role title, company, location, work mode
+   > (onsite/hybrid/remote), seniority, key requirements, comp if stated, and
+   > any outbound application link (careers page, lnkd.in, form). Also list any
+   > linked thread posts. If you cannot access the post, say so explicitly."
+
+2. If the envelope has no text, read it back via `llm_request_result` with the
+   `correlationId`.
+3. Present a clean summary. X hiring posts are often informal founder threads
+   that **link out** to the real application — surface that outbound apply link
+   prominently.
+4. Record it in `seen_jobs.json` (Step 4).
+5. Offer a full fit evaluation via **`/apply <url-or-pasted-text>`** — but only
+   if a real profile exists (`CLAUDE.md` has no `[YOUR_...]` placeholders). If
+   the profile is still a template, say so and do **not** fabricate a fit score.
+   Since X posts are ephemeral and `/apply` may not be able to re-fetch the URL,
+   pass the extracted post text to `/apply` rather than relying on the link.
+
+---
+
+### Mode B — Search X for hiring posts
+
+1. Build the search intent (role/skills + location + optional handle/hashtag +
+   recency). Call `mcp__gtwy__grok_request_async` (preferred for searches):
+
+   > "Search live X (Twitter) for recent job/hiring posts matching: <role/skills>
+   > in <location>, posted within <recency>. Include founder 'we're hiring'
+   > posts, #hiring posts, and recruiter posts. Return up to <N> results as a
+   > list; for each: author handle, post URL (the x.com/.../status/... link),
+   > post date, role title, company, location, work mode, and the outbound
+   > application link if present. Exclude reposts/duplicates and closed roles.
+   > If you cannot access live X data, say so explicitly."
+
+2. Poll `llm_job_status` → collect with `llm_job_result` (or
+   `llm_request_result` by `correlationId`).
+3. **Dedup:** drop any post URL already in `seen_jobs.json` and any company+role
+   already in `job_search_tracker.csv`.
+4. **Quick fit assessment** for each new post (signal only, not the full
+   `/apply` evaluation): High / Medium / Low. Skip scoring if the profile is
+   still a template (say `/setup` is needed first).
+
+---
+
+### Step 4: Deduplicate & Store (both modes)
+
+Add every X post seen (presented or skipped) to `job_scraper/seen_jobs.json`:
+
+```json
+{
+  "seen": {
+    "<status-id-or-post-url>": {
+      "title": "...",
+      "company": "...",
+      "author_handle": "@...",
+      "location": "...",
+      "url": "https://x.com/<handle>/status/<id>",
+      "apply_link": "https://...",
+      "source": "x",
+      "first_seen": "YYYY-MM-DD",
+      "fit": "high|medium|low|unknown",
+      "status": "new|skipped|evaluated"
+    }
+  }
+}
+```
+
+Use today's date from the session context for `first_seen`. Only present posts
+not already seen or tracked.
+
+### Step 5: Present Results (Mode B)
+
+Sort by fit (high first):
+
+```
+## New X Hiring Posts — YYYY-MM-DD
+
+Found X new posts (Y high, Z medium, W low).
+
+| # | Fit | Role | Company | Author | Location | Apply | Post |
+|---|-----|------|---------|--------|----------|-------|------|
+| 1 | High | ... | ... | @... | ... | [Apply](...) | [Post](...) |
+```
+
+For each high-match post add 2–3 bullets: why it matches, key requirements to
+check, any red flags (location outside commute range, vague/anonymous poster,
+no verifiable company).
+
+Then ask:
+> "Want a full evaluation of any of these? Give me the number(s) and I'll run
+> `/apply` on it."
+
+### Step 6: Hand off
+
+If the user picks a post, invoke **`/apply`** with the extracted post text (not
+just the URL, since X may not be re-fetchable by WebFetch). If they decide to
+apply, add a row to `job_search_tracker.csv` with `source` = `x` and the post
+URL in `source`/`notes`.
+
+---
+
+## Important Rules
+
+1. **Grok is the only X fetch mechanism.** Never WebFetch/Exa an `x.com` URL —
+   it fails. All X reads/searches go through `gtwy` + Grok.
+2. **Never pass `effort`/`reasoningEffort`** to `grok_request` (400 on the
+   default model). Plain `prompt` only.
+3. **Always read back by `correlationId`** when the sync envelope lacks text.
+4. **Never fabricate posts or fit scores.** Only present posts Grok actually
+   returned, with their real `status` URLs; only score fit against a real
+   profile.
+5. **Verify before trusting.** X hiring posts are unvetted — an anonymous/low-
+   signal poster, a company that can't be confirmed, or a sketchy apply link is
+   a red flag to surface, not hide. Cross-check the company independently when a
+   post advances to `/apply`.
+6. **Respect deduplication** against `seen_jobs.json` and
+   `job_search_tracker.csv`.
+7. **Honour location**; flag (don't silently drop) out-of-range roles; remote
+   overrides a location mismatch.
+
+---
+
+## Usage Examples
+
+### Read one post
+```
+read this x post https://x.com/HarshalCh8411/status/2064033788804661635
+```
+→ Mode A: `grok_request` fetches the post → extract job fields + outbound apply
+link → offer `/apply`.
+
+### Search X by role + city
+```
+/x AI engineer Sydney #hiring this week
+```
+→ Mode B: `grok_request_async` searches live X → poll → dedup → table.
+
+### Scope to a person/VC's hiring posts
+```
+find recent "we're hiring" posts from founders building agents, remote AUS ok
+```
+→ Mode B with a founder/we're-hiring framing in the Grok search prompt.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ ai-job-search/
 │   │   │   └── 07-interview-prep.md   # STAR examples + interview framework
 │   │   ├── job-scraper/               # Job search orchestration
 │   │   ├── linkedin-search/           # Read/search LinkedIn job postings (any country, WebSearch + WebFetch)
+│   │   ├── x-search/                  # Read/search X (Twitter) hiring posts via llm-cli-gateway + Grok
 │   │   └── upskill/                   # /upskill skill gap analysis and learning plan
 │   └── settings.local.json            # Claude Code permissions
 ├── .agents/skills/                    # Job portal CLI tools (Denmark)
@@ -202,6 +203,8 @@ The CV uses [moderncv](https://ctan.org/pkg/moderncv) (banking style). The cover
 The four CLI tools in `.agents/skills/` are specific to the **Danish job market** (Jobbank, Jobdanmark, Jobindex, Jobnet). They demonstrate the pattern for building job portal integrations. If you're in a different country, you can build equivalent tools for your local job portals using the same structure.
 
 The **`linkedin-search`** skill (`.claude/skills/linkedin-search/`) is country-agnostic and works out of the box: it reads any public `linkedin.com/jobs/view/...` posting and searches LinkedIn jobs by keyword + location using `WebSearch` + `WebFetch` (no API key, no MCP server). Use it directly — "read this linkedin post `<url>`" or "find AI engineer jobs on linkedin in Sydney" — until you build local portal CLIs.
+
+The **`x-search`** skill (`.claude/skills/x-search/`) reads and searches **X (Twitter)** hiring posts. X is auth-walled, so `WebFetch`/Exa cannot read `x.com` URLs; instead this skill routes through the **multi-LLM gateway (`gtwy` / `llm-cli-gateway`) using Grok**, which has native live X access. It requires that MCP server to be connected. Use it as "read this x post `<url>`" or "who's hiring AI engineers on X in Sydney".
 
 ### Salary benchmarking
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ ai-job-search/
 │   │   │   ├── 06-cover-letter-templates.md # LaTeX cover letter templates
 │   │   │   └── 07-interview-prep.md   # STAR examples + interview framework
 │   │   ├── job-scraper/               # Job search orchestration
+│   │   ├── linkedin-search/           # Read/search LinkedIn job postings (any country, WebSearch + WebFetch)
 │   │   └── upskill/                   # /upskill skill gap analysis and learning plan
 │   └── settings.local.json            # Claude Code permissions
 ├── .agents/skills/                    # Job portal CLI tools (Denmark)
@@ -199,6 +200,8 @@ The CV uses [moderncv](https://ctan.org/pkg/moderncv) (banking style). The cover
 ### Job search tools
 
 The four CLI tools in `.agents/skills/` are specific to the **Danish job market** (Jobbank, Jobdanmark, Jobindex, Jobnet). They demonstrate the pattern for building job portal integrations. If you're in a different country, you can build equivalent tools for your local job portals using the same structure.
+
+The **`linkedin-search`** skill (`.claude/skills/linkedin-search/`) is country-agnostic and works out of the box: it reads any public `linkedin.com/jobs/view/...` posting and searches LinkedIn jobs by keyword + location using `WebSearch` + `WebFetch` (no API key, no MCP server). Use it directly — "read this linkedin post `<url>`" or "find AI engineer jobs on linkedin in Sydney" — until you build local portal CLIs.
 
 ### Salary benchmarking
 


### PR DESCRIPTION
## What

Adds two new social-source job skills, complementing the Denmark-only portal CLIs in `.agents/skills/`:

### 1. `linkedin-search` (country-agnostic, no dependencies)
Reads and searches LinkedIn job postings using `WebSearch` (discover) + `WebFetch` (read) — the same primitives `job-scraper` already uses. No API key, no MCP server.
- **Mode A — Read:** WebFetch a `linkedin.com/jobs/view/<id>` URL → structured summary.
- **Mode B — Search:** `WebSearch site:linkedin.com/jobs/view <role> <location>` (scoped with `allowed_domains`) → fetch top hits → fit-sorted table.
- Note: deliberately does **not** use `mcp__exa__linkedin_search_exa`, which is deprecated and searches *people/profiles*, not jobs. (Exa's `web_search_exa`/`crawling_exa` are not deprecated.)

### 2. `x-search` (X / Twitter, via Grok)
X is auth-walled and JS-heavy — `WebFetch`, Exa `crawling_exa`/`web_fetch_exa`, and reader proxies all fail on `x.com` URLs. This skill routes all X reads/searches through the **multi-LLM gateway (`gtwy` / `llm-cli-gateway`) using Grok**, which has native live X access. Requires that MCP server.
- **Mode A — Read:** Grok fetches a `x.com/<handle>/status/<id>` post → extract job fields + outbound apply link.
- **Mode B — Search:** Grok searches live X for hiring posts by keyword/location/handle.
- Documents the Grok call gotchas learned during build: never pass `effort`/`reasoningEffort` (400 on the default `grok-build` model), read results back via `llm_request_result` by `correlationId`, prefer the async variant for searches.

## Shared design

Both skills reuse the existing `job_scraper/seen_jobs.json` + `job_search_tracker.csv` deduplication (tagged `source: linkedin` / `source: x`), mirror `job-scraper`'s presentation format, hand off to `/apply`, and refuse to fabricate fit scores when the profile is still an un-onboarded template.

## Validation

Both skills were exercised against live data during development:
- `linkedin-search`: read a real `jobs/view` posting end-to-end; WebSearch returned clean `linkedin.com/jobs/view` URLs (incl. `au.linkedin.com`).
- `x-search`: Grok read a real X account's latest posts (with `status/` URLs) and searched X for a real hiring post.

## Files
- `.claude/skills/linkedin-search/SKILL.md` (new)
- `.claude/skills/x-search/SKILL.md` (new)
- `README.md` (skill tree + "Job search tools" notes for both)