### PR TITLE
feat: add opencode support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ Thumbs.db
 # Memory files (Claude Code user-specific)
 .claude/projects/
 
+# OpenCode planning artifacts (local working files — regenerable)
+.sisyphus/
+
 # Skills lock (auto-generated)
 skills-lock.json
 

--- a/.opencode/command/add-portal.md
+++ b/.opencode/command/add-portal.md
@@ -1,0 +1,153 @@
+# /add-portal - Generate a Job-Portal Search Skill for Your Local Market
+
+You are helping the user build a job-portal search skill for a job board in their market. The repo ships worked examples of the pattern (four Danish portals plus the country-agnostic `linkedin-search`), and the README invites users elsewhere to build equivalents — this command turns that invitation into a guided workflow: investigate the portal, scaffold the skill from the canonical structure, and test-run a live query before registering anything.
+
+The generator is **country-agnostic**: it works for any portal in any market and language. The skills it produces are typically market-specific and live in the user's fork (per repo policy, country-specific portal skills are not merged upstream — the generator is the upstream feature, its output is yours).
+
+`$ARGUMENTS` may contain a subcommand, a portal URL, or nothing.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Arguments
+
+- If `$ARGUMENTS` contains `--list`: use Glob with `.agents/skills/*/SKILL.md`, print a table of installed portal skills (name, market from the description, data source from `url-reference.md`), and stop.
+- If `$ARGUMENTS` contains a URL: treat it as the portal URL and carry it into Step 1.
+- Otherwise: start the interview at Step 1.
+
+---
+
+## Step 1: Interview - Portal Basics
+
+Ask the user (skip anything already answered by `$ARGUMENTS`):
+
+1. **Portal URL** - the job board's public site (e.g. `https://www.seek.com.au`, `https://www.stepstone.de`).
+2. **Skill name** - kebab-case, suffixed `-search` (e.g. `seek-search`, `stepstone-search`). Must not collide with an existing folder in `.agents/skills/`.
+3. **Market and language** - which country/region the portal covers and what language its postings use. This drives the trigger phrases in `SKILL.md` (include local-language terms like the Danish skills do: "ledige stillinger", "jobsøgning").
+4. **A realistic test query** - a job title or skill the user would actually search for, used for the live test in Step 4.
+
+---
+
+## Step 2: Investigate the Portal
+
+Do reconnaissance before writing any code. Use WebFetch (or `curl` via Bash) on the portal:
+
+1. **Find the search URL pattern.** Load the portal's search page, run a search in the URL bar mentally or via fetch, and identify: the search endpoint, the query parameter, and any parameters for location, posting age, and pagination. Prefer a JSON API if one backs the site (check for `/api/` XHR endpoints in the page source); otherwise plan to parse the HTML results page.
+2. **Fetch one search-results response** for the test query and identify the per-result fields: **id, title, company, location, posting date, and URL**. For HTML, note the class names / attributes that anchor each field. For JSON, note the field paths.
+3. **Find the detail-page pattern** - the URL that returns a single posting's full description, and where the description, deadline, employment type, and apply link live in it.
+4. **Check access requirements and terms.**
+   - Fetch `robots.txt` and check whether the search/detail paths are disallowed.
+   - If the portal requires login/authentication to view listings, **stop**: this pattern only works on public pages. Tell the user and suggest checking whether the portal has an official API.
+   - If robots.txt disallows the paths or the portal's terms prohibit automated access, tell the user plainly and let them decide whether to proceed for personal use. If they proceed, the generated `SKILL.md` **must** carry a prominent personal-use-only warning (copy the tone of `linkedin-search`'s "⚠️ Personal use only" section: keep volume low, no commercial or bulk use, own responsibility).
+
+Record everything you found - endpoints, parameters, field anchors, quirks - you will write it into `url-reference.md` in Step 3.
+
+---
+
+## Step 3: Scaffold the Skill
+
+**Canonical reference:** read `.agents/skills/linkedin-search/` before generating - it is the zero-dependency worked example of this exact structure. Copy its architecture, not its LinkedIn-specific parsing.
+
+Create `.agents/skills/<name>/` with:
+
+```
+<name>/
+├── SKILL.md              # Skill definition with trigger phrases
+├── url-reference.md      # Endpoint documentation from Step 2
+└── cli/
+    ├── package.json
+    ├── tsconfig.json
+    ├── README.md
+    ├── src/
+    │   ├── cli.ts        # Arg parsing, help text, command dispatch
+    │   ├── helpers.ts    # Fetch with backoff, parsers, error writer
+    │   └── commands/
+    │       ├── search.ts
+    │       └── detail.ts
+    └── tests/
+        └── helpers.ts    # runCLI + parseJSON test utilities (copy from jobindex-search)
+```
+
+### The portal-skill contract (every generated skill MUST honor this)
+
+These conventions are what make portal skills interchangeable for `/scrape` and for users reading any skill's docs:
+
+- **Commands:** `search` and `detail <id|url>`.
+- **Search flags:** `--query`/`-q`, `--jobage <days>` (posting age; map to the portal's parameter, note in SKILL.md if unsupported), `--page <n>` (1-indexed), `--limit <n>` (client-side cap), `--format json|table|plain` (default `json`). Add `--location`/`-l` if the portal supports location as a parameter; if it only supports location inside the keyword query, document that in SKILL.md the way `jobindex-search` does ("include the city in `--query`").
+- **JSON output shape:** `{ "meta": { "count": ..., "page": ... }, "results": [...] }` where each result has at least `id`, `title`, `company`, `location`, `date`, `url` (missing values are `null`, never omitted).
+- **Errors:** written to **stderr** as `{ "error": "...", "code": "..." }`, exit code `1`. Never write errors to stdout.
+- **Fetching:** browser User-Agent, exponential backoff with jitter on 429/5xx (max ~6 retries), `""`/`null` on 404 rather than a crash.
+- **HTML parsing:** split the response into per-result chunks and parse each independently, so one malformed card cannot break the rest (see `parseJobCards` in `linkedin-search/cli/src/helpers.ts`).
+- **Dependencies:** default to **zero runtime dependencies** (plain `bun` + `fetch` + regex parsing) like `linkedin-search` - `bun install` should only pull dev types. Only add a parsing library if the portal's markup genuinely defeats chunked regex parsing, and say so in the README.
+
+### File specifics
+
+- **`SKILL.md` frontmatter:** `name`, `version: 1.0.0`, a `description` written for skill triggering - it must name the portal, the market, and include trigger phrases in English **and** the market's language; `context: fork`; `allowed-tools: Bash(bun run skills/<name>/cli/src/cli.ts *)`.
+- **`SKILL.md` body:** what the skill searches, the personal-use warning if Step 2 found terms restrictions, command reference with flags, 4-6 usage examples using the user's market (real cities, realistic roles), output-format table, and a Notes section recording portal quirks found in Step 2.
+- **`url-reference.md`:** the endpoints, parameters table, and response-structure notes from Step 2 - this is the file a future maintainer needs when the portal changes its markup.
+- **`package.json`:** name `<portal>-cli`, `"type": "module"`, scripts `start`, `test` (`bun test --timeout 30000`), and `typecheck` (`tsc --noEmit`); dev-only dependencies in the zero-dependency default.
+- **`tests/`:** copy `runCLI`/`parseJSON` from `jobindex-search/cli/tests/helpers.ts`, then add a small live smoke-test file: `search` with the test query returns exit code 0 and ≥1 result with non-null `id`/`title`/`url`; a bogus flag or missing required arg exits 1 with a JSON error on stderr.
+
+---
+
+## Step 4: Test-Run a Live Query (MANDATORY)
+
+Never register a portal skill that has not returned real results. Markup assumptions from Step 2 routinely miss quirks that only show up live.
+
+1. Install dev types and typecheck:
+   ```bash
+   cd .agents/skills/<name>/cli && bun install && bun run typecheck
+   ```
+2. Run the live search with the user's test query:
+   ```bash
+   bun run src/cli.ts search -q "<test query>" --limit 5 --format table
+   ```
+3. Verify the results are real and complete: titles and companies are populated (not empty strings or HTML fragments), URLs resolve to the portal, dates parse. If fields come back null or garbled, fix the parsers in `helpers.ts` and re-run. Iterate until clean.
+4. Take one `id` from the results and run `detail`:
+   ```bash
+   bun run src/cli.ts detail <id> --format plain
+   ```
+   Verify the description is readable text (entities decoded, tags stripped, paragraph breaks preserved).
+5. Run the test suite: `bun run test`.
+6. Keep volume low during iteration - a handful of requests, not a crawl. If the portal rate-limits you mid-test, back off and tell the user.
+
+Do not proceed to Step 5 until search, detail, and tests all pass.
+
+---
+
+## Step 5: Register
+
+1. Ask whether the user wants the new portal added to their `/scrape` search strategy. If yes, add the portal's site to the relevant query categories in `.claude/skills/job-scraper/search-queries.md` (site-specific queries, like the existing `jobindex.dk` entries) so `/scrape` includes it.
+2. Remind the user to add the install line for their own records if they maintain a fork README:
+   ```bash
+   cd .agents/skills/<name>/cli && bun install && cd ../../../..
+   ```
+   (Skip if the skill is zero-dependency and they don't care about typecheck types.)
+3. Note that the skill auto-triggers from its `SKILL.md` description - no other wiring is needed.
+
+---
+
+## Step 6: Confirm
+
+Present a summary:
+
+> **Portal skill `<name>` generated and verified.**
+>
+> - Files: `.agents/skills/<name>/` (SKILL.md, url-reference.md, CLI with tests)
+> - Live test: `search "<test query>"` returned <N> results; `detail` verified on one posting
+> - Data source: <endpoint summary>; <personal-use warning noted, if applicable>
+>
+> Try it: `bun run .agents/skills/<name>/cli/src/cli.ts search -q "<test query>" --format table`
+>
+> Per upstream policy, market-specific skills like this live in your fork rather than being PR'd upstream. If the portal changes its markup later, `url-reference.md` records the parsing anchors to update.
+
+---
+
+## Design Principles
+
+- The generator is country-agnostic; its output is market-specific and stays in the user's fork. This matches the repo policy that upstream stays a universal template.
+- Investigation before scaffolding: the command never generates parsers from guesses - Step 2 fetches real responses first, and Step 4 verifies against live data before anything is registered.
+- The portal-skill contract keeps every generated skill interchangeable with the shipped ones: same commands, same flags, same output shape, same error convention.
+- Zero runtime dependencies by default, matching `linkedin-search` - a portal skill should run on a fresh clone with nothing but `bun`.
+- Access rules are surfaced, not silently bypassed: auth-walled portals are declined, robots.txt/ToS restrictions are reported to the user, and restricted portals get a prominent personal-use-only warning in the generated skill.

--- a/.opencode/command/add-template.md
+++ b/.opencode/command/add-template.md
@@ -1,0 +1,172 @@
+# /add-template - Register a Custom CV or Cover Letter Template
+
+You are helping the user register their own LaTeX template with the AI Job Search framework. The framework ships with moderncv (banking style) for CVs and a custom `cover.cls` for cover letters. This command lets the user swap in their own template: store the template files, capture usage instructions (compile engine, fonts, style rules, page limits), verify the template compiles, and wire it into the `/apply` workflow so every future application uses it.
+
+`$ARGUMENTS` may contain a subcommand, a file path, or nothing.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Arguments
+
+- If `$ARGUMENTS` contains `--list`: run **List Mode** below and stop.
+- If `$ARGUMENTS` contains `--use <name>`: skip to **Step 5: Activate** with that template name. `--use default` deactivates any custom template and restores the stock guidance (see Step 5).
+- If `$ARGUMENTS` contains a file path or @-mentioned file: treat it as the template source and carry it into Step 1.
+- Otherwise: start the registration flow at Step 1.
+
+### List Mode
+
+Use Glob with `templates/**/TEMPLATE.md` to find registered templates. For each, read the manifest and print a table:
+
+```
+## Registered Templates
+
+| Name | Type | Engine | Fonts | Active |
+|------|------|--------|-------|--------|
+| <name> | CV / Cover letter | lualatex/xelatex/pdflatex | <main font> | yes/no |
+```
+
+A template is **active** if `05-cv-templates.md` (CV) or `06-cover-letter-templates.md` (cover letter) contains an `ACTIVE-TEMPLATE` managed block naming it. If no custom templates exist, say so and explain that `/add-template` registers one. Stop here.
+
+---
+
+## Step 1: Template Type and Source
+
+Ask the user (skip anything already answered by `$ARGUMENTS`):
+
+1. **Type:** Is this a **CV** template or a **cover letter** template?
+2. **Source:** Where is the template? Accept any of:
+   - A path or @-mention of a `.tex` file (plus optional `.cls`/`.sty` files)
+   - Pasted LaTeX content
+   - A directory containing the template and its assets (class files, fonts, images)
+
+Read every provided file. If the template references a document class or package that is not part of standard TeX distributions (e.g. a custom `.cls`), confirm the user has the file and ask for it if missing — the template cannot compile without it.
+
+---
+
+## Step 2: Capture Template Instructions
+
+Interview the user for the metadata that `/apply` needs to use the template correctly. Infer as much as possible from the LaTeX source first (documentclass, `\fontspec` calls, geometry, colors) and present your inferences for confirmation rather than asking blind questions.
+
+Collect:
+
+1. **Name** - short kebab-case identifier (e.g. `awesome-cv`, `classic-serif`). Must not collide with an existing folder in `templates/`.
+2. **Compile engine** - `lualatex`, `xelatex`, or `pdflatex`. If the source uses `fontspec` or loads font files by path, it requires `xelatex` or `lualatex`; tell the user this rather than letting them pick `pdflatex`.
+3. **Fonts** - which font(s) the template uses and where they come from:
+   - **Bundled font files** (`.ttf`/`.otf` shipped with the template): copy them into the template folder in Step 3 and record the relative `Path` used in `\fontspec` calls.
+   - **System / TeX-distribution fonts**: record the font name and note that the user's machine must have it installed.
+4. **Style rules** - anything the drafter must preserve when filling the template: color scheme, section order, heading style, spacing conventions, bullet formatting, date format.
+5. **Page limit** - hard page count for the compiled PDF. Default: **2 pages** for a CV, **1 page** for a cover letter. `/apply`'s compile-and-inspect loop enforces this.
+6. **Known pitfalls** (optional) - macros that break with certain content (like the stock template's `\lettercontent{}`/`itemize` interaction), characters that need escaping, sections that must not be reordered.
+
+---
+
+## Step 3: Store the Template
+
+Create the template folder:
+
+- CV: `templates/cv/<name>/`
+- Cover letter: `templates/cover_letters/<name>/`
+
+Write into it:
+
+1. **`template.tex`** - the template skeleton. Replace all personal data in the source with `[PLACEHOLDER]` tokens (`[YOUR_NAME]`, `[YOUR_EMAIL]`, `[YOUR_PHONE]`, `[YOUR_LINKEDIN_URL]`, ...) so the template is shareable and profile-agnostic. Keep the structure, preamble, and styling exactly as provided.
+2. **Class/style files** - copy any `.cls`/`.sty` files alongside `template.tex`.
+3. **`fonts/`** - copy bundled font files here, preserving any directory layout the `\fontspec` `Path` options expect. Adjust `Path` values in `template.tex` to be relative to the template folder.
+4. **`TEMPLATE.md`** - the manifest. Use exactly this format:
+
+```markdown
+# Template: <name>
+
+- **Type:** CV | Cover letter
+- **Engine:** lualatex | xelatex | pdflatex
+- **Page limit:** <N> page(s)
+- **Fonts:** <main font> (<bundled in fonts/ | system font - must be installed>)
+- **Class/packages:** <documentclass and any non-standard packages, or "standard">
+
+## Compile command
+
+    cd <output dir> && <engine> -interaction=nonstopmode <file>.tex
+
+## Style rules
+
+- <rule 1: colors, section order, heading style, ...>
+- <rule 2>
+
+## Known pitfalls
+
+- <pitfall and its fix, or "none recorded">
+```
+
+---
+
+## Step 4: Verify the Template Compiles (MANDATORY)
+
+Never register a template without a successful test compile. LaTeX templates that "look fine" routinely fail on missing fonts, missing classes, or engine mismatches.
+
+1. Copy `template.tex` to a scratch file in the same folder (e.g. `_compile_test.tex`) and fill every `[PLACEHOLDER]` with realistic dummy data (name, contact line, one education entry, one job entry with 3 bullets — enough content to exercise the layout).
+2. Compile with the declared engine:
+   ```bash
+   cd templates/<type>/<name> && <engine> -interaction=nonstopmode _compile_test.tex
+   ```
+3. If the compile fails: show the user the relevant error lines, diagnose (missing font file, wrong engine, missing class), fix what you can (e.g. font `Path` values), and re-compile. If the fix needs input only the user has (a missing font file, a license-restricted class), ask for it and wait.
+4. On success, Read the PDF and confirm the layout renders sensibly (no overlapping text, fonts loaded, page count plausible for dummy content). Record any surprises in the manifest's "Known pitfalls".
+5. Delete the scratch files: `_compile_test.tex`, `_compile_test.pdf`, and all `.aux`/`.log`/`.out` artifacts.
+
+Do not proceed to Step 5 until the test compile passes.
+
+---
+
+## Step 5: Activate the Template
+
+Activation wires the template into `/apply` by adding a **managed block** to the top of the relevant guidance file — `05-cv-templates.md` for CVs, `06-cover-letter-templates.md` for cover letters. `/apply` reads these files in its drafting step, so the block is all it takes.
+
+Insert (or replace, if one exists) this block immediately after the file's H1 title:
+
+```markdown
+<!-- BEGIN ACTIVE-TEMPLATE (managed by /add-template - do not edit by hand) -->
+> **Active template override: `<name>`**
+>
+> A custom template is active. Where this block conflicts with the stock guidance below, this block wins. Structural advice below (tailoring, page-budget, cutting rules) still applies.
+>
+> - **Template skeleton:** `templates/<type>/<name>/template.tex` — use this as the structural reference instead of the stock template
+> - **Manifest:** `templates/<type>/<name>/TEMPLATE.md` — read this for style rules and known pitfalls before drafting
+> - **Compile with:** `<engine>` (not the engine named in the stock guidance below)
+> - **Fonts:** <font summary, including any Path note for bundled fonts>
+> - **Page limit:** exactly <N> page(s)
+> - **Output file:** unchanged (`cv/main_<company>.tex` / `cover_letters/cover_<company>_<role>.tex`); copy any class/font files the template needs into the output directory, or reference them by relative path
+<!-- END ACTIVE-TEMPLATE -->
+```
+
+Rules:
+
+- Exactly **one** managed block per guidance file. Replace the whole block between the `BEGIN`/`END` markers when switching templates; never stack blocks.
+- **`--use default`**: remove the managed block entirely. The stock moderncv / cover.cls guidance below it is untouched and takes over again.
+- Do not modify anything outside the markers.
+
+---
+
+## Step 6: Confirm
+
+Present a summary:
+
+> **Template `<name>` registered and activated.**
+>
+> - Files: `templates/<type>/<name>/` (skeleton, manifest<, class files><, fonts>)
+> - Test compile: passed with `<engine>` (<N> page(s))
+> - `/apply` will now draft <CVs | cover letters> from this template.
+>
+> Useful follow-ups:
+> - `/add-template --list` — see all registered templates
+> - `/add-template --use <other-name>` — switch templates
+> - `/add-template --use default` — go back to the stock <moderncv | cover.cls> template
+
+---
+
+## Design Principles
+
+- Registration is idempotent: re-running with the same name offers to update the existing template rather than duplicating it.
+- Templates are stored profile-agnostic (`[PLACEHOLDER]` tokens) so they can be shared or committed without leaking personal data.
+- The compile check in Step 4 is non-negotiable — a template that has never compiled will fail mid-`/apply`, which is the worst place to discover it.
+- Activation is a small managed block, not a rewrite of the guidance files: `/setup` and manual edits to `05`/`06` survive template switches, and `--use default` is a clean revert.

--- a/.opencode/command/apply.md
+++ b/.opencode/command/apply.md
@@ -220,7 +220,7 @@ Do not proceed to Step 6 until both PDFs pass inspection.
 
 ### 5d. Clean up build artifacts
 
-After the final clean compile, delete the `.aux`, `.log`, `.out` files (keep` files (keep the `.tex` and `.pdf`).
+After the final clean compile, delete the `.aux`, `.log`, `.out` files (keep the `.tex` and `.pdf`).
 
 ---
 

--- a/.opencode/command/apply.md
+++ b/.opencode/command/apply.md
@@ -1,0 +1,246 @@
+# /apply - Drafter-Reviewer Job Application Workflow
+
+You are orchestrating a two-agent job application workflow. The job posting is provided below as `$ARGUMENTS` (either a URL or pasted text).
+
+Follow these steps **exactly in order**. Do not skip steps.
+
+**Token-efficiency rules for this workflow:**
+- Never re-Read a file whose contents are already in your context from an earlier step. If you read it in Step 1, it is still available in Step 2.
+- When dispatching the reviewer agent, pass draft content **inline in the agent prompt** rather than asking the agent to Read files you already have in memory.
+- Run the full verification checklist exactly once, at the end (Step 6). The reviewer focuses on content critique, not verification.
+- Step 5 (compile and inspect PDFs) is mandatory and non-skippable — LaTeX page-break decisions are unpredictable, and `.tex` files that look fine often produce broken PDFs (orphaned entry titles, cover letters spilling to page 2, bullet fonts mismatching).
+
+---
+
+## Step 0: Parse Input
+
+- If `$ARGUMENTS` looks like a URL, use `WebFetch` to retrieve the job posting content.
+- If it is pasted text, use it directly.
+- Extract: **company name**, **role title**, **department** (if mentioned), **location**, and **language** of the posting (Danish or English).
+- Store these for use throughout the workflow.
+
+---
+
+## Step 1: DRAFTER - Evaluate Fit
+
+Read the evaluation framework:
+- `.claude/skills/job-application-assistant/04-job-evaluation.md`
+- `.claude/skills/job-application-assistant/01-candidate-profile.md`
+
+Using the framework from `04-job-evaluation.md`, evaluate the job posting against the candidate's profile. If the salary lookup tool is configured, run:
+
+```bash
+python salary_lookup.py "<Company Name>" --json
+```
+
+If the posting specifies a city, add `--city "<City>"` to narrow results. Parse the JSON output and include the salary benchmark in the evaluation. If the tool is not configured or returns an error, skip the salary benchmark.
+
+Present the evaluation to the user with:
+
+1. **Skills match** - which required/preferred skills match vs. gaps
+2. **Experience match** - how work history maps to the role
+3. **Behavioral/culture match** - how behavioral profile fits the role/company culture
+4. **Salary benchmark** - salary index for the company (if available)
+5. **Overall fit score** and recommendation (strong fit / moderate fit / weak fit)
+
+After presenting the evaluation, ask the user:
+> "Should I proceed with drafting the CV and cover letter for this role?"
+
+**If the user says no, stop here.** If yes, continue to Step 2.
+
+---
+
+## Step 2: DRAFTER - Draft CV + Cover Letter
+
+You already have `01-candidate-profile.md` and `04-job-evaluation.md` in context from Step 1. **Do not re-read them.**
+
+Read only the reference files you do not yet have:
+- `.claude/skills/job-application-assistant/03-writing-style.md`
+- `.claude/skills/job-application-assistant/05-cv-templates.md`
+- `.claude/skills/job-application-assistant/06-cover-letter-templates.md`
+
+Also read the most recent existing CV and cover letter files for concrete structural reference (one of each is enough):
+- Read any existing `cv/main_*.tex` file as a LaTeX template reference
+- Read any existing `cover_letters/cover_*.tex` or `cover_letters/Cover_*.tex` file as a template reference
+
+### CV (`cv/main_<company>.tex`)
+- Always in **English**
+- Follow the moderncv/banking format from `05-cv-templates.md`
+- Tailor the profile statement and experience bullets to the specific role
+- Reframe skills and achievements to match job requirements
+- Keep to 2 pages
+
+### Cover Letter (`cover_letters/cover_<company>_<role>.tex`)
+- **Match the language of the job posting** (Danish posting -> Danish cover letter, English posting -> English cover letter)
+- Follow the structure from `06-cover-letter-templates.md`
+- Use the `cover.cls` template
+- Tailor the opening paragraph to the specific role and company
+- Address to a named person if available in the posting, otherwise "Dear Hiring Manager" (or equivalent in posting language)
+- Keep to approximately one page
+- Any mention of agentic coding or AI tooling must reference **Claude Code** by name
+
+Write both files to disk. Keep the exact text of both drafts in working memory — you will pass them inline to the reviewer in Step 3 and revise them in Step 4 without re-reading.
+
+---
+
+## Step 3: REVIEWER - Research & Critique
+
+Use the **Agent tool** to spawn a `general-purpose` reviewer agent. The reviewer gets a fresh context, so pass the drafts **inline in the prompt** below (do not make the reviewer Read them). Scope the reviewer's file reads to content-critique essentials only — the reviewer does not need the LaTeX template files (`05`, `06`) to critique content, since those govern structural/LaTeX concerns the drafter already applied.
+
+Replace `<COMPANY>`, `<ROLE>`, `<INSERT_JOB_POSTING_TEXT_HERE>`, `<INSERT_CV_DRAFT_HERE>`, and `<INSERT_COVER_LETTER_DRAFT_HERE>` with actual values before dispatching.
+
+```
+You are a hiring manager proxy reviewing a job application. Your job is to make the application as targeted and compelling as possible.
+
+## Your Tasks
+
+### 1. Research the Company
+Use WebSearch and WebFetch to research:
+- The company's website, mission, and recent news
+- The specific department or team (if mentioned in the posting)
+- Any recent projects, press releases, or strategic initiatives relevant to the role
+- Company culture and values
+
+### 2. Read Reference Materials (content-critique only)
+Read these four files — and only these — to ground your critique:
+- `.claude/skills/job-application-assistant/01-candidate-profile.md`
+- `.claude/skills/job-application-assistant/02-behavioral-profile.md` — use this specifically to check whether the cover letter's voice matches the candidate's natural register. A "Collaborator" PI profile, for example, should not be given a combative, solo-hero tone; a "Persuader" profile should not be given over-hedged, apologetic phrasing.
+- `.claude/skills/job-application-assistant/03-writing-style.md`
+- `.claude/skills/job-application-assistant/04-job-evaluation.md`
+
+Do NOT read `05-cv-templates.md` or `06-cover-letter-templates.md` — those govern LaTeX structure the drafter already applied and are not needed for content critique.
+
+### 3. Drafts to Review
+Both drafts are provided inline below. Do NOT use the Read tool on the draft files — use these exact texts.
+
+<CV_DRAFT file="cv/main_<COMPANY>.tex">
+<INSERT_CV_DRAFT_HERE>
+</CV_DRAFT>
+
+<COVER_LETTER_DRAFT file="cover_letters/cover_<COMPANY>_<ROLE>.tex">
+<INSERT_COVER_LETTER_DRAFT_HERE>
+</COVER_LETTER_DRAFT>
+
+### 4. Job Posting
+<JOB_POSTING>
+<INSERT_JOB_POSTING_TEXT_HERE>
+</JOB_POSTING>
+
+### 5. Produce Feedback
+
+Return your feedback in **two parts**:
+
+**Part A — Structured edits (preferred format whenever possible):**
+A JSON array of concrete edits the drafter can apply directly without re-reading the files. Each edit is an object:
+```json
+{
+  "file": "cv/main_<COMPANY>.tex" | "cover_letters/cover_<COMPANY>_<ROLE>.tex",
+  "old_string": "<exact text currently in the draft>",
+  "new_string": "<replacement text>",
+  "reason": "<one-line rationale: keyword match / company angle / reframing / style>"
+}
+```
+Only use this format when you can quote the exact `old_string` from the drafts above. Make `old_string` unique — include enough surrounding context so it matches exactly once per file.
+
+**Part B — Narrative suggestions (for judgment calls that are not mechanical edits):**
+Prose suggestions grouped by category. Produce each category even if your finding is "no issues" — silence on a category can be mistaken for skipping it.
+- **Missed keywords/requirements** — what to add and roughly where, if it cannot be expressed as a clean string replacement
+- **Company/department-specific angles** — connections between experience and the company's strategic priorities, based on your research
+- **Action-oriented reframing** — identify passive, generic, or low-energy statements and suggest action-oriented rewrites. Use this category especially for structural weakness that doesn't fit a single-sentence swap (e.g., "the whole opening paragraph reads as passive — restructure around your single strongest match to the posting").
+- **Tone and style issues** — check against `03-writing-style.md` AND `02-behavioral-profile.md`. Flag any issues with tone, formality, or voice (cliches, hedging, over-humility, inconsistent register), and specifically flag any mismatch between the letter's voice and the candidate's natural register as described in the behavioral profile.
+
+**CRITICAL RULE:** All suggestions must be grounded in actual profile data. Do NOT suggest fabricating skills, experience, or achievements. If a requirement is a gap, say so honestly and suggest how to frame adjacent experience instead.
+
+Do **not** run a verification checklist — the drafter will do that in the final step. Focus on content critique.
+
+Return Part A and Part B together as a single structured message.
+```
+
+---
+
+## Step 4: DRAFTER - Revise Based on Feedback
+
+Once the reviewer agent returns its feedback:
+
+1. **Apply Part A (structured edits) directly with the Edit tool.** Do NOT re-read the draft files — you already have them in context from Step 2, and the reviewer's `old_string` values were quoted from that same text. For each edit in the JSON array, call `Edit` with the given `file`, `old_string`, and `new_string`. Skip any whose rationale would require fabricating content.
+2. **Apply Part B (narrative suggestions)** using judgment. These need interpretation, not mechanical replacement. Walk through every Part B category the reviewer returned and address it:
+   - **Missed keywords/requirements:** add the keyword or capability where it fits naturally in the CV or cover letter. Prefer the experience bullets (concrete evidence) over the profile statement (abstract claim).
+   - **Company/department-specific angles:** weave the reviewer's research into the cover letter opening or motivation paragraph. Verify every company claim via WebFetch/WebSearch before including it — do not trust reviewer research at face value.
+   - **Action-oriented reframing:** rewrite passive or generic phrasing (CV profile statement, cover letter opening, bullet leads). Structural weakness that the reviewer flagged without a clean JSON edit lives here.
+   - **Tone and style issues:** apply the writing-style-guide fixes (no em-dashes, no cliches, no apologetic hedging, consistent first-person active voice).
+   Use Edit for targeted changes; only re-read a file if an edit fails because the surrounding text has shifted.
+3. Do NOT incorporate any suggestion that would fabricate skills or experience. If a posting requirement is a genuine gap, acknowledge it honestly and frame adjacent experience instead.
+
+After all edits are applied, the two files on disk are the final drafts.
+
+---
+
+## Step 5: DRAFTER - Compile & Inspect PDFs (MANDATORY)
+
+**Never skip this step.** The `.tex` files looking fine is not sufficient — LaTeX page-break decisions are unpredictable and commonly produce broken layouts (orphaned job titles separated from their bullets, cover letters spilling to 2 pages, bullet fonts not matching body text). Compile both documents and visually verify the PDFs before presenting.
+
+### 5a. Compile
+
+```bash
+cd cv && lualatex -interaction=nonstopmode main_<company>.tex
+cd ../cover_letters && xelatex -interaction=nonstopmode cover_<company>_<role>.tex
+```
+
+- CV uses **lualatex** — pdflatex fails on modern MiKTeX with fontawesome5 font-expansion errors. lualatex handles the same sources cleanly.
+- Cover letter uses **xelatex** — cover.cls requires fontspec.
+
+If either compile fails, fix the error and re-compile until clean.
+
+### 5b. Inspect layout
+
+Read both PDFs via the Read tool and verify:
+
+**CV (`cv/main_<company>.pdf`):**
+- [ ] Exactly 2 pages (not 1, not 3)
+- [ ] No orphaned `\cventry` titles — a job/education title line must never sit alone at the bottom of page 1 with its bullets on page 2. This is the most common failure.
+- [ ] Section headings are not isolated at the top of page 2 with only 1-2 lines below
+- [ ] No awkward whitespace gaps
+
+**Cover letter (`cover_letters/cover_<company>_<role>.pdf`):**
+- [ ] Exactly 1 page
+- [ ] Signature block visible, not cut off or pushed to a second page
+- [ ] Bullet list font matches surrounding body text (both should be Raleway-Medium)
+
+### 5c. Iterate until clean
+
+If the layout has problems, edit the `.tex` files and recompile. Common fixes (see `05-cv-templates.md` and `06-cover-letter-templates.md` for full details):
+
+- **Orphaned CV entry title:** `\usepackage{needspace}` in preamble, then `\needspace{5\baselineskip}` immediately before the problematic `\cventry`
+- **CV spills to page 3 with only a trailing section:** `\enlargethispage{2-3\baselineskip}` before a late section
+- **Substantial content on page 3:** cut content using **relevance-weighted cutting** (see `05-cv-templates.md` → "Relevance-weighted cutting"). Score each candidate line by (a) relevance to THIS posting's keywords and responsibilities, (b) uniqueness (is it duplicated elsewhere?), (c) narrative load (does the cover letter depend on it?). Cut the lowest-total-score line first, regardless of section. Do NOT mechanically apply a static section-based priority order — an older-role bullet that hits posting keywords is worth more than a recent-role bullet that does not.
+- **Cover letter itemize breaks compile or uses wrong font:** close `\lettercontent{}` before the list, wrap the list in `{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont \begin{itemize}...\end{itemize}\par}`
+- **Cover letter spills to 2 pages:** trim using the same relevance-weighted logic. First cut: sentences that restate what a bullet already said. Second cut: a bullet that does not hit posting keywords. Last resort: a bullet that does hit posting keywords. Never reduce geometry or line spacing.
+
+Do not proceed to Step 6 until both PDFs pass inspection.
+
+### 5d. Clean up build artifacts
+
+After the final clean compile, delete the `.aux`, `.log`, `.out` files (keep` files (keep the `.tex` and `.pdf`).
+
+---
+
+## Step 6: Present Final Output
+
+Run the full verification checklist from `CLAUDE.md` now — this is the **only** verification pass in the workflow. Re-read both files once here to verify final state on disk matches your mental model after the Step 4 and Step 5 edits.
+
+### Verification Checklist
+Report pass/fail for each item in the CLAUDE.md verification checklist (factual accuracy, targeting, consistency, quality).
+
+### Key Tailoring Decisions
+Summarize 3-5 key decisions made to tailor the application:
+- What was emphasized and why
+- What company-specific angles were incorporated
+- What the reviewer suggested that was most impactful
+- Any gaps that were acknowledged or reframed
+
+### Files Created
+List the files written:
+- `cv/main_<company>.tex`
+- `cover_letters/cover_<company>_<role>.tex`
+
+Tell the user: "Both files are ready for your review. Open them to check the final output before compiling."

--- a/.opencode/command/expand.md
+++ b/.opencode/command/expand.md
@@ -1,0 +1,216 @@
+# /expand - Competency Expansion from Documents and Online Presence
+
+You are enriching the candidate profile by discovering competencies hidden in documents and public online presence. This command is additive only — it never modifies existing profile content, only extends it.
+
+Follow these steps **exactly in order**. Do not skip steps.
+
+---
+
+## Step 0: Read Existing Profile Files
+
+Read these two files in parallel before doing anything else. You must know what is already there so you do not propose duplicates.
+
+- `.claude/skills/job-application-assistant/01-candidate-profile.md`
+- `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+
+Hold this content in context throughout the command. Do not re-read these files later.
+
+---
+
+## Step 1: Discovery — Scan All Sources
+
+Scan every available source for "experience items" — anything that implies skill, knowledge, or competency. Process sources in this order.
+
+### 1a. documents/cv/
+Read all files in `documents/cv/`. Extract:
+- Every course or module listed (including university coursework and online courses)
+- Every certification mentioned, with issuer and date
+- Every job responsibility bullet point (tools, methods, outcomes)
+- Every independent project or side project
+- Every volunteer or extracurricular role
+
+### 1b. documents/linkedin/
+Read all files in `documents/linkedin/`. Extract:
+- Courses and certifications in the "Licenses & Certifications" section
+- Skills and endorsements list
+- Volunteer experiences
+- Projects section
+- Any platform-specific items not already found in the CV
+
+### 1c. documents/diplomas/
+Read all files in `documents/diplomas/`. Extract:
+- All course/module names listed on transcripts
+- Thesis title and subject area
+- Any specialisation or track name
+
+### 1d. documents/references/
+Read all files in `documents/references/`. Extract:
+- Competency language used by the referee (what skills or qualities they mention)
+- Any specific projects, tools, or methods named
+
+### 1e. GitHub Profile
+Look up the GitHub username from `01-candidate-profile.md`. If a GitHub URL or username is present:
+
+1. Use WebFetch or WebSearch to retrieve the public profile and pinned repositories
+2. For each repository found:
+   - Fetch the repository README
+   - Note: name, description, primary language(s), topics/tags, any frameworks or libraries mentioned in the README
+3. Also retrieve the full repository list if available (to catch unpinned repos)
+
+If no GitHub username or URL is found in the profile, skip this source and note it was skipped.
+
+### 1f. Other URLs in Profile
+Check `01-candidate-profile.md` for any other URLs (portfolio site, personal website, Kaggle, Google Scholar, ResearchGate, publication links). For each:
+- Fetch the page
+- Extract any tools, methods, datasets, awards, or skills mentioned
+
+---
+
+## Step 2: Web Enrichment
+
+For each experience item discovered in Step 1, search the web to extract the competencies it implies. Apply both approaches below — do not choose one over the other.
+
+### Approach A: Direct lookup (explicit tools and frameworks)
+If the item names a specific tool, framework, library, method, or platform, search for it directly:
+- `"[Course name] [Provider] syllabus learning outcomes"`
+- `"[Certification name] skills covered exam guide"`
+- `"[Tool/framework name] skills what you learn"`
+
+Fetch the most relevant page and extract the competency list.
+
+### Approach B: Inferred competencies (from description and context)
+For each item, regardless of whether Approach A found anything, also reason from the description:
+- What problem domain does this item address?
+- What methods, skills, or knowledge does someone need to do this work?
+- What is the standard toolchain for this kind of work?
+
+Combine both approaches into a single competency list for each item.
+
+### Prioritise web lookup for:
+- Named online courses (Coursera, edX, Udemy, LinkedIn Learning, DataCamp, fast.ai, etc.)
+- Named certifications (AWS, GCP, Azure, Databricks, Tableau, etc.)
+- University courses with a standard syllabus
+- GitHub repositories with a README that names specific technologies
+
+### Infer (without web lookup) for:
+- Generic job responsibility bullets with no named tool
+- Vague project descriptions
+- Reference letter language (already phrased as competency — just record it)
+
+---
+
+## Step 3: Build Competency Map
+
+After enriching all items, build a deduplicated competency map. Group findings into these categories:
+
+**Technical Skills — Primary** (core languages, frameworks, methods you use regularly)  
+**Technical Skills — Secondary** (tools you have used but are not primary)  
+**Domain Knowledge** (subject matter expertise: geophysics, ML, NLP, etc.)  
+**Methods and Practices** (agile, version control, reproducibility, testing, etc.)  
+**Soft / Behavioral** (leadership, communication, collaboration signals from references and project descriptions)  
+
+For each competency, record:
+- The competency name
+- The source item it came from (e.g. "Coursera — Deep Learning Specialisation", "GitHub — repo-name", "Reference letter — Jens Jensen")
+- Whether it came from direct lookup (A), inference (B), or both
+
+Remove anything already present in `01-candidate-profile.md` or `02-behavioral-profile.md`.
+
+---
+
+## Step 4: Present Grouped Summary
+
+Present all new competencies for the user's review before writing anything. Format:
+
+```
+## /expand found [N] new competency signals across [M] sources
+
+**COURSES & CERTIFICATIONS**
+Source: [Course/cert name — Provider]
+  + [Competency 1]
+  + [Competency 2]
+  ...
+
+**GITHUB — [repo-name]**
+Source: README + inferred from tech stack
+  + [Competency 1]
+  + [Competency 2]
+  ...
+
+**JOB RESPONSIBILITIES — [Company, Role]**
+Source: CV bullets + direct tool lookup
+  + [Competency 1]
+  ...
+
+**BEHAVIORAL SIGNALS**
+Source: [Reference letter — Name / LinkedIn About / Project leadership]
+  + [Signal 1]
+  ...
+
+[more sections as needed]
+```
+
+Then ask:
+
+> **How would you like to proceed?**
+>
+> - **`all`** — Add everything above to your profile
+> - **`review`** — I'll walk you through each source group one at a time
+> - **`skip`** — Cancel without writing anything
+>
+> Or list specific groups to skip (e.g. "skip GitHub, add everything else").
+
+Wait for the user's response before writing anything.
+
+---
+
+## Step 5: Write Confirmed Additions
+
+Apply only the confirmed items. Use the Edit tool to add to the relevant sections of each file — do not rewrite entire files.
+
+### Additions to `01-candidate-profile.md`
+- Technical skills (primary and secondary) → append to the Technical Skills section
+- Domain knowledge → append to the Domain Knowledge or Technical Skills section (match the existing structure)
+- Methods and practices → append appropriately
+
+For each addition, add a brief source annotation in a comment or parenthetical: *(Coursera — Deep Learning Specialisation)*, *(GitHub — project-name)*, etc. This makes future `/expand` runs idempotent.
+
+### Additions to `02-behavioral-profile.md`
+- Soft/behavioral signals → append to the "Strongest Behavioral Traits" or "How I Work Best" section (match existing structure)
+- Always label inferred behavioral additions: *[Inferred from reference letter — Name / review before relying on this]*
+
+---
+
+## Step 6: Summary Report
+
+After writing, present:
+
+```
+## /expand Complete
+
+### Added to 01-candidate-profile.md
+[List each competency added, with source]
+
+### Added to 02-behavioral-profile.md
+[List each behavioral signal added, with source]
+
+### Sources processed
+[List each source scanned and how many competencies it yielded]
+
+### Sources skipped
+[List any sources that were missing, empty, or yielded nothing new — with brief reason]
+
+### Needs manual review
+[Any items that were ambiguous, partially readable, or where web lookup returned no clear syllabus]
+```
+
+---
+
+## Design Principles
+
+- **Additive only.** This command never modifies existing profile content. It only appends.
+- **Source-traceable.** Every addition records where it came from, so future runs are idempotent and the user can verify or remove individual items later.
+- **Both approaches, always.** Web lookup and inference are applied together — not as alternatives. A named course gets its official syllabus AND a reasoned competency list.
+- **User confirms before writing.** The full competency map is shown and confirmed before a single file is touched.
+- **Behavioral signals are labeled.** Anything inferred from tone, language, or indirect signals is marked as inferred so it is reviewed critically.
+- **GitHub is fully scanned.** All public repositories are checked, not just pinned ones — unpinned repos often contain significant competency signals.

--- a/.opencode/command/reset.md
+++ b/.opencode/command/reset.md
@@ -1,0 +1,224 @@
+# /reset - Reset Candidate Profile Data
+
+You are resetting parts of the job search framework back to a blank state so the user can start fresh with `/setup`.
+
+**This command is destructive.** Nothing is deleted until the user explicitly confirms. Follow these steps exactly in order.
+
+---
+
+## Step 0: Parse Scope from Arguments
+
+Check `$ARGUMENTS` for a scope keyword:
+
+- `profile` — clears candidate profile data from skill files only
+- `documents` — deletes user-provided files from the `documents/` folder only
+- `all` — both of the above
+
+If `$ARGUMENTS` is empty or does not contain a recognized scope keyword, ask:
+
+> **What would you like to reset?**
+>
+> - **`profile`** — Clears candidate data from the skill files (profile, behavioral, STAR examples, profile statements). The framework structure and writing rules are preserved. Use this to re-run `/setup` from scratch.
+>
+> - **`documents`** — Deletes all files you've placed in the `documents/` folder (CV PDFs, LinkedIn export, diplomas, references, past applications). The folder structure and `README.md` are preserved.
+>
+> - **`all`** — Both of the above.
+>
+> Reply with `profile`, `documents`, or `all`.
+
+Wait for the user's response before continuing.
+
+---
+
+## Step 1: Show Exactly What Will Be Cleared
+
+Before doing anything, show the user precisely what will be wiped.
+
+### If scope includes `profile`:
+
+Read the current state of these files and report whether each has content or is already empty:
+
+- `.claude/skills/job-application-assistant/01-candidate-profile.md`
+- `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+- `.claude/skills/job-application-assistant/05-cv-templates.md` *(profile statements section only — framework structure is preserved)*
+- `.claude/skills/job-application-assistant/07-interview-prep.md` *(STAR examples and STAR candidates sections only — framework structure is preserved)*
+
+Present as:
+
+```
+## Profile reset will clear:
+
+- 01-candidate-profile.md — [has content / already empty]
+  Full file will be replaced with a blank template.
+
+- 02-behavioral-profile.md — [has content / already empty]
+  Full file will be replaced with a blank template.
+
+- 05-cv-templates.md — [has profile statements / already blank]
+  Profile statement templates will be cleared. LaTeX structure and tailoring guidelines are preserved.
+
+- 07-interview-prep.md — [has STAR examples / already blank]
+  STAR examples and any STAR candidate stubs will be cleared. Framework, tough questions, and roleplay guidelines are preserved.
+
+The following files are NOT touched (they contain framework rules, not candidate data):
+  - 03-writing-style.md
+  - 04-job-evaluation.md
+  - 06-cover-letter-templates.md
+```
+
+### If scope includes `documents`:
+
+Use Glob to list all files present in `documents/cv/`, `documents/linkedin/`, `documents/diplomas/`, `documents/references/`, and `documents/applications/`. Present as:
+
+```
+## Documents reset will delete:
+
+documents/cv/
+  - [filename] or "(empty)"
+
+documents/linkedin/
+  - [filename] or "(empty)"
+
+documents/diplomas/
+  - [filename] or "(empty)"
+
+documents/references/
+  - [filename] or "(empty)"
+
+documents/applications/
+  - [subfolder/filename] or "(empty)"
+
+documents/README.md — NOT deleted (instructions file)
+```
+
+If all document subfolders are already empty, state "All document subfolders are already empty — nothing to delete." and skip the confirmation step for this scope.
+
+---
+
+## Step 2: Require Explicit Confirmation
+
+Present the confirmation prompt:
+
+> **This cannot be undone.**
+>
+> Type **`RESET`** (all caps) to confirm, or anything else to cancel.
+
+Wait for the user's response.
+
+- If the user types exactly `RESET`: proceed to Step 3.
+- If the user types anything else: abort and tell them "Reset cancelled. Nothing was changed."
+
+---
+
+## Step 3: Execute the Reset
+
+### Profile reset
+
+**For `01-candidate-profile.md`**, replace the file content with:
+
+```markdown
+# Candidate Profile
+
+<!-- Run /setup to populate this file -->
+
+## Identity
+
+## Education
+
+## Professional Experience
+
+## Independent Projects
+
+## Technical Skills
+
+## Publications
+
+## Awards
+
+## References
+```
+
+**For `02-behavioral-profile.md`**, replace the file content with:
+
+```markdown
+# Behavioral Profile
+
+<!-- Run /setup to populate this file -->
+
+## Overview
+
+## Strongest Behavioral Traits
+
+## How I Work Best
+
+## Growth Areas
+
+## Mapping to Job Posting Language
+
+## Management Style Preferences
+
+## Using This in Applications
+```
+
+**For `05-cv-templates.md`**, locate the section that begins with `**Profile statement templates` and extends through the role-specific template blocks. Replace only that section with:
+
+```markdown
+**Profile statement templates:**
+
+<!-- Run /setup to populate role-specific profile statements -->
+```
+
+Leave all other content in `05-cv-templates.md` intact.
+
+**For `07-interview-prep.md`**, locate and remove:
+- The entire `## Ready-Made STAR Examples` section and all numbered STAR examples under it
+- Any `## STAR Candidates (Complete Manually)` section added by `/setup` Path A
+
+Replace with:
+
+```markdown
+## Ready-Made STAR Examples
+
+<!-- Run /setup to populate STAR examples from your actual experience -->
+```
+
+Leave all other content in `07-interview-prep.md` intact (STAR format explanation, tough questions, questions to ask interviewers, phone/video tips, follow-up etiquette, roleplay guidelines).
+
+### Documents reset
+
+For each non-empty document subfolder, delete all files within it using Bash `rm`. Do not delete the folder itself, and do not delete `documents/README.md`.
+
+```bash
+rm -f documents/cv/*
+rm -f documents/linkedin/*
+rm -f documents/diplomas/*
+rm -f documents/references/*
+rm -rf documents/applications/*/
+```
+
+---
+
+## Step 4: Confirm What Was Done and Next Steps
+
+After the reset is complete, report:
+
+```
+## Reset complete
+
+### Cleared
+[List each file/folder that was actually modified or cleared]
+
+### Unchanged
+[List anything that was already empty or was intentionally preserved]
+```
+
+Then tell the user what to do next based on what was reset:
+
+**If profile was reset:**
+> Your candidate profile is now blank. Run `/setup` to repopulate it. The command auto-detects any files in your `documents/` folder and offers to read from there; otherwise it walks you through a CV import or interactive interview.
+
+**If documents were reset:**
+> The `documents/` folder is now empty. Add your career documents and run `/setup` to populate your profile. See `documents/README.md` for instructions on what to put where.
+
+**If both were reset:**
+> Both your profile files and documents folder are now empty. Add documents to `documents/` (or skip and use the CV import / interview path), then run `/setup`.

--- a/.opencode/command/setup.md
+++ b/.opencode/command/setup.md
@@ -1,0 +1,406 @@
+# /setup - Profile Onboarding
+
+You are running the onboarding setup for the AI Job Search framework. Your goal is to collect the user's professional information and populate all profile files so the `/apply` workflow works out of the box.
+
+There are three paths into setup. Step 0 picks the right one; all three converge on Step 3 (file generation) and Step 4 (confirmation).
+
+---
+
+## Step 0: Welcome & Choose Path
+
+If `$ARGUMENTS` contains `--section <name>`, skip directly to that section in Path C for an update-only flow. Do not run the path-selection prompt below.
+
+Otherwise, before greeting the user, scan the `documents/` folder. Use Glob with `documents/**/*` and count files per subfolder (`cv/`, `linkedin/`, `diplomas/`, `references/`, `applications/`).
+
+Then welcome the user with a single message that lists three paths. The wording changes based on what was found.
+
+**If `documents/` has files** in one or more subfolders, lead with Path A:
+
+> **Welcome to the AI Job Search setup!**
+>
+> I'll help you build your professional profile so the AI can evaluate job postings, tailor CVs, write cover letters, and prepare you for interviews.
+>
+> I see files in your `documents/` folder: [list per subfolder, e.g. "2 in cv/, 1 in linkedin/, 3 in references/"]. Three ways to start:
+>
+> **Path A: Read my documents folder** (recommended for what you have) - I'll read everything in `documents/`, cross-reference for consistency, and build your profile from real source materials. Idempotent and safe to re-run as you add more documents.
+>
+> **Path B: Single CV import** - Paste or @-mention a single CV/resume here. I'll extract it and ask follow-up questions for what's missing.
+>
+> **Path C: Interview mode** - I'll walk you through structured questions section by section.
+>
+> Which would you like?
+
+**If `documents/` is empty or missing**, surface Path A as a "do this if you have materials" option:
+
+> **Welcome to the AI Job Search setup!**
+>
+> I'll help you build your professional profile so the AI can evaluate job postings, tailor CVs, write cover letters, and prepare you for interviews.
+>
+> Three ways to start:
+>
+> **Path A: Documents folder** (best signal if you have several materials) - Drop your CV / LinkedIn export / diplomas / reference letters in the `documents/` folder, then say "go". I'll read everything and build your profile from it. See `documents/README.md` for the folder layout.
+>
+> **Path B: Single CV import** - Paste or @-mention a single CV/resume here. I'll extract it and ask follow-up questions for what's missing.
+>
+> **Path C: Interview mode** - I'll walk you through structured questions section by section. Good if you're starting from scratch.
+>
+> Which would you like?
+
+Wait for the user's choice. If they pick A but the folder is still empty, tell them what to add (point at `documents/README.md`) and stop.
+
+---
+
+## Path A: Documents Folder
+
+Reads structured documents in `documents/`, cross-references them for consistency, and merges extracted data into the seven profile skill files. Read-before-write and idempotent: changes already present will not be proposed again.
+
+Follow these steps **exactly in order**.
+
+### Step A1: Inventory
+
+Use Glob with `documents/**/*` to scan the full tree. Print:
+
+```
+## Documents Found
+
+**cv/**: [list files, or "(empty)"]
+**linkedin/**: [list files, or "(empty)"]
+**diplomas/**: [list files, or "(empty)"]
+**references/**: [list files, or "(empty)"]
+**applications/**: [list subfolders with their files, or "(empty)"]
+
+I will read these and cross-reference before proposing any changes.
+```
+
+If every subfolder is empty, stop and tell the user to populate the folder. Point at `documents/README.md` for the layout.
+
+### Step A2: Read Existing Skill Files
+
+Read these in parallel before extracting anything. You must know what is already there to make the merge intelligent.
+
+- `.claude/skills/job-application-assistant/01-candidate-profile.md`
+- `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+- `.claude/skills/job-application-assistant/03-writing-style.md`
+- `.claude/skills/job-application-assistant/04-job-evaluation.md`
+- `.claude/skills/job-application-assistant/05-cv-templates.md`
+- `.claude/skills/job-application-assistant/06-cover-letter-templates.md`
+- `.claude/skills/job-application-assistant/07-interview-prep.md`
+
+Hold this content in context throughout Path A. Do not re-read.
+
+### Step A3: Parse Documents
+
+Read each document found in Step A1. Process subfolders in this order: `cv/`, `linkedin/`, `diplomas/`, `references/`, `applications/`.
+
+**`cv/` documents:** name, contact (email, phone, LinkedIn, GitHub), education (degree, institution, dates, thesis), work experience (title, company, dates, location, bullets), skills, publications, awards, profile/summary.
+
+**`linkedin/` documents:** About/summary section (full text, used for behavioral inference), work experience, education, skills and endorsements, certifications, volunteer work, publications, recommendations received (full text). If multiple LinkedIn exports are present, use the most recently modified file.
+
+**`diplomas/` documents:** official degree title and level, institution name (official spelling), graduation date, grade or distinction or GPA if visible.
+
+**`references/` documents:** referee name, title, organization; full text of the letter (extract specific quotes); competency language used.
+
+**`applications/<company>_<role>/` subfolders:**
+- `job_posting.md`: role title, company, required skills, experience level, sector, role type
+- `cover_letter.tex`: opening structure, body structure, bullet style, closing, recurring phrases
+- `cv_draft.tex`: profile statement, section ordering, framing for this role type
+- `outcome.md`: status (hired/rejected/no_response/interview_only), interview stages, notes
+
+After reading, proceed to Step A4 without intermediate output. The user sees a complete picture in Step A6.
+
+### Step A4: Cross-Reference Check
+
+Before mapping anything to skill files, check for inconsistencies:
+
+- Date mismatches between CV / LinkedIn / diploma
+- Title mismatches across documents for the same role
+- Education mismatches (degree name, graduation date)
+- Employer name variations
+
+If inconsistencies are found, present them as a numbered list and wait for the user to resolve each one before continuing:
+
+```
+## Cross-Reference Issues Found
+
+These need to be resolved before I continue. For each one, tell me which version is correct.
+
+1. **Role title mismatch - [COMPANY]:**
+   CV says: "[TITLE_A]"
+   LinkedIn says: "[TITLE_B]"
+   Which is correct?
+
+2. ...
+```
+
+If no inconsistencies, state "No cross-reference issues found." and continue.
+
+### Step A5: Build Change Sets
+
+For each skill file, compare extracted document content against the current file content from Step A2. Build two buckets.
+
+**Additive changes:** entirely new content not in the skill file in any form. Examples: a certification not in `01-candidate-profile.md`, a new endorsement skill, a referee not yet listed, a new behavioral quote from a reference letter, a new award.
+
+**Conflicting changes:** content that touches something already in a skill file but disagrees. Examples: a different date range for an existing job, a different job title for the same role, a different graduation date than what is recorded.
+
+**Inference rules** (apply when populating from inferred sources):
+
+- **`02-behavioral-profile.md`:** Source is LinkedIn About + recommendation letters. Extract recurring themes, adjectives, phrases about how the candidate works. Add only to "Strongest Behavioral Traits", "How [Candidate] Works Best", or "Management Style Preferences" sections. Do not overwrite existing scored assessments. Always label inferred additions: *[Inferred from LinkedIn About / Reference letter - review before relying on this]*
+- **`03-writing-style.md`:** Source is `cover_letter.tex` files. Extract recurring patterns. Add as observations under "## Patterns Observed in Past Applications". Do not modify existing rules. Only add if 2+ cover letters show a genuine pattern.
+- **`04-job-evaluation.md`:** Source is `job_posting.md` + `outcome.md` pairs. If an application reached interview or offer: note role type and sector as a confirmed strong-fit signal. If 2+ applications repeat a no-response or rejection pattern: note it. Add findings under "## Calibration from Past Applications". Do not modify the existing scoring framework.
+- **`05-cv-templates.md`:** Source is `cv_draft.tex` files. Extract any profile statement that does not already appear in templates. Label with: *[Used for: <company>_<role>]*
+- **`06-cover-letter-templates.md`:** Source is `cover_letter.tex` files. Extract opening patterns, bullet structures, closing formulations. Add only what is structurally distinct from existing templates.
+- **`07-interview-prep.md`:** Source is CV bullets, LinkedIn descriptions, reference letter quotes. Identify achievements not yet covered by an existing STAR example. Do NOT draft full STAR examples. Add stubs under "## STAR Candidates (Complete Manually)":
+
+```markdown
+### [Achievement title]
+**Source:** [CV / LinkedIn / Reference letter - role/company]
+**What happened:** [one sentence]
+**Why it matters:** [interview question types this could answer]
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+```
+
+### Step A6: Present and Confirm Changes
+
+Present the full change set before writing anything.
+
+**Additive changes** (single grouped list, organized by target file):
+
+```
+## Proposed Additive Changes
+
+### 01-candidate-profile.md
+- [ ] New certification: [title], [issuer], [date] - extracted from LinkedIn
+- [ ] New reference: [name, title, company]
+  Quote: "[relevant quote]"
+
+### 02-behavioral-profile.md
+- [ ] New behavioral observation [labeled as inference]: "[phrase]"
+
+[and so on per file]
+```
+
+Then ask:
+
+> **Apply all additive changes?** These add new content without touching anything already in the files.
+> Reply **yes** to apply all, or list the numbers you want to skip.
+
+Wait for the response. Apply only the confirmed items.
+
+**Conflicting changes** (one at a time):
+
+```
+## Conflict 1 of [N]: Job title - [COMPANY]
+
+**Current in 01-candidate-profile.md:**
+[TITLE_A] - [COMPANY] ([START]-[END])
+
+**Proposed (from LinkedIn export):**
+[TITLE_B] - [COMPANY] ([START]-[END])
+
+Options:
+  [keep] Keep the existing text
+  [replace] Replace with the version from the document
+  [manual] I'll edit this myself - skip for now
+```
+
+Wait for the user's choice on each conflict. If no conflicts, state "No conflicting changes found." and skip this section.
+
+### Step A7: Write Confirmed Changes and Fill Gaps
+
+Apply the confirmed changes with the Edit tool. Make targeted edits only. Do not rewrite entire files. State which changes were applied per file. If a file has no confirmed changes, state "No changes made to [filename]."
+
+Documents cover skills, experience, education, references, and behavioral signal. They do not cover everything `/apply` and `/scrape` need. After the writes, ask follow-up questions for gaps:
+
+- Career goals and target role types
+- What excites the user in their next role
+- Deal-breakers and must-haves
+- Salary expectations / baseline (optional)
+- Commute or location constraints (if not visible from CV)
+- Job search configuration (use the questions from Path C Section 9 below)
+
+Then proceed to Step 3 to populate the non-skill files (`CLAUDE.md`, `cv/main_example.tex`, `.claude/skills/job-scraper/search-queries.md`). Step 3 will detect that the seven skill files are already populated and skip those substeps.
+
+---
+
+## Path B: Single CV Import
+
+If the user provides a single CV/resume:
+
+1. Read the document thoroughly.
+2. Extract all structured information: name, contact, education, experience, skills, publications, awards.
+3. Present a summary of what was extracted.
+4. Ask follow-up questions for gaps (behavioral profile, career goals, deal-breakers, salary expectations, references).
+5. Proceed to Step 3 (file generation).
+
+---
+
+## Path C: Interview Mode
+
+Walk through each section conversationally. Ask questions naturally, not as a form. Let the user answer in their own words and you'll structure the data.
+
+### Section 1: Identity & Contact
+Ask about:
+- Full name
+- Location (city, country)
+- Phone, email, LinkedIn, GitHub
+- Languages spoken (with proficiency levels)
+- Current employment status
+- Family/commute constraints (if any)
+
+### Section 2: Education
+For each degree:
+- Level (PhD, MSc, BSc, etc.), field, institution, years
+- Thesis topic (if applicable)
+- Key coursework or topics
+
+Also ask about certifications (online courses, professional certs).
+
+### Section 3: Professional Experience
+For each role (most recent first):
+- Job title, company, dates, location
+- Key responsibilities (3-5 bullets)
+- Key achievements or projects
+- Technologies/tools used
+
+Also ask about independent projects, freelance work, or side projects.
+
+### Section 4: Technical Skills
+- Programming languages + proficiency level
+- ML/AI frameworks and tools
+- Domain expertise
+- Software tools and platforms
+- Any other technical skills
+
+### Section 5: Publications & Awards (optional)
+- Peer-reviewed papers, conference presentations
+- Hackathons, competitions, awards
+- Skip if not applicable
+
+### Section 6: Behavioral Profile (optional)
+If they have a formal assessment (PI, DISC, Myers-Briggs, StrengthsFinder):
+- Ask them to describe or share the results
+
+If not, ask behavioral questions:
+- "What work environments do you thrive in?"
+- "What drains your energy at work?"
+- "How do you prefer to work in teams?"
+- "How do you make decisions, quickly or deliberately?"
+- "What's your communication style?"
+- Synthesize answers into a behavioral profile
+
+### Section 7: Career Goals & Preferences
+- Target roles and industries
+- What excites you in work
+- Deal-breakers and must-haves
+- Salary expectations/baseline (optional)
+- What environments to avoid
+- Commute/location constraints
+
+### Section 8: References (optional)
+For each reference:
+- Name, title, company, email, phone
+- Relationship to the user
+
+### Section 9: Job Search Configuration
+This section generates the search queries that power `/scrape`. Use the information from Sections 1, 4, and 7 to build targeted queries.
+
+Ask about:
+- **Role titles to search for:** "What job titles should I search for? For example: Data Scientist, ML Engineer, Geophysicist." Collect 3-8 specific titles.
+- **Key skills as search terms:** "Which of your skills are most likely to appear in job postings?" Pick 3-5 that are distinctive and searchable.
+- **Target companies (optional):** "Are there specific companies you'd like to monitor for openings?"
+- **Geographic scope:** "Which cities or regions should I search in? How far are you willing to commute?" Use this to define the location filter tiers (ideal, acceptable, borderline, too far).
+- **Job portals:** "The framework includes tools for Danish job portals (Jobindex, Jobbank, Jobdanmark, Jobnet). Are these the right ones for you, or do you use other sites?" Note: if the user is outside Denmark, acknowledge that the built-in CLI tools are Denmark-specific and suggest they can add their own portal integrations or rely on LinkedIn/Google site-searches.
+
+**Important:** Also suggest role types the user may not have considered, based on their skill profile. For example:
+- If they have strong Python + domain expertise: "Have you considered roles like 'Technical Consultant' or 'Solutions Engineer' in your domain?"
+- If they have ML + a specific industry: "Companies in adjacent industries also hire for these skills. Should I include searches for [adjacent sector]?"
+- If they have project management experience alongside technical skills: "Would you also want to search for 'Technical Project Manager' or 'Team Lead' roles?"
+
+This proactive suggestion step helps users discover career paths they might not have considered.
+
+---
+
+## Step 3: Generate Profile Files
+
+Once data collection is complete, generate or finish populating the following files. **For Path A**, the seven skill files are already populated by Step A7; check each before writing and skip if its content is no longer placeholder text.
+
+### 1. Update `CLAUDE.md`
+Replace all `[PLACEHOLDER]` tokens with the user's actual information. Keep the structure, workflow, and verification checklist intact.
+
+### 2. Populate `01-candidate-profile.md` *(Path B and C; skip if Path A populated it)*
+Write the full candidate profile with structured sections: Identity, Education, Professional Experience, Independent Projects, Technical Skills, Publications, Awards, References.
+
+### 3. Populate `02-behavioral-profile.md` *(Path B and C; skip if Path A populated it)*
+Write the behavioral profile based on assessment results or synthesized answers.
+
+### 4. Update `04-job-evaluation.md` *(Path B and C; skip if Path A populated it)*
+Replace skill match areas with the user's actual skills:
+- Strong match areas: [their primary skills]
+- Moderate match areas: [their secondary skills]
+- Weak match areas: [skills they lack]
+
+Update career goals and motivation filters with their actual preferences.
+
+### 5. Update `05-cv-templates.md` *(Path B and C; skip if Path A populated it)*
+Add role-specific profile statement templates based on their background.
+
+### 6. Update `07-interview-prep.md` *(Path B and C; skip if Path A populated it)*
+Create STAR examples from their actual experience (at least 3-4 examples). Path A leaves STAR stubs under "## STAR Candidates (Complete Manually)" rather than full examples; if any stubs are present, mention them in Step 4 so the user knows to flesh them out.
+
+### 7. Update `cv/main_example.tex`
+Replace placeholder personal data with their actual name, contact info, and add their education and most recent experience entries.
+
+### 8. Generate `.claude/skills/job-scraper/search-queries.md`
+Replace all placeholder tokens in the search queries file with the user's actual information from Section 9 (or the equivalent follow-up questions in Path A's Step A7):
+- Replace `[YOUR_PRIMARY_ROLE_TYPE]`, `[YOUR_PRIMARY_JOB_TITLE]`, etc. with actual role titles
+- Replace `[YOUR_KEY_SKILL]`, `[YOUR_DOMAIN_KEYWORD_1]`, etc. with actual skills and domain terms
+- Replace `[YOUR_CITY]`, `[YOUR_COUNTRY]`, `[YOUR_REGION]` with actual location
+- Fill in the location filter tiers (ideal, acceptable, borderline, too far) based on commute constraints
+- Organize queries into priority categories matching the user's career direction:
+  - Priority 1: Their strongest/most desired role direction
+  - Priority 2: Their domain expertise
+  - Priority 3: Adjacent roles they could pivot into
+  - Priority 4: Broader roles (wider net)
+
+---
+
+## Step 4: Confirm & Next Steps
+
+Present a summary:
+
+> **Setup complete!** Here's what was generated:
+>
+> - `CLAUDE.md` - Your full candidate profile
+> - `.claude/skills/job-application-assistant/01-candidate-profile.md` - Structured profile
+> - `.claude/skills/job-application-assistant/02-behavioral-profile.md` - Behavioral assessment
+> - `.claude/skills/job-application-assistant/04-job-evaluation.md` - Personalized evaluation framework
+> - `.claude/skills/job-application-assistant/05-cv-templates.md` - CV templates with your profile statements
+> - `.claude/skills/job-application-assistant/07-interview-prep.md` - STAR examples from your experience
+> - `cv/main_example.tex` - Your LaTeX CV template
+> - `.claude/skills/job-scraper/search-queries.md` - Job search queries for `/scrape`
+>
+> **Try it out:**
+> - Run `/scrape` to search for matching jobs right now
+> - Run `/apply` with a job posting URL to see the full application workflow
+> - Run `/setup --section search` later to update your search queries as your priorities evolve
+
+If Path A left any STAR stubs in `07-interview-prep.md`, also note:
+
+> Path A flagged [N] STAR candidate stubs in `07-interview-prep.md` that need your situation/task/action/result details before you use them in interviews.
+
+---
+
+## Design Principles
+
+- Three onboarding paths converge on the same skill files. Step 0 picks the right path based on what's in `documents/`. Steps 3 and 4 are shared.
+- Path A is read-before-write and idempotent. Re-running it as documents are added does not duplicate or overwrite existing content; conflicts are surfaced for explicit resolution.
+- Path A labels inferred behavioral or style additions so the user can review them critically before relying on them.
+- Each section in Path C is a natural conversation, not a form. The user can skip optional sections.
+- Synthesize answers into structured formats (the user does not need to know markdown or LaTeX).
+- Can be re-run with `--section <name>` to update specific sections (e.g., `/setup --section search` to reconfigure job search queries without re-doing the full profile).
+- Section 9 (search) in Path C, and the equivalent follow-up questions in Path A, proactively suggest role types the user may not have considered.
+- At the end, suggest running `/scrape` and `/apply` with a test job posting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# AI Job Search — OpenCode Agent Instructions
+
+<!-- SETUP: This file is populated by running /setup -->
+<!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
+
+## Role
+This repo is a job application workspace. The AI acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
+2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
+3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
+4. **Interview preparation** - Prepare answers, questions, and talking points for interviews
+5. **Career strategy** - Advise on positioning and personal branding
+
+## Candidate Profile
+
+<!-- This section is auto-populated by /setup. You can also fill it in manually. -->
+
+### Identity
+- **Name:** [YOUR_NAME]
+- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
+- **Languages:** [YOUR_LANGUAGES]
+- **Status:** [YOUR_EMPLOYMENT_STATUS]
+- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+
+### Education
+<!-- List your degrees, most recent first -->
+- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
+  - Thesis: "[THESIS_TITLE]"
+  - Topics: [KEY_TOPICS]
+
+### Professional Experience
+<!-- List your roles, most recent first -->
+- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
+  - [KEY_RESPONSIBILITY_1]
+  - [KEY_RESPONSIBILITY_2]
+  - [KEY_ACHIEVEMENT]
+
+### Technical Skills
+- **Primary:** [YOUR_PRIMARY_SKILLS]
+- **Secondary:** [YOUR_SECONDARY_SKILLS]
+- **Domain:** [YOUR_DOMAIN_EXPERTISE]
+- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+
+### Certifications
+<!-- List relevant certifications with dates -->
+- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+
+### Publications
+<!-- List peer-reviewed publications, if any -->
+- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+
+### Awards
+<!-- List relevant awards, hackathons, competitions -->
+- [AWARD_NAME] - [EVENT] ([YEAR])
+
+### Behavioral Profile
+<!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
+- **[TRAIT_1]** - [DESCRIPTION]
+- **[TRAIT_2]** - [DESCRIPTION]
+- **Strengths:** [YOUR_STRENGTHS]
+- **Growth areas:** [YOUR_GROWTH_AREAS]
+- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+
+### What Excites You
+<!-- What motivates you professionally -->
+- [PASSION_1]
+- [PASSION_2]
+
+### Target Sectors
+<!-- Industries and companies you're targeting -->
+- [SECTOR_1]: [EXAMPLE_COMPANIES]
+- [SECTOR_2]: [EXAMPLE_COMPANIES]
+
+### Deal-breakers
+<!-- Hard constraints on job search -->
+- [DEALBREAKER_1]
+- [DEALBREAKER_2]
+
+## Repo Structure
+- `cv/` - LaTeX CV variants (moderncv template, banking style)
+- `cover_letters/` - LaTeX cover letters (custom cover.cls template)
+- `.claude/skills/` - AI skill definitions for the application workflow (auto-discovered by opencode)
+- `.agents/skills/` - Job search CLI tools (auto-discovered by opencode)
+
+## Workflow for New Job Applications
+1. User provides a job posting (URL or text)
+2. **Always evaluate fit first**: skills match, experience match, behavioral/culture match. Present this assessment to the user before proceeding.
+3. If good fit: create targeted CV (`cv/main_<company>.tex`) and cover letter (`cover_letters/cover_<company>_<role>.tex`)
+4. **Verify both documents** (see Verification Checklist below)
+5. Prepare interview talking points based on the role requirements and your strengths
+
+**Important:** When mentioning agentic coding or AI tooling in CVs/cover letters, explicitly reference **Claude Code** by name.
+
+## Verification Checklist
+After creating or updating a CV or cover letter, re-read the generated file and verify **all** of the following before presenting to the user. Report the results as a pass/fail checklist.
+
+### Factual accuracy
+- [ ] All claims match actual profile (CLAUDE.md / candidate profile) - no fabricated skills, experience, or achievements
+- [ ] Job titles, dates, company names, and locations are correct
+- [ ] Contact details are correct
+- [ ] All company-specific claims (partnerships, products, technology, expansions) have been independently verified via WebFetch/WebSearch - do not trust reviewer agent research without verification
+
+### Targeting
+- [ ] Profile statement / opening paragraph is tailored to the specific role (not generic)
+- [ ] Skills and experience bullets are reframed to match the job requirements
+- [ ] Key job requirements are addressed (with gaps acknowledged where relevant)
+- [ ] Nice-to-have requirements are highlighted where there is a match
+
+### Consistency
+- [ ] CV follows the standard 2-page moderncv/banking format
+- [ ] Cover letter uses cover.cls template and established structure
+- [ ] Tone is consistent across CV and cover letter
+- [ ] No contradictions between CV and cover letter content
+
+### Quality
+- [ ] No LaTeX syntax errors (balanced braces, correct commands)
+- [ ] No spelling or grammar errors
+- [ ] Agentic coding / AI tooling references mention **Claude Code** by name
+- [ ] Cover letter is addressed to the correct person (or "Dear Hiring Manager" if unknown)
+- [ ] Cover letter fits approximately one page
+
+### Compiled PDF verification (MANDATORY - never skip)
+Both documents MUST be compiled and visually inspected via the Read tool on the PDF output. "Looks fine in the .tex" is not acceptable - LaTeX page-break decisions are unpredictable. Iterate until these all pass:
+- [ ] CV compiled with **lualatex** (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors). Cover letter compiled with **xelatex** (cover.cls requires fontspec).
+- [ ] **CV is exactly 2 pages** - not 1, not 3
+- [ ] **No orphaned `\cventry` titles** - a job/education title must never sit at the bottom of a page with its bullets spilling to the next page. Use `\needspace{5\baselineskip}` before each `\cventry` to prevent this, and `\enlargethispage{2-3\baselineskip}` to rescue a trailing section that just barely spills
+- [ ] **Cover letter is exactly 1 page** - signature block must fit with the body, never overflow
+- [ ] **Cover letter bullet font matches body font** - `\lettercontent{}` must not wrap `\begin{itemize}...\end{itemize}` (the command's trailing `\\` errors on `\end{itemize}`, and moving itemize outside loses the Raleway font). Standard pattern: close `\lettercontent{}`, then wrap the list in `{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont \begin{itemize}...\end{itemize}\par}`
+
+## Available Commands & Skills
+
+### Core Workflow Commands
+- `/apply` — Full application workflow (evaluate fit → draft CV + cover letter → review → compile PDFs)
+- `/setup` — Profile onboarding (documents folder, CV import, or interview mode)
+- `/expand` — Competency expansion from documents and online presence
+- `/reset` — Reset candidate profile data or documents folder
+- `/add-template` — Register custom LaTeX CV or cover letter template
+- `/add-portal` — Generate a job-portal search skill for your local market
+
+### Job Search Skills (Auto-discovered)
+- `/scrape` — Search Danish job portals for matching positions (job-scraper skill)
+- `/upskill` — Skill gap analysis and learning plan from tracked jobs (upskill skill)
+- `/job-application-assistant` — Evaluate job postings, tailor CVs, write cover letters, interview prep
+
+### Job Portal CLI Tools (Auto-discovered)
+- `jobbank-search` — Akademikernes Jobbank (Denmark)
+- `jobdanmark-search` — Jobdanmark.dk (Denmark)
+- `jobindex-search` — Jobindex.dk (Denmark)
+- `jobnet-search` — Jobnet.dk (Denmark, government portal)
+- `linkedin-search` — LinkedIn public job listings (country-agnostic, zero runtime deps)
+
+### Usage Examples
+```bash
+# Search for jobs
+/scrape
+/scrape data science
+
+# Apply to a job
+/apply https://jobindex.dk/job/1234567
+
+# Update search queries
+/setup --section search
+
+# Analyze skill gaps
+/upskill
+/upskill https://jobindex.dk/job/1234567
+
+# Register custom template
+/add-template
+
+# Generate new portal skill
+/add-portal
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # AI Job Search
 
-An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
+An AI-powered job application framework built for [Claude Code](https://claude.com/claude-code) and [opencode](https://github.com/opencode-ai/opencode). Fork it, fill in your profile, and let AI evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
 <p align="center">
   <a href="https://ko-fi.com/madslorentzen">
@@ -14,7 +14,7 @@ An AI-powered job application framework built on [Claude Code](https://claude.co
 
 ## What this is
 
-A structured workflow that turns Claude Code into a full-stack job application assistant. The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
+A structured workflow that turns an AI coding agent into a full-stack job application assistant. Works with both [Claude Code](https://claude.com/claude-code) and [opencode](https://github.com/opencode-ai/opencode). The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
 
 ```
 /setup          /scrape              /apply <url>
@@ -36,7 +36,7 @@ The framework encodes career guidance best practices, including structured evalu
 
 ## Prerequisites
 
-- [Claude Code](https://claude.com/claude-code) (CLI)
+- [Claude Code](https://claude.com/claude-code) or [opencode](https://github.com/opencode-ai/opencode) (CLI)
 - Python 3.10+
 - [Bun](https://bun.sh) (for Danish job search CLI tools)
 - LaTeX distribution with `lualatex` and `xelatex`: [TeX Live](https://tug.org/texlive/) or [MiKTeX](https://miktex.org/). The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors); the cover letter compiles with `xelatex` because `cover.cls` requires `fontspec`.
@@ -69,6 +69,18 @@ claude
 # Then inside Claude Code:
 /setup
 ```
+
+#### Alternative: opencode
+
+If you use [opencode](https://github.com/opencode-ai/opencode) instead of Claude Code:
+
+```bash
+opencode
+# Then inside opencode:
+/setup
+```
+
+The project auto-detects opencode's AGENTS.md format and the `.opencode/command/` command files. All workflows (`/setup`, `/scrape`, `/apply`) work identically.
 
 `/setup` offers three paths: read your `documents/` folder if you have one populated (CV PDF, LinkedIn export, diplomas, reference letters, past applications), import a single CV pasted in chat, or walk through an interview. It auto-detects what you have and asks. Documents-folder mode is idempotent and safe to re-run as you add more material; see `documents/README.md` for the layout.
 
@@ -110,6 +122,15 @@ This runs the full workflow: evaluate fit, draft CV + cover letter, review with 
 ```
 ai-job-search/
 ├── CLAUDE.md                          # Main candidate profile + workflow rules
+├── AGENTS.md                          # opencode project instructions (equivalent to CLAUDE.md)
+├── .opencode/
+│   └── command/                       # opencode command definitions
+│       ├── apply.md                   # /apply workflow (drafter-reviewer)
+│       ├── setup.md                   # /setup onboarding
+│       ├── expand.md                  # /expand competency enrichment
+│       ├── add-template.md            # /add-template register custom LaTeX templates
+│       ├── add-portal.md              # /add-portal generate job-portal skill
+│       └── reset.md                   # /reset wipe profile data
 ├── .claude/
 │   ├── commands/
 │   │   ├── apply.md                   # /apply workflow (drafter-reviewer)
@@ -276,7 +297,7 @@ To get the most from this, invest time during `/setup` in describing not just yo
 ## Acknowledgements
 
 - [Mikkel Krogholm](https://github.com/mikkelkrogsholm) ([skills repo](https://github.com/mikkelkrogsholm/skills)) for the job search CLI skills
-- Built with [Claude Code](https://claude.com/claude-code) by [Anthropic](https://anthropic.com)
+- Built with [Claude Code](https://claude.com/claude-code) by [Anthropic](https://anthropic.com) and [opencode](https://github.com/opencode-ai/opencode)
 
 ## License
 


### PR DESCRIPTION
This PR adds compatibility with [opencode](https://github.com/opencode-ai/opencode), an open-source AI coding agent, alongside the existing Claude Code setup. All workflows (`/setup`, `/scrape`, `/apply`) work identically in both tools with zero changes to the existing codebase.

### What's included

**AGENTS.md** (new) — The opencode equivalent of CLAUDE.md, containing:
- Candidate profile structure (identity, education, experience, skills, behavioral profile)
- Job application workflow with drafter-reviewer pattern
- Comprehensive verification checklist for CVs and cover letters
- Available commands reference

**.opencode/command/ × 6** (new) — OpenCode command definitions:
| File | Description |
|------|-------------|
| `apply.md` | Full drafter-reviewer job application workflow |
| `setup.md` | Profile onboarding with 3 paths (documents, CV import, interview) |
| `expand.md` | Competency enrichment from documents and online presence |
| `reset.md` | Profile data and documents folder reset |
| `add-template.md` | Custom LaTeX template registration |
| `add-portal.md` | Job-portal search skill generation |

**README.md** — Updated to reflect opencode as a first-class alternative:
- Title/lead mentions both Claude Code and opencode
- "What this is" describes both tools
- Prerequisites list opencode as alternative CLI
- Quick start includes "Alternative: opencode" section
- File tree includes AGENTS.md and `.opencode/command/`
- Acknowledgements updated

**.gitignore** — Added `.sisyphus/` for opencode planning artifacts

### Design decisions

- **Zero changes to existing files** — The `.claude/commands/`, `.claude/skills/`, and `.agents/skills/` directories are auto-discovered by both tools and work as-is
- **AGENTS.md mirrors CLAUDE.md** — Same structure, same workflow, same verification rules. No duplication of maintenance burden
- **Commands are documentation, not hooks** — OpenCode reads `.opencode/command/*.md` as AI-readable instructions when commands are invoked, similar to how `.claude/commands/*.md` work in Claude Code

### Commits

1. `feat: add opencode conversion files — commands, AGENTS.md, gitignore`
2. `docs: add opencode compatibility information to README`
3. `fix: remove duplicated text in apply.md cleanup section`