### PR TITLE
Add Ko-fi button to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 # AI Job Search
 
+<p align="center">
+  <a href="https://ko-fi.com/madslorentzen">
+    <img src="https://storage.ko-fi.com/cdn/kofi3.png?v=6" alt="Buy me a coffee at ko-fi.com" height="40">
+  </a>
+</p>
+
 An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
 ## What this is


### PR DESCRIPTION
Adds the official dark Ko-fi "Buy me a coffee" button (hosted on Ko-fi's CDN) centered directly under the README title, linking to ko-fi.com/madslorentzen. Complements the repo Sponsor button added in #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)