### PR TITLE
Fix `.gitignore` dropping scraper skills (blanket `.agents/` rule)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,8 @@ job_search_tracker.csv
 # Upskill reports (personal output)
 upskill/*.md
 
-# Agent usage logs
-.agents/
+# Agent skills: track the source, ignore only deps and logs.
+# (A blanket `.agents/` ignore silently drops the job-search CLI skills from the repo.)
+.agents/**/node_modules/
+.agents/**/*.log
+.agents/usage/


### PR DESCRIPTION
Splitting the `.gitignore` fix out of #20 as its own PR, as suggested.

The trailing `.agents/` rule in `.gitignore` ignores the entire job-search CLI tree. Any skill source added under `.agents/` is silently excluded unless force-added — the trap that affects the existing Danish scrapers and anyone forking to add their own portal scraper.

This narrows it to ignore only build/runtime artefacts:

```
.agents/**/node_modules/
.agents/**/*.log
.agents/usage/
```

so skill source is tracked while deps/logs stay ignored. No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
