### PR TITLE
fix(linkedin-search): decode hex HTML entities in CLI output

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -67,6 +67,15 @@ export interface JobDetail extends JobCard {
   applyUrl: string | null
 }
 
+/**
+ * Convert a Unicode code point to a string. Uses `fromCodePoint` (not
+ * `fromCharCode`) so supplementary-plane code points (e.g. emoji, U+1F600)
+ * decode correctly, and drops out-of-range values instead of throwing.
+ */
+function numericEntity(cp: number): string {
+  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
+}
+
 function decodeHtmlEntities(text: string): string {
   return text
     .replace(/&amp;/g, "&")
@@ -75,7 +84,9 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    // Numeric character references: decimal (&#233;) and hexadecimal (&#xE9;).
+    .replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
     .replace(/&nbsp;/g, " ")
 }
 

--- a/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import { parseJobCards, parseJobDetail } from "../src/helpers";
+
+// Minimal search-card markup: parseJobCards splits on the job-posting URN and
+// needs an id, a base-search-card__title, and a full-link. Everything else is
+// optional. We inject HTML entities into the title/company to exercise decoding.
+function searchCard(id: string, title: string, company = "Acme"): string {
+  return `<li>
+    <div data-entity-urn="urn:li:jobPosting:${id}">
+      <a class="base-card__full-link" href="https://www.linkedin.com/jobs/view/${id}"></a>
+      <h3 class="base-search-card__title">${title}</h3>
+      <h4 class="base-search-card__subtitle"><a href="https://www.linkedin.com/company/acme">${company}</a></h4>
+    </div>
+  </li>`;
+}
+
+describe("decodeHtmlEntities (via parseJobCards)", () => {
+  test("decodes hexadecimal numeric entities (&#xE9;)", () => {
+    const [card] = parseJobCards(searchCard("123", "Caf&#xE9; Manager"));
+    expect(card.title).toBe("Café Manager");
+  });
+
+  test("decodes uppercase-X hexadecimal entities (&#X...;)", () => {
+    const [card] = parseJobCards(searchCard("124", "Deb&#XFC;t Role")); // &#XFC; = ü
+    expect(card.title).toBe("Debüt Role");
+  });
+
+  test("still decodes decimal numeric entities (&#233;) — regression", () => {
+    const [card] = parseJobCards(searchCard("125", "Caf&#233; Lead"));
+    expect(card.title).toBe("Café Lead");
+  });
+
+  test("decodes supplementary-plane code points with fromCodePoint (&#128512;)", () => {
+    const [card] = parseJobCards(searchCard("126", "Growth &#128512;"));
+    expect(card.title).toBe("Growth 😀");
+  });
+
+  test("decodes hex supplementary-plane code points (&#x1F600;)", () => {
+    const [card] = parseJobCards(searchCard("127", "Growth &#x1F600;"));
+    expect(card.title).toBe("Growth 😀");
+  });
+
+  test("decodes hex entities in the company subtitle too", () => {
+    const [card] = parseJobCards(searchCard("128", "Engineer", "N&#xF8;rrebro ApS"));
+    expect(card.company).toBe("Nørrebro ApS");
+  });
+});
+
+describe("decodeHtmlEntities (via parseJobDetail)", () => {
+  test("decodes hex entities inside the job title", () => {
+    const html = `<h1 class="topcard__title">Se&#xF1;or Engineer</h1>`;
+    const job = parseJobDetail(html, "999");
+    expect(job.title).toBe("Señor Engineer");
+  });
+});


### PR DESCRIPTION
## Problem

`decodeHtmlEntities` in `linkedin-search/cli/src/helpers.ts` decodes **decimal** numeric character references (`&#233;`) but not the **hexadecimal** form (`&#xE9;`), which is equally valid HTML. Hex-encoded entities fall through undecoded and surface as raw text (`Caf&#xE9; Manager`) in job titles, company names, locations, and descriptions — exactly the fields a user reads.

It also uses `String.fromCharCode`, which truncates to 16 bits and therefore **corrupts supplementary-plane code points** (e.g. emoji, `&#128512;` → U+1F600). `String.fromCodePoint` is the correct API.

This matters for a tool whose stated scope is "any country/region": accented characters (`é`, `ø`, `ü`, `ñ`, `å`) are frequently delivered as numeric entities. The same decoder pattern also exists in `jobindex-search` — see the follow-up note below.

## Fix

- Route both decimal and hex numeric entities through a small `numericEntity(cp)` helper that uses `String.fromCodePoint` with a `0…0x10FFFF` range guard.
- Add a hexadecimal rule (`&#[xX]…;`) next to the existing decimal one.
- No new imports, no behavior change for existing decimal/BMP input, no dependency added (the package stays zero-dependency).

```ts
function numericEntity(cp: number): string {
  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
}
// ...
.replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
.replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
```

## Tests

Adds `tests/parsing.test.ts` — network-free unit tests that exercise the decoder through the exported `parseJobCards` / `parseJobDetail` (the decoder itself is private, so the public contract is tested): hex, uppercase-`X` hex, decimal (regression), decimal + hex astral code points, company subtitle, and the detail-page title path.

## Evidence (before / after)

I verified the exact decoder transformation against a Node harness reproducing the old and new `replace` chains on identical inputs:

| Input | Before | After | Expected |
|---|---|---|---|
| `Caf&#xE9; Manager` | `Caf&#xE9; Manager` ❌ | `Café Manager` ✅ | `Café Manager` |
| `Deb&#XFC;t Role` | `Deb&#XFC;t Role` ❌ | `Debüt Role` ✅ | `Debüt Role` |
| `Caf&#233; Lead` | `Café Lead` ✅ | `Café Lead` ✅ | `Café Lead` |
| `Growth &#128512;` | `Growth ` (corrupted) ❌ | `Growth 😀` ✅ | `Growth 😀` |
| `Growth &#x1F600;` | `Growth &#x1F600;` ❌ | `Growth 😀` ✅ | `Growth 😀` |
| `N&#xF8;rrebro ApS` | `N&#xF8;rrebro ApS` ❌ | `Nørrebro ApS` ✅ | `Nørrebro ApS` |

**Before: 1/6 · After: 6/6.** The included `bun test` suite asserts the same cases (I don't have `bun` locally, so CI / a local `bun test` in `.agents/skills/linkedin-search/cli` is the authoritative run).

## Scope

One decoder, one concern (numeric entities). Named entities (e.g. `&aelig;`) are intentionally out of scope. The identical pattern in `jobindex-search` (`cli/src/helpers.ts` and `cli/src/commands/detail.ts`) is left for a **separate follow-up PR** to keep this change focused.