### PR TITLE
chore: add test script to linkedin-search cli

### DIFF
--- a/.agents/skills/linkedin-search/cli/package.json
+++ b/.agents/skills/linkedin-search/cli/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {},


### PR DESCRIPTION
One-liner follow-up from the #35 review: adds `"test": "bun test --timeout 30000"` to `linkedin-search/cli/package.json`, matching the jobindex-search convention. Verified `bun run test` passes 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)