### PR TITLE
docs: clarify Anthropic affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 <p align="center">
-  <img src="claude_animation.gif" alt="Claude Job Search Assistant" width="200">
+  <img src="claude_animation.gif" alt="AI Job Search Assistant" width="200">
 </p>
 
 # AI Job Search
 
 An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
+
+> Note: This is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic. Anthropic and Claude Code are referenced only to describe the toolchain this workflow uses.
 
 <p align="center">
   <a href="https://ko-fi.com/madslorentzen">


### PR DESCRIPTION
Addresses #48.

## Summary
- Adds a short README disclaimer that this is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic.
- Updates the top image alt text from "Claude Job Search Assistant" to "AI Job Search Assistant" so the README does not imply an official Claude mascot.

## Notes
This is a narrow documentation clarification. It is not legal advice and does not claim to resolve every possible trademark or branding concern.

## Verification
- git diff --check
- rg -n "not affiliated|endorsed|sponsored|maintained" README.md