### PR TITLE
feat: add foundit-search skill for job listings in India

### DIFF
--- a/.agents/skills/foundit-search/SKILL.md
+++ b/.agents/skills/foundit-search/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: foundit-search
+version: 1.0.0
+description: >
+  Make sure to use this skill whenever the user mentions anything related to job
+  searching in India, Indian job listings, job vacancies in Indian cities, or the
+  Indian job market — even if they don't mention foundit.in or Monster India
+  explicitly. Invoke for open positions, hiring, and vacancies across any sector
+  or role (IT, data, design, marketing, finance, operations, etc.) in India.
+  Trigger phrases include: jobs in india, india job search, naukri, foundit,
+  monster india, indian jobs, jobs in bangalore, jobs in bengaluru, jobs in
+  mumbai, jobs in delhi, jobs in hyderabad, jobs in pune, jobs in chennai, jobs
+  in gurgaon, jobs in noida, jobs in kolkata, software jobs india, IT jobs india,
+  fresher jobs, fresher jobs india, data scientist job india, developer jobs
+  india, remote jobs india, walk-in interview, walk in drive, off campus hiring,
+  lakhs per annum, LPA salary, sarkari naukri alternatives, private jobs india.
+context: fork
+allowed-tools: Bash(bun run skills/foundit-search/cli/src/cli.ts *)
+---
+
+# Foundit Search Skill (India)
+
+Search live job listings from **Foundit.in** (formerly Monster India), one of India's
+largest job portals, covering all major Indian cities and sectors. No authentication,
+no API key, and **zero runtime dependencies** — it runs with just `bun`.
+
+> This is the India-market instance of the repo's job-portal-skill pattern, alongside
+> the Danish portals and the country-agnostic `linkedin-search`. Foundit's public
+> middleware API returns clean JSON, so no HTML parsing is needed.
+
+## ⚠️ Personal use only
+
+This uses Foundit's public middleware API (the same one its own search page calls).
+**Keep volume low and don't use it commercially or for bulk data collection.**
+Run it on your own responsibility.
+
+## When to use this skill
+
+- Search for job openings anywhere in India (Bengaluru, Mumbai, Delhi NCR, Hyderabad, Pune, Chennai, …) or remote
+- Filter by recency (posted in the last 1/3/7/15/30 days) or years of experience (great for fresher searches: `-e 0-1`)
+- Get the full description, required skills, salary, and applicant count for a specific job listing
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run skills/foundit-search/cli/src/cli.ts search --query "<keywords>" [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q <text>` — keyword search (title, skill, role). Recommended; at least one of `--query`/`--location` is required.
+- `--location <text>` / `-l <text>` — city or region, e.g. `bangalore`, `mumbai`, `delhi`, `pune`, `hyderabad`, `chennai`, `remote`.
+- `--jobage <days>` — posted within N days: `1`, `3`, `7`, `15`, `30`. Omit for all postings.
+- `--experience <range>` / `-e <range>` — years of experience, e.g. `0-1` (freshers), `2-5`, `10-15`, or a single number like `3`.
+- `--page <n>` — page number (1-indexed).
+- `--limit <n>` / `-n <n>` — results per page (max 100, default 15).
+- `--format json|table|plain` — default `json`.
+
+### Fetch full job detail
+
+```bash
+bun run skills/foundit-search/cli/src/cli.ts detail <id|url> [--format json|plain]
+```
+
+`id` is the job ID from `search` results (e.g. `57827235`). You may also pass a full
+foundit.in job URL. Returns the full description, required skills, experience range,
+salary (when disclosed), employment type, industries, functions, and applicant count.
+
+## Usage examples
+
+```bash
+# Python developer roles in Bengaluru, last 7 days
+bun run skills/foundit-search/cli/src/cli.ts search -q "python developer" -l bangalore --jobage 7 --format table
+
+# Fresher-friendly data analyst roles in Mumbai
+bun run skills/foundit-search/cli/src/cli.ts search -q "data analyst" -l mumbai -e 0-1 --format table
+
+# Product manager roles anywhere in India
+bun run skills/foundit-search/cli/src/cli.ts search -q "product manager" --format table
+
+# Full details for a specific job
+bun run skills/foundit-search/cli/src/cli.ts detail 57827235 --format plain
+```
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing IDs to `detail` |
+| `table` | Quick human-readable scanning |
+| `plain` | Reading a single job's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the process exits with code `1`.
+
+## Notes
+
+- Data is from Foundit's public `middleware` JSON endpoints — no credentials required.
+- Salaries are frequently undisclosed on Indian portals; `salary` is `null` when hidden or `0-0 INR`.
+- The API may rate-limit; the CLI retries 429/5xx with exponential backoff. Keep volume low (see note above).
+- Job IDs are numeric (e.g. `57827235`) — pass them as-is to `detail`.
+- Naukri.com (India's biggest portal) fronts its API with reCAPTCHA, so it cannot be scripted without a headless browser; Foundit offers comparable India-wide coverage with a clean public JSON API.

--- a/.agents/skills/foundit-search/cli/README.md
+++ b/.agents/skills/foundit-search/cli/README.md
@@ -1,0 +1,60 @@
+# foundit-cli
+
+CLI for searching jobs on **Foundit.in** (formerly Monster India) — one of India's
+largest job portals, covering all major Indian cities and sectors.
+
+**Data source**: Foundit public `middleware` JSON endpoints (`jobsearch` and `jobdetail/<id>`).
+**Authentication**: None required.
+**Dependencies**: None (plain `bun` + `fetch`). `bun install` is optional and only pulls dev type defs.
+
+> **Personal use only.** This uses Foundit's public API; keep volume low, don't use it
+> commercially or for bulk data collection, and run it on your own responsibility.
+
+## Installation
+
+```bash
+cd .agents/skills/foundit-search/cli
+bun install   # optional — only installs TypeScript dev types
+```
+
+The CLI runs without any install because it has zero runtime dependencies.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `search` | Search for job listings (needs `--query` and/or `--location`) |
+| `detail` | Fetch full detail for a single job listing |
+
+`search` accepts `--format json|table|plain` (default `json`); `detail` accepts `--format json|plain`.
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` with exit code `1`.
+
+## Quick examples
+
+```bash
+# Backend roles in Hyderabad, last 7 days
+bun run src/cli.ts search -q "backend engineer" -l hyderabad --jobage 7 --format table
+
+# Fresher data analyst roles in Mumbai
+bun run src/cli.ts search -q "data analyst" -l mumbai -e 0-1 --format table
+
+# Product roles anywhere in India
+bun run src/cli.ts search -q "product manager" --format table
+
+# Full detail for one job
+bun run src/cli.ts detail 57827235 --format plain
+```
+
+See `../SKILL.md` for the full flag reference and the personal-use note.
+
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--query` | `-q` | Keywords (title / skill / role). At least one of query/location required. |
+| `--location` | `-l` | City or region, e.g. `bangalore`, `mumbai`, `delhi`, `remote`. |
+| `--jobage` | | Posted within N days: `1`, `3`, `7`, `15`, `30`. |
+| `--experience` | `-e` | Years of experience: `0-1`, `2-5`, `10-15`, or a single number. |
+| `--page` | | 1-indexed page. |
+| `--limit` | `-n` | Results per page (max 100, default 15). |
+| `--format` | | `json` \| `table` \| `plain`. |

--- a/.agents/skills/foundit-search/cli/package.json
+++ b/.agents/skills/foundit-search/cli/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "foundit-cli",
+  "version": "1.0.0",
+  "description": "CLI for searching jobs on Foundit.in (formerly Monster India) — India's public job portal. No authentication, zero runtime dependencies. Personal use only.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "foundit-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest"
+  }
+}

--- a/.agents/skills/foundit-search/cli/src/cli.ts
+++ b/.agents/skills/foundit-search/cli/src/cli.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+// Self-contained CLI for searching jobs on Foundit.in (formerly Monster India),
+// India's large public job portal. No external CLI framework, so it runs
+// anywhere `bun` is available with zero install beyond the repo clone.
+//
+// Personal use only. This reads Foundit's public middleware JSON API; keep
+// volume low, do not use it commercially or for bulk data collection, and run
+// it on your own responsibility.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", l: "location", n: "limit", e: "experience" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `foundit-cli — search jobs on Foundit.in (Monster India), India-wide
+
+USAGE
+  bun run src/cli.ts search --query "<keywords>" [flags]
+  bun run src/cli.ts detail <id|url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>        Keywords (job title, skill, or role). Recommended.
+  --location, -l <text>     City or region, e.g. "bangalore", "mumbai", "delhi",
+                            "pune", "hyderabad", "chennai", "remote". Optional.
+  --jobage <days>           Posted within N days: 1, 3, 7, 15, 30. Default: all.
+  --experience, -e <range>  Years of experience, e.g. "0-1", "2-5", "10-15", or "3".
+  --page <n>                1-indexed page. Default 1.
+  --limit, -n <n>           Results per page (max 100). Default 15.
+  --format <fmt>            json (default) | table | plain.
+
+EXAMPLES
+  bun run src/cli.ts search -q "python developer" -l bangalore --jobage 7 --format table
+  bun run src/cli.ts search -q "data engineer" -l mumbai -e 2-5 --format table
+  bun run src/cli.ts search -q "product manager" --format table
+  bun run src/cli.ts detail 57827235 --format plain
+
+Personal use only — uses Foundit's public API; keep volume low.
+`
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  if (cmd === "search") {
+    const query = typeof flags.query === "string" ? flags.query : undefined
+    const location = typeof flags.location === "string" ? flags.location : undefined
+    if (!query && !location) {
+      process.stderr.write(
+        JSON.stringify({
+          error: 'provide at least --query/-q or --location/-l (e.g. -q "python developer" -l bangalore)',
+          code: "NO_QUERY",
+        }) + "\n",
+      )
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const limit = flags.limit ? Math.min(100, Math.max(1, parseInt(flags.limit as string, 10))) : 15
+    const opts: SearchOpts = {
+      query,
+      location,
+      jobage: flags.jobage ? parseInt(flags.jobage as string, 10) : undefined,
+      experience: typeof flags.experience === "string" ? flags.experience : undefined,
+      page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
+      limit,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(JSON.stringify({ error: "detail requires an <id|url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      id,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main().then((code) => process.exit(code))

--- a/.agents/skills/foundit-search/cli/src/commands/detail.ts
+++ b/.agents/skills/foundit-search/cli/src/commands/detail.ts
@@ -1,0 +1,64 @@
+import { DETAIL_URL, jsonFetch, toJobDetail, writeError } from "../helpers.js"
+
+export interface DetailOpts {
+  id: string
+  format: "json" | "plain"
+}
+
+/** Accept a raw job ID or a foundit.in job URL (trailing numeric segment). */
+function normalizeId(input: string): string | null {
+  const bare = input.match(/^\d{4,}$/)
+  if (bare) return input
+  const url = input.match(/-(\d{4,})(?:\?|\/|$)/) || input.match(/\/(\d{4,})(?:\?|$)/)
+  if (url) return url[1]
+  return null
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const id = normalizeId(opts.id)
+  if (!id) {
+    writeError(`Could not parse a job ID from "${opts.id}"`, "BAD_ID")
+    return 1
+  }
+  try {
+    const data = (await jsonFetch(`${DETAIL_URL}/${id}`)) as {
+      jobDetailResponse?: Record<string, unknown>
+      activeJob?: boolean
+    } | null
+    // Unknown IDs come back as HTTP 200 with an empty jobDetailResponse.
+    const raw = data?.jobDetailResponse
+    if (!raw || (!raw.id && !raw.jobId)) {
+      writeError("Job not found", "NOT_FOUND")
+      return 1
+    }
+    const job = toJobDetail(raw)
+
+    if (opts.format === "plain") {
+      const lines = [
+        job.title,
+        `${job.company || "—"} · ${job.location || "—"}`,
+        "",
+        job.experience ? `Experience: ${job.experience}` : "",
+        job.salary ? `Salary: ${job.salary}` : "",
+        job.employmentTypes.length ? `Employment: ${job.employmentTypes.join(", ")}` : "",
+        job.jobTypes.length ? `Job type: ${job.jobTypes.join(", ")}` : "",
+        job.functions.length ? `Function: ${job.functions.join(", ")}` : "",
+        job.industries.length ? `Industries: ${job.industries.join(", ")}` : "",
+        job.skills.length ? `Skills: ${job.skills.join(", ")}` : "",
+        job.totalApplicants != null ? `Applicants: ${job.totalApplicants}` : "",
+        "",
+        job.description || "(no description)",
+        "",
+        `URL: ${job.url}`,
+        job.applyUrl ? `Apply: ${job.applyUrl}` : "",
+      ].filter((l) => l !== "")
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/foundit-search/cli/src/commands/search.ts
+++ b/.agents/skills/foundit-search/cli/src/commands/search.ts
@@ -1,0 +1,103 @@
+import {
+  SEARCH_URL,
+  jsonFetch,
+  toJobCard,
+  experienceRange,
+  writeError,
+  type JobCard,
+} from "../helpers.js"
+
+export interface SearchOpts {
+  query?: string
+  location?: string
+  jobage?: number
+  experience?: string
+  page: number
+  limit: number
+  format: "json" | "table" | "plain"
+}
+
+function buildUrl(opts: SearchOpts): string {
+  const params = new URLSearchParams()
+  if (opts.query) params.set("query", opts.query)
+  if (opts.location) params.set("locations", opts.location)
+  if (opts.jobage && opts.jobage > 0 && opts.jobage < 9999) {
+    params.set("jobFreshness", String(opts.jobage))
+  }
+  const exp = experienceRange(opts.experience)
+  if (exp) params.set("experienceRanges", exp)
+  params.set("limit", String(opts.limit))
+  params.set("start", String((opts.page - 1) * opts.limit))
+  params.set("queryDerived", "true")
+  return `${SEARCH_URL}?${params.toString()}`
+}
+
+function renderTable(cards: JobCard[]): string {
+  if (cards.length === 0) return "No results."
+  const rows = cards.map((c) => {
+    const title = (c.title || "").slice(0, 42).padEnd(42)
+    const company = (c.company || "—").slice(0, 26).padEnd(26)
+    const loc = (c.location || "—").slice(0, 24).padEnd(24)
+    const exp = (c.experience || "—").slice(0, 10).padEnd(10)
+    const posted = c.posted || "—"
+    return `${c.id.padEnd(9)} ${title} ${company} ${loc} ${exp} ${posted}`
+  })
+  const header =
+    "ID".padEnd(9) +
+    " " +
+    "TITLE".padEnd(42) +
+    " " +
+    "COMPANY".padEnd(26) +
+    " " +
+    "LOCATION".padEnd(24) +
+    " " +
+    "EXP".padEnd(10) +
+    " POSTED"
+  return [header, "-".repeat(header.length), ...rows].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  try {
+    const data = (await jsonFetch(buildUrl(opts))) as {
+      jobSearchResponse?: {
+        data?: unknown[]
+        meta?: { paging?: { total?: number } }
+      }
+    } | null
+    const response = data?.jobSearchResponse
+    if (!response || !Array.isArray(response.data)) {
+      writeError("Unexpected response from Foundit search API", "BAD_RESPONSE")
+      return 1
+    }
+    // The results array interleaves "adsense" ad slots with real job cards.
+    const cards = response.data
+      .filter((j) => (j as Record<string, unknown>)?.id || (j as Record<string, unknown>)?.jobId)
+      .map((j) => toJobCard(j as Record<string, unknown>))
+    const total = response.meta?.paging?.total ?? cards.length
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(cards) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        cards
+          .map(
+            (c) =>
+              `${c.title}\n  ${c.company || "—"} · ${c.location || "—"} · ${c.experience || "—"} · ${c.posted || "—"}\n  id: ${c.id}\n  ${c.url}`,
+          )
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify(
+          { meta: { count: cards.length, total, page: opts.page }, results: cards },
+          null,
+          2,
+        ) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/foundit-search/cli/src/helpers.ts
+++ b/.agents/skills/foundit-search/cli/src/helpers.ts
@@ -1,0 +1,187 @@
+// Data source: Foundit.in (formerly Monster India) public "middleware" JSON API.
+// No authentication required; the endpoints just expect a browser-like User-Agent,
+// an Accept: application/json header, and a foundit.in Referer (without the
+// Referer the API answers 400 "content negotiation failed").
+
+export const SEARCH_URL = "https://www.foundit.in/middleware/jobsearch"
+export const DETAIL_URL = "https://www.foundit.in/middleware/jobdetail"
+export const SITE_URL = "https://www.foundit.in"
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+/** Fetch JSON with exponential backoff on 429/5xx. Returns null on a 404. */
+export async function jsonFetch(url: string): Promise<unknown | null> {
+  const maxRetries = 6
+  let delay = 500
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": UA,
+        Accept: "application/json",
+        "Accept-Language": "en-US,en;q=0.9",
+        Referer: `${SITE_URL}/srp/results`,
+      },
+      redirect: "follow",
+    })
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+      }
+      const jitter = Math.floor(Math.random() * 500)
+      await new Promise((r) => setTimeout(r, delay + jitter))
+      delay = Math.min(delay * 2, 8000)
+      continue
+    }
+    if (response.status === 404) return null
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+    }
+    return response.json()
+  }
+  throw new Error("Request failed after max retries")
+}
+
+export interface JobCard {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  experience: string | null
+  salary: string | null
+  posted: string | null
+  employmentTypes: string[]
+  url: string
+}
+
+export interface JobDetail extends JobCard {
+  jobTypes: string[]
+  industries: string[]
+  functions: string[]
+  skills: string[]
+  totalApplicants: number | null
+  description: string | null
+  applyUrl: string | null
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&nbsp;/g, " ")
+}
+
+/** Convert the job description's HTML to plain text, keeping paragraph breaks. */
+export function htmlToText(html: string): string {
+  const withBreaks = html
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|li|ul|ol|div|h\d)>/gi, "\n")
+    .replace(/<li[^>]*>/gi, "- ")
+  return decodeHtmlEntities(withBreaks.replace(/<[^>]+>/g, ""))
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type Raw = Record<string, any>
+
+/** "0-0 INR" and hideSalary both mean the salary is not disclosed. */
+function readSalary(job: Raw): string | null {
+  if (job.hideSalary) return null
+  const salary = typeof job.salary === "string" ? job.salary.trim() : ""
+  if (!salary || salary.startsWith("0-0")) return null
+  return salary
+}
+
+function readExperience(job: Raw): string | null {
+  if (typeof job.exp === "string" && job.exp.trim()) return job.exp.trim()
+  const min = job.minimumExperience?.years
+  const max = job.maximumExperience?.years
+  if (min == null && max == null) return null
+  if (min != null && max != null) return `${min}-${max} Years`
+  return `${min ?? max}+ Years`
+}
+
+function readLocation(job: Raw): string | null {
+  if (typeof job.locations === "string" && job.locations.trim()) return job.locations.trim()
+  if (Array.isArray(job.locations)) {
+    const cities = job.locations
+      .map((l: Raw) => (typeof l === "string" ? l : l?.city))
+      .filter(Boolean)
+    if (cities.length > 0) return cities.join("; ")
+  }
+  return null
+}
+
+function readUrl(job: Raw): string {
+  const path = job.seoJdUrl || job.jdUrl
+  if (typeof path === "string" && path.startsWith("/")) return `${SITE_URL}${path}`
+  return `${SITE_URL}/job/${job.id ?? job.jobId ?? ""}`
+}
+
+/** Map one raw search-result entry to a JobCard. */
+export function toJobCard(job: Raw): JobCard {
+  return {
+    id: String(job.id ?? job.jobId ?? ""),
+    title: typeof job.title === "string" ? job.title.trim() : "(untitled)",
+    company: job.hideCompanyName ? null : job.companyName || null,
+    location: readLocation(job),
+    experience: readExperience(job),
+    salary: readSalary(job),
+    posted: job.postedBy || job.updatedAt || null,
+    employmentTypes: Array.isArray(job.employmentTypes) ? job.employmentTypes.filter(Boolean) : [],
+    url: readUrl(job),
+  }
+}
+
+function readSkillList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((s: Raw) => (typeof s === "string" ? s : s?.text)).filter(Boolean)
+  }
+  if (typeof value === "string") {
+    return value.split(",").map((s) => s.trim()).filter(Boolean)
+  }
+  return []
+}
+
+/** Map the raw jobDetailResponse to a JobDetail. */
+export function toJobDetail(job: Raw): JobDetail {
+  const card = toJobCard(job)
+  // The full skill list is split across `skills` and `itSkills`; merge and dedupe.
+  const skills = [...new Set([...readSkillList(job.skills), ...readSkillList(job.itSkills)])]
+  return {
+    ...card,
+    posted: job.postedAt || card.posted,
+    jobTypes: Array.isArray(job.jobTypes) ? job.jobTypes.filter(Boolean) : [],
+    industries: Array.isArray(job.industries) ? job.industries.filter(Boolean) : [],
+    functions: Array.isArray(job.functions) ? job.functions.filter(Boolean) : [],
+    skills,
+    totalApplicants: typeof job.totalApplicants === "number" ? job.totalApplicants : null,
+    description: typeof job.description === "string" ? htmlToText(job.description) || null : null,
+    applyUrl: job.redirectUrl || null,
+  }
+}
+
+/**
+ * Parse an --experience value into Foundit's experienceRanges format ("min~max").
+ * Accepts "2-5", "2~5", or a single number like "3" (treated as 3~3).
+ */
+export function experienceRange(input: string | undefined): string | null {
+  if (!input) return null
+  const m = input.match(/^(\d{1,2})\s*[-~]\s*(\d{1,2})$/)
+  if (m) return `${m[1]}~${m[2]}`
+  const single = input.match(/^(\d{1,2})$/)
+  if (single) return `${single[1]}~${single[1]}`
+  return null
+}

--- a/.agents/skills/foundit-search/cli/tsconfig.json
+++ b/.agents/skills/foundit-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/foundit-search/url-reference.md
+++ b/.agents/skills/foundit-search/url-reference.md
@@ -1,0 +1,56 @@
+# Foundit.in URL Reference
+
+Public, unauthenticated `middleware` JSON endpoints used by this skill — the same
+endpoints Foundit's own search page (`foundit.in/srp/results`) calls from the browser.
+
+> Personal use only — keep volume low; don't use commercially or for bulk data collection.
+
+Both endpoints require browser-like headers or they answer `400 "content negotiation failed"`:
+
+```
+User-Agent: <any modern browser UA>
+Accept: application/json
+Referer: https://www.foundit.in/srp/results
+```
+
+## Search
+
+```
+GET https://www.foundit.in/middleware/jobsearch
+```
+
+Query params:
+
+| Param | Meaning | Example |
+|-------|---------|---------|
+| `query` | Free-text keywords | `python developer` |
+| `locations` | City/region | `bangalore` · `mumbai` · `delhi` · `remote` |
+| `jobFreshness` | Posted within N days | `1`, `3`, `7`, `15`, `30` |
+| `experienceRanges` | Years of experience, `min~max` | `0~1`, `2~5`, `10~15` |
+| `limit` | Page size (max 100) | `15` |
+| `start` | Pagination offset | `0`, `15`, `30`, … |
+| `queryDerived` | Always `true` (matches site behaviour) | `true` |
+
+Returns JSON: `jobSearchResponse.data[]` is the job list;
+`jobSearchResponse.meta.paging.total` is the total match count. Each entry carries
+`id`, `title`, `companyName`, `locations`, `exp`, `salary`, `postedBy`/`updatedAt`,
+`employmentTypes`, `skills`, and `seoJdUrl`/`jdUrl` (relative job-page path).
+
+## Detail
+
+```
+GET https://www.foundit.in/middleware/jobdetail/<jobId>
+```
+
+Returns JSON: `jobDetailResponse` with the full HTML `description`, `skills[]`
+(objects with `text`), `industries[]`, `functions[]`, `jobTypes[]`,
+`employmentTypes[]`, `totalApplicants`, salary/experience min-max objects, and
+`redirectUrl` (external apply link, when the posting is hosted off-site).
+Top-level `activeJob` indicates whether the posting is still open.
+
+## Notes
+
+- No authentication or cookies required — just the three headers above.
+- `salary` of `0-0 INR` (or `hideSalary: true`) means not disclosed — very common on Indian portals.
+- Respect rate limits — the CLI backs off on 429/5xx.
+- Naukri.com was evaluated first but its `jobapi` rejects non-browser traffic with `406 "recaptcha required"`, so Foundit is the scriptable choice for India.

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ cd .agents/skills/jobdanmark-search/cli && bun install && cd ../../../..
 cd .agents/skills/jobindex-search/cli && bun install && cd ../../../..
 cd .agents/skills/jobnet-search/cli && bun install && cd ../../../..
 cd .agents/skills/linkedin-search/cli && bun install && cd ../../../..
+cd .agents/skills/foundit-search/cli && bun install && cd ../../../..
 ```
 
-For `linkedin-search` the install is optional: it has zero runtime dependencies and runs with plain `bun`; `bun install` only pulls TypeScript dev types.
+For `linkedin-search` and `foundit-search` the install is optional: they have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
 
 ### 3. Set up your profile
 
@@ -126,7 +127,8 @@ ai-job-search/
 │   ├── jobdanmark-search/             # Jobdanmark.dk (Denmark)
 │   ├── jobindex-search/               # Jobindex.dk (Denmark)
 │   ├── jobnet-search/                 # Jobnet.dk (Denmark, government portal)
-│   └── linkedin-search/               # LinkedIn public job listings (country-agnostic)
+│   ├── linkedin-search/               # LinkedIn public job listings (country-agnostic)
+│   └── foundit-search/                # Foundit.in / Monster India (India)
 ├── cv/
 │   └── main_example.tex               # moderncv LaTeX template
 ├── cover_letters/
@@ -205,6 +207,8 @@ The CV uses [moderncv](https://ctan.org/pkg/moderncv) (banking style). The cover
 The four Danish CLI tools in `.agents/skills/` (Jobbank, Jobdanmark, Jobindex, Jobnet) demonstrate the pattern for building a job-portal integration for a specific market. If you're in a different country, you can build equivalent tools for your local job portals using the same structure.
 
 For a **country-agnostic** starting point, the repo also includes **`linkedin-search`** — a job-search skill built on LinkedIn's public, unauthenticated `jobs-guest` endpoints. It is field-agnostic, has **zero runtime dependencies** (runs with just `bun`), and takes the search location as an explicit flag, so it works for any market out of the box (`-l "Berlin, Germany"`, `-l "Mumbai, Maharashtra, India"`, `-l "Remote"`, …). It is intended for **personal use only** — automated access is against LinkedIn's Terms of Service, so keep volume low. See `.agents/skills/linkedin-search/SKILL.md`.
+
+For the **Indian market**, the repo includes **`foundit-search`** — a job-search skill for Foundit.in (formerly Monster India), covering all major Indian cities and sectors. Like `linkedin-search` it has zero runtime dependencies and requires no authentication; it supports filtering by city, recency, and years of experience (including fresher searches with `-e 0-1`). Personal use only — keep volume low. See `.agents/skills/foundit-search/SKILL.md`.
 
 ### Salary benchmarking
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -52,12 +52,12 @@ Or manually: fork on GitHub, then clone your fork.
 ## 3. Install job search CLI dependencies
 
 ```bash
-for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search; do
+for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search foundit-search; do
   cd .agents/skills/$tool/cli && bun install && cd ../../../..
 done
 ```
 
-For `linkedin-search` the install is optional: it has zero runtime dependencies and runs with plain `bun`; `bun install` only pulls TypeScript dev types.
+For `linkedin-search` and `foundit-search` the install is optional: they have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
 
 ## 4. Run the setup interview
 


### PR DESCRIPTION
Introduced a new job-search skill, `foundit-search`, for accessing job listings on Foundit.in (formerly Monster India). This skill includes a CLI with commands for searching jobs and fetching job details, supporting various filters such as location and experience. The installation is optional as it has zero runtime dependencies. Updated README and SETUP documentation to reflect the addition of this skill and its usage instructions.