### PR TITLE
Move Ko-fi button below intro paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 # AI Job Search
 
+An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
+
 <p align="center">
   <a href="https://ko-fi.com/madslorentzen">
     <img src="https://storage.ko-fi.com/cdn/kofi3.png?v=6" alt="Buy me a coffee at ko-fi.com" height="40">
   </a>
 </p>
-
-An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
 ## What this is
 


### PR DESCRIPTION
Repositions the Ko-fi button from directly under the title to just below the intro paragraph, per preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)