### PR TITLE
fix(jobindex-search): decode hex HTML entities in CLI output

### DIFF
--- a/.agents/skills/jobindex-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobindex-search/cli/src/commands/detail.ts
@@ -20,6 +20,15 @@ interface DetailResult {
 }
 
 /**
+ * Convert a Unicode code point to a string. Uses `fromCodePoint` (not
+ * `fromCharCode`) so supplementary-plane code points (e.g. emoji, U+1F600)
+ * decode correctly, and drops out-of-range values instead of throwing.
+ */
+function numericEntity(cp: number): string {
+  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
+}
+
+/**
  * Decode HTML entities in text
  */
 function decodeHtmlEntities(text: string): string {
@@ -30,7 +39,9 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    // Numeric character references: decimal (&#233;) and hexadecimal (&#xE9;).
+    .replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
     .replace(/&nbsp;/g, " ")
 }
 

--- a/.agents/skills/jobindex-search/cli/src/helpers.ts
+++ b/.agents/skills/jobindex-search/cli/src/helpers.ts
@@ -181,6 +181,15 @@ export function parseSearchPage(html: string): SearchPageResult {
 }
 
 /**
+ * Convert a Unicode code point to a string. Uses `fromCodePoint` (not
+ * `fromCharCode`) so supplementary-plane code points (e.g. emoji, U+1F600)
+ * decode correctly, and drops out-of-range values instead of throwing.
+ */
+function numericEntity(cp: number): string {
+  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
+}
+
+/**
  * Decode HTML entities in text
  */
 function decodeHtmlEntities(text: string): string {
@@ -191,7 +200,9 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&apos;/g, "'")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    // Numeric character references: decimal (&#233;) and hexadecimal (&#xE9;).
+    .replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
     .replace(/&nbsp;/g, " ")
 }
 

--- a/.agents/skills/jobindex-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/parsing.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { parseJobCards } from "../src/helpers";
+
+// Minimal jobad-wrapper markup: parseJobCards splits on `jobad-wrapper-<id>`
+// and reads the title from the <h4><a href>…</a></h4> and the company from the
+// jix-toolbar-top__company link. We inject HTML entities to exercise decoding.
+function card(id: string, title: string, company = "Acme A/S"): string {
+  return `<div id="jobad-wrapper-${id}" class="PaidJob">
+    <h4><a href="https://www.jobindex.dk/jobannonce/${id}">${title}</a></h4>
+    <div class="jix-toolbar-top__company">
+      <a href="https://www.jobindex.dk/virksomhed/acme">${company}</a>
+    </div>
+  </div>`;
+}
+
+describe("decodeHtmlEntities (via parseJobCards)", () => {
+  test("decodes hexadecimal numeric entities (&#xF8; -> ø)", () => {
+    const [c] = parseJobCards(card("h1", "Sm&#xF8;rrebro Chef"));
+    expect(c.title).toBe("Smørrebro Chef");
+  });
+
+  test("decodes uppercase-X hexadecimal entities (&#XE6; -> æ)", () => {
+    const [c] = parseJobCards(card("h2", "K&#XE6;re Kollega"));
+    expect(c.title).toBe("Kære Kollega");
+  });
+
+  test("still decodes decimal numeric entities (&#229; -> å) — regression", () => {
+    const [c] = parseJobCards(card("h3", "&#229;rhus Lead"));
+    expect(c.title).toBe("århus Lead");
+  });
+
+  test("decodes supplementary-plane code points with fromCodePoint (&#128512;)", () => {
+    const [c] = parseJobCards(card("h4", "Growth &#128512;"));
+    expect(c.title).toBe("Growth 😀");
+  });
+
+  test("decodes hex supplementary-plane code points (&#x1F600;)", () => {
+    const [c] = parseJobCards(card("h5", "Growth &#x1F600;"));
+    expect(c.title).toBe("Growth 😀");
+  });
+
+  test("decodes hex entities in the company name too", () => {
+    const [c] = parseJobCards(card("h6", "Engineer", "N&#xF8;rrebro ApS"));
+    expect(c.company).toBe("Nørrebro ApS");
+  });
+});


### PR DESCRIPTION
## Problem

`decodeHtmlEntities` in `jobindex-search` — duplicated in `cli/src/helpers.ts` and `cli/src/commands/detail.ts` — decodes **decimal** numeric character references (`&#233;`) but not the **hexadecimal** form (`&#xE9;`), which is equally valid HTML. Hex-encoded entities fall through undecoded and surface as raw text (`Sm&#xF8;rrebro Chef`) in the titles, company names, locations and descriptions the user reads.

This is especially relevant for a **Danish** portal: `æ` `ø` `å` are frequently delivered as numeric entities, and their hexadecimal forms (`&#xE6;` `&#xF8;` `&#xE5;`) currently render broken.

It also uses `String.fromCharCode`, which truncates to 16 bits and therefore **corrupts supplementary-plane code points** (e.g. emoji, `&#128512;` → U+1F600). `String.fromCodePoint` is the correct API.

This is the same defect fixed for `linkedin-search` in #55; this PR applies the identical fix to `jobindex-search` as the promised follow-up.

## Fix

- Route both decimal and hex numeric entities through a small `numericEntity(cp)` helper that uses `String.fromCodePoint` with a `0…0x10FFFF` range guard.
- Add a hexadecimal rule (`&#[xX]…;`) next to the existing decimal one.
- Applied to **both** copies of `decodeHtmlEntities` (the file layout keeps them duplicated per portal-CLI convention). No new imports, no dependency added, no behavior change for existing decimal/BMP input.

## Tests

Adds `tests/parsing.test.ts` — network-free unit tests that exercise the decoder through the exported `parseJobCards` (the decoder is private): hex, uppercase-`X` hex, decimal (regression), decimal + hex astral code points, and the company path. The `parseDetailPage` copy is not exported for a pure unit test, so it is covered by the identical shared fix and the same before/after harness below.

## Evidence (before / after)

Verified the exact decoder transformation through the real `parseJobCards` wrapper/title/company regexes against a Node harness reproducing the old and new `replace` chains on identical inputs:

| Field | Input | Before | After |
|---|---|---|---|
| title | `Sm&#xF8;rrebro Chef` | `Sm&#xF8;rrebro Chef` ❌ | `Smørrebro Chef` ✅ |
| title | `K&#XE6;re Kollega` | `K&#XE6;re Kollega` ❌ | `Kære Kollega` ✅ |
| title | `&#229;rhus Lead` | `århus Lead` ✅ | `århus Lead` ✅ |
| title | `Growth &#128512;` | `Growth ` (corrupted) ❌ | `Growth 😀` ✅ |
| title | `Growth &#x1F600;` | `Growth &#x1F600;` ❌ | `Growth 😀` ✅ |
| company | `N&#xF8;rrebro ApS` | `N&#xF8;rrebro ApS` ❌ | `Nørrebro ApS` ✅ |

**Before: 1/6 · After: 6/6.** The included `bun test` suite asserts the same cases (CI / a local `bun test` in `.agents/skills/jobindex-search/cli` is the authoritative run).

## Scope

Two decoder copies, one concern (numeric entities). Named entities (e.g. `&aelig;`) are intentionally out of scope. Companion to #55.