### PR TITLE
feat: add /interview command for stage-specific interview prep from the application archive

### DIFF
--- a/.claude/commands/interview.md
+++ b/.claude/commands/interview.md
@@ -1,0 +1,107 @@
+# /interview - Prepare for an Interview on a Tracked Application
+
+You are preparing the user for a real, scheduled interview on one of their applications. The frameworks for this already exist - `07-interview-prep.md` (STAR examples, tough questions, questions to ask, roleplay protocol) and the Company Research Checklist in `04-job-evaluation.md` - and the `/outcome` archive records which stage the user is at and what earlier stages surfaced. This command wires them together into a stage-specific prep pack and an optional mock interview.
+
+`/apply` optimizes what the company reads; `/interview` optimizes what the company hears. The bridge between them is consistency: the interviewer has read the submitted CV and cover letter, so everything prepared here must match what those documents claim.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Input
+
+`$ARGUMENTS` may contain a company name (optionally with a role), e.g. `/interview acme`.
+
+- **With an argument:** match against `job_search_tracker.csv` rows (case-insensitive on company, then role). One match → proceed. Several → list and ask. None → this application isn't tracked; suggest `/outcome <company>` to register it first, or accept the posting and role details directly if the user wants to prep anyway.
+- **Without an argument:** list tracker rows whose status suggests a live process (`interview`, `offer`, or recently `applied`) and ask which one. If the tracker is empty, ask for the company, role, and posting.
+
+v1 preps for a **specific application**. Generic no-target practice is out of scope - if asked, prep against a real tracked application instead.
+
+---
+
+## Step 1: Load the Application Context
+
+1. **The archive** (maintained by `/outcome`): `documents/applications/<company>_<role>/`
+   - `job_posting.md` - the exact posting the user applied to
+   - `cv_draft.tex` and `cover_letter.tex` - what was actually submitted. **These are what the interviewer read**; every talking point must be consistent with their claims.
+   - `outcome.md` - the stage reached so far and any recorded feedback from earlier stages. Feedback from stage N is the highest-value input for stage N+1 prep.
+2. **Fallbacks** (the application may predate `/outcome`): posting via WebFetch on the tracker row's `source` URL, or ask the user to paste it; CV via `cv/main_<company>.tex` and cover letter via `cover_letters/cover_<company>_*.tex`. State plainly which context is missing rather than guessing - and suggest `/outcome <company>` to build the archive for next time.
+3. **Ask the user what this interview is** (skip anything `outcome.md` already records): stage (phone screen / technical / case / final round), date, format (phone, video, onsite), and who is interviewing (names and titles, if known).
+4. **Read the frameworks once** - do not re-read them in later steps:
+   - `.claude/skills/job-application-assistant/07-interview-prep.md`
+   - `.claude/skills/job-application-assistant/01-candidate-profile.md`
+   - `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+   - `.claude/skills/job-application-assistant/04-job-evaluation.md`
+
+---
+
+## Step 2: Research the Company (Interview-Focused)
+
+Execute the Company Research Checklist that `04-job-evaluation.md` defines: company website (mission, values, recent news), review sites, LinkedIn (team size, recent hires), and media coverage (growth, restructuring, workplace issues).
+
+Additions for interview purposes:
+
+- **Interviewer angle:** if interviewer names are known (from Step 1 or the tracker's `contact_person`), look up their public professional profile. A hiring manager probes team fit and motivation; a senior engineer probes technical depth; HR probes the CV timeline. Note the likely angle per interviewer - do not speculate beyond public information.
+- **Conversation hooks:** 2-3 recent, verifiable company specifics (a product launch, a stated strategic priority) the user can reference naturally in answers and in the "why this company" moment.
+
+**Verify before using:** every company claim that will appear in the prep pack must be independently confirmed via WebFetch/WebSearch - same rule the repo applies to cover-letter claims. An unverified "fact" delivered confidently in an interview is worse than no fact.
+
+---
+
+## Step 3: Build the Prep Pack
+
+Assemble a stage-appropriate prep document with these sections:
+
+### 1. Likely questions
+Derive from four sources, in priority order:
+1. **Recorded feedback from earlier stages** (`outcome.md`) - anything flagged, doubted, or left unresolved will come back
+2. **The fit evaluation's gaps** - the requirements where the profile is weakest are the likeliest probes. For each, prepare an honest bridge answer per `07`'s "You don't have [X]" pattern: acknowledge, connect adjacent experience, show the learning path. **Never prepare an answer that invents experience.**
+3. **The posting's stated requirements** - competency by competency
+4. **The stage type** - phone screens get motivation and timeline questions; technical rounds get the posting's stack; final rounds get values, salary, and "any reservations" questions
+
+### 2. STAR answer mapping
+Match the ready-made STAR examples in `07-interview-prep.md` to the likely questions using their "Use for" tags. Then:
+- For likely questions **no existing STAR example covers**, draft a new STAR answer grounded strictly in facts from `01-candidate-profile.md` - profile facts arranged into S/T/A/R, not embellished. Include these drafts in the prep pack; offer to append them to `07-interview-prep.md` only if the user explicitly approves.
+- If `/setup` left incomplete STAR stubs relevant to this role, surface them: the user should fill in the details before the interview.
+
+### 3. Consistency brief
+A short list of the specific claims the submitted CV and cover letter make (achievements, numbers, skills emphasized) that the interviewer is most likely to probe. The rule stated plainly: **no claim in the room that isn't on the paper, and every claim on the paper must be defensible in depth.**
+
+### 4. Tough questions, customized
+The relevant entries from `07`'s tough-question list with per-application answers - "Why this company specifically?" must use the verified hooks from Step 2, never a generic line.
+
+### 5. Questions to ask
+Pick 4-6 from `07`'s categories, customized to the research and the stage: role and team questions at screens, tech and growth questions at technical rounds, culture and leadership questions by the final round (that is the last chance to detect a deal-breaker). Cut any question the research already answers publicly - asking it signals you didn't look.
+
+### 6. Logistics
+The phone/video tips from `07` when the format calls for them, plus date and interviewer names as a header.
+
+Save the pack to `documents/applications/<company>_<role>/interview_prep_<stage>.md` (create the folder if this application predates `/outcome`). The folder is gitignored, so the pack stays personal; one file per stage, so earlier packs remain as history. Present the pack in chat as well - the file is the artifact, the conversation is the delivery.
+
+---
+
+## Step 4: Offer a Mock Interview
+
+Ask if the user wants to practice. If yes, run the roleplay **in this conversation** following the Roleplay Guidelines in `07-interview-prep.md` exactly: warm-up first, then role-specific technical questions, 1-2 behavioral questions tied to the posting's competencies, and one tough question or curveball. After each answer, give brief feedback - what worked, what to sharpen, and which STAR example from the pack would have served better.
+
+Calibrate feedback against `02-behavioral-profile.md`: coach toward the user's natural register, not a generic ideal - the same voice-consistency rule the `/apply` reviewer applies to cover letters.
+
+---
+
+## Step 5: Close the Loop
+
+End with:
+
+> Good luck. After the interview, run `/outcome <company>` to log the stage and any feedback - it sharpens the prep for the next round, and once the process resolves it feeds your fit-framework calibration via `/setup`.
+
+If Step 3 drafted new STAR answers the user approved for keeps, remind them those were appended to `07-interview-prep.md` (or offer again if they deferred).
+
+---
+
+## Important Rules
+
+1. **Consistency with the submitted documents.** The interviewer read the archived CV and cover letter; prep must never contradict them or coach claims beyond them.
+2. **Honesty on gaps.** Weak matches get bridge answers (acknowledge → adjacent experience → learning path), never invented experience. Same rule as everywhere else in this repo.
+3. **Verified research only.** Company specifics go in the pack only after independent confirmation. Interviewer notes stick to public professional information.
+4. **Stage-appropriate prep.** A phone screen pack and a final-round pack are different documents; recorded feedback from earlier stages takes priority over generic question lists.
+5. **Write only to the application archive.** The prep pack lands in `documents/applications/<company>_<role>/`; framework and profile files are never edited, except appending user-approved STAR examples to `07-interview-prep.md` on explicit request.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -113,6 +113,10 @@ Summarize what was recorded:
 >
 > [Calibration suggestion from Step 5, if triggered]
 
+If the update recorded an upcoming or newly scheduled interview stage, also suggest:
+
+> "Interview coming up? `/interview <company>` builds a prep pack for that stage from this application's archive - the posting, the documents you submitted, and any feedback recorded from earlier rounds."
+
 ---
 
 ## Important Rules

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ This runs the full workflow: evaluate fit, draft CV + cover letter, review with 
 
 ## Other commands
 
-`/setup`, `/scrape`, and `/apply` form the core workflow. Six more commands extend it once your profile is in place:
+`/setup`, `/scrape`, and `/apply` form the core workflow. Seven more commands extend it once your profile is in place:
 
+- **`/interview`** preps you for a scheduled interview on a tracked application. It builds a stage-specific prep pack from the application's archive (the exact posting, the CV and cover letter the interviewer actually read, feedback recorded from earlier rounds), researches the company and interviewers with a verify-before-use rule, maps likely questions to your STAR examples, and offers a mock interview following the roleplay protocol in `07-interview-prep.md`. Gaps get honest bridge answers, never invented experience.
 - **`/outcome`** records what happened to an application - interview stages, offers, rejections, silence. It archives the submitted CV, cover letter, and posting text into `documents/applications/<company>_<role>/`, keeps `outcome.md` in the format `/setup` Path A parses, and updates the tracker. Once a few applications resolve, it points you back to `/setup` to calibrate the fit framework from what actually got interviews.
 - **`/rank`** bridges `/scrape` and `/apply`: it batch-scores all newly scraped postings against the fit framework (parallel agents fetch each posting and score the five evaluation dimensions) and returns a ranked shortlist with honest per-job strengths and gaps. Deal-breakers veto, deadlines get urgency flags, dead postings get marked expired. Pick a number and it hands off to the full `/apply` workflow.
 - **`/expand`** enriches your profile by scanning public sources you've already linked in it (GitHub repos, portfolio site, Kaggle, Google Scholar) and looking up syllabi for named courses and certifications. Discovered competencies are added to your profile with a source tag. Useful right after `/setup` to surface skills that documents alone don't make explicit.
@@ -124,6 +125,7 @@ ai-job-search/
 │   │   ├── add-portal.md              # /add-portal generate a job-portal search skill for your market
 │   │   ├── rank.md                    # /rank triage scraped jobs into a ranked shortlist
 │   │   ├── outcome.md                 # /outcome record application results, archive materials
+│   │   ├── interview.md               # /interview stage-specific prep pack + mock interview
 │   │   └── reset.md                   # /reset wipe profile data or documents folder
 │   ├── skills/
 │   │   ├── job-application-assistant/  # Core application skill

--- a/documents/README.md
+++ b/documents/README.md
@@ -143,6 +143,8 @@ Any signal about what they valued or didn't?
 
 `in_progress` marks an application that is still open (used by `/outcome` for interview-stage updates before a resolution). `/setup`'s calibration draws conclusions only from applications with a final status.
 
+Application folders may also contain **`interview_prep_<stage>.md`** files written by `/interview` (one per interview stage, kept as history). `/setup` reads only the four files named above and ignores these.
+
 **What `/setup` learns from outcome.md:**
 - Which role types and companies have led to interviews (signals strong fit areas)
 - Which applications did not progress (informs the experience match calibration in `04-job-evaluation.md`)


### PR DESCRIPTION
## What

A `/interview <company>` command that preps the user for a real, scheduled interview on a tracked application. The frameworks for this already exist — `07-interview-prep.md` (STAR examples with `Use for` tags, tough-question patterns, questions-to-ask categories, a 7-step roleplay protocol) and the Company Research Checklist in `04-job-evaluation.md` — but no command operationalizes them: `/apply` ends at "files ready," and the moment an interview lands, nothing picks the thread back up. This is the second command that draws on the archive `/outcome` (#54) maintains.

Framing: `/apply` optimizes what the company **reads**; `/interview` optimizes what the company **hears**. The bridge is consistency — the interviewer read the submitted CV and cover letter, so everything prepped must match what those documents claim.

## Verifiable claims

- **Consumes `07-interview-prep.md` as-is**: STAR matching uses its existing `Use for` tags; the mock interview follows its "Roleplay Guidelines" section verbatim (warm-up → role-specific → behavioral → curveball, feedback after each answer); tough questions and questions-to-ask come from its lists, customized per application.
- **Executes the Company Research Checklist** that `04-job-evaluation.md` defines (website/reviews/LinkedIn/media) — previously documented but never run by any command.
- **Archive schema respected**: reads the four files `documents/README.md` names; writes only `interview_prep_<stage>.md` (one per stage, kept as history), and `documents/README.md` now documents those files explicitly, noting `/setup` reads only its four named files and ignores them. The folder is already gitignored (`documents/applications/**`), so prep packs stay personal.
- **Graceful when the archive predates `/outcome`**: falls back to the tracker's `source` URL / `cv/main_<company>.tex` / asking the user, and states plainly what context is missing rather than guessing.

## Design notes

- **Feedback-first question derivation**: likely questions come, in priority order, from recorded earlier-stage feedback in `outcome.md`, then the fit evaluation's gaps (the weakest matches are the likeliest probes — each gets an honest bridge answer per `07`'s "you don't have [X]" pattern, never invented experience), then posting requirements, then stage type.
- **Consistency brief**: the prep pack lists the submitted documents' most probeable claims, with the rule stated plainly — no claim in the room that isn't on the paper.
- **Verify-before-use research**: company specifics enter the pack only after independent WebFetch/WebSearch confirmation (the repo's cover-letter rule, extended); interviewer notes stick to public professional information.
- **Boundaries**: never edits framework or profile files, with one explicit-consent exception — newly drafted STAR answers (grounded strictly in `01-candidate-profile.md` facts) are appended to `07` only on the user's explicit approval.
- **Loop closure**: ends by pointing to `/outcome <company>` — stage feedback recorded there is the top input for the next round's prep, and resolutions feed `/setup`'s calibration.
- **Scope**: v1 preps for a specific tracked application only; generic no-target practice is explicitly out of scope.

## Files

- `.claude/commands/interview.md` — the command (new)
- `.claude/commands/outcome.md` — suggests `/interview` when an interview stage is recorded (one block)
- `documents/README.md` — documents `interview_prep_<stage>.md` in the application-folder schema
- `README.md` — commands list, file-structure tree

No changes to `07-interview-prep.md`, the evaluation framework, or any existing workflow logic.