### PR TITLE
Add Ko-fi sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: madslorentzen


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with a Ko-fi link (`ko-fi.com/madslorentzen`) so the repo shows a Sponsor button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)