### PR TITLE
fix(skills): add YAML frontmatter to enable auto-triggering and tool enforcement

### DIFF
--- a/.claude/skills/job-application-assistant/SKILL.md
+++ b/.claude/skills/job-application-assistant/SKILL.md
@@ -1,8 +1,13 @@
-# Job Application Assistant
+---
+name: job-application-assistant
+description: >
+  Assists with job applications: evaluating job postings, tailoring CVs, writing cover letters,
+  and preparing for interviews. Triggers on keywords like: job posting, job application, CV,
+  cover letter, resume, interview prep, job fit, career, application, apply, ansøgning, stilling
+allowed-tools: Read, Glob, Grep, WebFetch, WebSearch, Edit, Write, AskUserQuestion
+---
 
-**name:** job-application-assistant
-**description:** Assists with job applications: evaluating job postings, tailoring CVs, writing cover letters, and preparing for interviews. Triggers on keywords like: job posting, job application, CV, cover letter, resume, interview prep, job fit, career, application, apply, ansøgning, stilling
-**allowed-tools:** Read, Glob, Grep, WebFetch, WebSearch, Edit, Write, AskUserQuestion
+# Job Application Assistant
 
 ---
 

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -1,8 +1,12 @@
-# Job Scraper
+---
+name: job-scraper
+description: >
+  Scrapes Danish job sites for new positions matching your profile. Deduplicates across runs.
+  Triggers on: job scrape, find jobs, search jobs, new jobs, job search, scrape jobs, /scrape
+allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, Agent, AskUserQuestion
+---
 
-**name:** job-scraper
-**description:** Scrapes Danish job sites for new positions matching your profile. Deduplicates across runs. Triggers on: job scrape, find jobs, search jobs, new jobs, job search, scrape jobs, /scrape
-**allowed-tools:** Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, Agent, AskUserQuestion
+# Job Scraper
 
 ---
 

--- a/.claude/skills/upskill/SKILL.md
+++ b/.claude/skills/upskill/SKILL.md
@@ -1,8 +1,13 @@
-# Upskill
+---
+name: upskill
+description: >
+  Compares tracked job postings against the candidate profile to identify skill gaps and generate
+  a prioritized learning plan with study resources. Triggers on: /upskill, upskill, skill gaps,
+  what should I learn, learning plan
+allowed-tools: Read, Write, Glob, Grep, WebFetch, WebSearch
+---
 
-**name:** upskill
-**description:** Compares tracked job postings against the candidate profile to identify skill gaps and generate a prioritized learning plan with study resources. Triggers on: /upskill, upskill, skill gaps, what should I learn, learning plan
-**allowed-tools:** Read, Write, Glob, Grep, WebFetch, WebSearch
+# Upskill
 
 ---
 


### PR DESCRIPTION
## Fix: Add YAML frontmatter to .claude/skills/ SKILL.md files

### Problem

All three SKILL.md files in `.claude/skills/` use bold markdown syntax  for `name`, `description`, and `allowed-tools` instead of proper YAML  frontmatter:

**name:** job-application-assistant
**description:** Assists with job applications...
**allowed-tools:** Read, Glob, Grep...

This causes two problems:

1. **Auto-triggering is broken.** Claude Code's routing system cannot parse the description from bold markdown. It falls back to reading the first text value in the file body — the name value — and uses that as the trigger word. Natural language prompts like "help me write a cover letter" never activate the skill.

2. **Tool restrictions are not enforced.** `allowed-tools` declared in bold markdown is not parsed by the harness. The skill runs with unrestricted tool access instead of the intended restrictions.

### Impact

- Direct natural language requests ("write a cover letter for X", "help with my CV") silently fall through with no skill activation
- Skills only work when explicitly invoked via slash commands (/apply, /setup, etc.)
- Any fork relying on natural language triggering will fail silently with no error or warning
- Tool restrictions declared in the skill are not enforced

### Evidence

Tested locally with two skills side by side — one with proper YAML frontmatter, one without:

| Test | Without YAML | With YAML |
|---|---|---|
| Natural language prompt matching description | ✗ No trigger | ✓ Triggered correctly |
| Typing the name value as a prompt | ✓ Triggered (wrong behaviour) | ✗ Did not trigger |
| Direct slash command /skill-name | ✓ Works | ✓ Works |

The /skills token output confirmed the issue at session load time. Without YAML, Claude Code loaded less than 20 tokens per skill — just the name value extracted from the first line. With proper YAML, all three skills load their full descriptions correctly:

  job-application-assistant: ~80 tokens
  upskill:                   ~60 tokens
  job-scraper:               ~50 tokens

This confirms the fallback extraction is happening at session start, and that the full description is only accessible to the routing system when proper YAML frontmatter is present.

Before: Natural language prompt matching the description → no trigger
After: Same prompt after adding YAML frontmatter → skill activates correctly


### Fix

Added proper YAML frontmatter to all three SKILL.md files in .claude/skills/. All existing content below the frontmatter is 
unchanged. Slash command behaviour is unaffected — commands are driven by the folder name, not the frontmatter. This is a zero-risk change.

### References

- Claude Code official skills docs: https://code.claude.com/docs/en/skills
- Anthropic Help Center (skill format): https://support.claude.com/en/articles/12512198-how-to-create-custom-skills
