### PR TITLE
feat: onboard candidate profile via /setup (Path A)

### DIFF
--- a/.claude/skills/job-application-assistant/01-candidate-profile.md
+++ b/.claude/skills/job-application-assistant/01-candidate-profile.md
@@ -4,55 +4,80 @@
 <!-- After running /setup, all sections will be filled with your actual information -->
 
 ## Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_ADDRESS]
-- **Phone:** [YOUR_PHONE]
-- **Email:** [YOUR_EMAIL]
-- **LinkedIn:** [YOUR_LINKEDIN_URL]
+- **Name:** Jesus Mejia Arcila
+- **Location:** San Jose, Costa Rica
+- **Phone:** (506) 7124-1800
+- **Email:** jesusdma03@gmail.com
+- **LinkedIn:** linkedin.com/in/jesus-mejia
 - **GitHub:** [YOUR_GITHUB_URL]
-- **Languages:** [YOUR_LANGUAGES with proficiency levels]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
+- **Languages:** Spanish (Native), English (Professional Working Proficiency, B2)
+- **Status:** Employed full-time (CRG Solutions), concurrently finishing Bachelor's degree
 - **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
 
 ## Education
 
 | Degree | Period | Institution | Key Topics |
 |--------|--------|-------------|------------|
-| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+| Bachelor's Degree in Computer Systems Engineering | 2023 - Present | Universidad Fidelitas (UFide), San Jose, Costa Rica | Systems engineering, software development |
+| High School Diploma & Technical Degree - Service Center Executive | 2019 - 2021 | Colegio Tecnico Profesional de Pavas | Customer/service center operations |
 
 ## Professional Experience
 
-### [JOB_TITLE] - [COMPANY] ([START] - [END])
-[LOCATION]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+### IT Technical Support Specialist - CRG Solutions (on-site at Heineken) (February 2025 - Present)
+San Jose, Costa Rica
+- Provide technical IT support for Heineken operations, resolving hardware, software, and connectivity incidents
+- Diagnose and escalate issues following ITIL-aligned support procedures
+- Independently designed and developed the company's internal corporate portal (Next.js, Vercel) covering hardware inventory, software catalog with approval workflows, knowledge base, and Microsoft OAuth authentication
 
-<!-- Add more roles as needed -->
+### Business Technologies Automation Intern - Bimbo Global Services (March 2025 - September 2025)
+- Developed and deployed internal applications using Power Apps and Power Pages with Dataverse and SharePoint
+- Automated internal workflows with Power Automate, reducing request and reservation management turnaround time
+- Designed end-to-end solutions for internal ticketing, parking and cubicle reservations, and digital inspections across DEV, QA, and PROD environments
+- Contributed to process digitalization initiatives, improving operational efficiency and user experience
+
+### Administrative Intern - Office of the Attorney General of the Republic (Procuraduria General de la Republica) (October 2021 - December 2021)
+- Managed and maintained the institution's physical and digital document archives, ensuring proper organization and preservation
+- Led document digitization processes, improving accessibility and reducing retrieval times significantly
+- Provided professional service to internal and external users for document location and delivery, maintaining confidentiality standards
+- Participated in optimizing administrative procedures, contributing practical improvements to document management workflows
 
 ## Independent Projects
 <!-- Projects outside of employment: freelance, open source, personal -->
-- **[PROJECT_NAME]**: [DESCRIPTION]
+- **CRG Internal Portal** (crgapp-frontend.vercel.app): Solo-built multi-tenant corporate portal - FastAPI, Azure SQL Server (T-SQL), Next.js 15, React 19, Radix UI, Tailwind CSS, JWT, Microsoft SSO, Groq (Llama 3) chatbot, Docker, GitHub Actions, Vercel/Render. Engine-level row-level security across 3 schemas isolating tenant data per-session.
+- **Economedica Internacional S.A.** (www.economedicacr.com): Corporate website and digital product catalog for a medical supplies importer/distributor, 8 product categories, EmailJS contact form, XML sitemap for SEO. Next.js 15, React 19, TypeScript, Tailwind CSS v4.
+- **Show Marketing & Producciones** (www.showmarketingcr.com): Public marketing site for an event production/talent agency, talent roster/services/portfolio sections, WhatsApp contact integration. Next.js, TypeScript, Tailwind CSS.
+- **Wildlife Tracking System in National Parks** (academic): Web platform to register/track animals across Costa Rica's national parks using real-time GPS (GPS Trak-4). HTML, CSS, Bootstrap, PHP, JavaScript.
+- **Family BARF** (academic): Veterinary management system and e-commerce platform - employee management, appointment scheduling, client records, automated PDF/Excel reports. ASP.NET Core, Razor Pages, C#, SQL Server.
 
 ## Technical Skills
 
 ### Programming & ML
-- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
-- [OTHER_SKILLS]
+- **Python**: FastAPI backend development
+- **Java**: Spring Boot
+- **JavaScript / TypeScript**: React 19, Next.js 15
+- **C#**: ASP.NET Core MVC, Razor Pages
+- **HTML / CSS**: Tailwind CSS, Bootstrap, Radix UI
+- **AI / LLM**: Groq API, Llama 3, context-aware chatbot integration
 
 ### Domain Expertise
-- [DOMAIN_1]
-- [DOMAIN_2]
+- Full-stack web development (frontend + backend + database, solo end-to-end delivery)
+- Business process automation (Power Platform: Power Apps, Power Automate, Power Pages, Dataverse, SharePoint)
+- IT technical support (ITIL-aligned)
+- Multi-tenant SaaS architecture and row-level security
 
 ### Software & Tools
-- [TOOL_LIST]
+- Databases: Azure SQL Server (T-SQL), MySQL, SQL Server, Oracle
+- Cloud & DevOps: Docker, GitHub Actions (CI/CD), Vercel, Render, Azure
+- Auth & Security: JWT, Microsoft SSO, Row-Level Security, HttpOnly cookies
+- Version Control: Git, GitHub
+- Office Suite: Microsoft Word, Excel, PowerPoint
 
 ## Publications
 <!-- List peer-reviewed publications, if any -->
-1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+None yet.
 
 ## Awards
-- [AWARD] - [EVENT] ([YEAR])
+None yet.
 
 ## References
 - [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])

--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -16,9 +16,9 @@ How well do the required/preferred skills align with the candidate's capabilitie
 | 40-59 | Partial match, significant upskilling needed |
 | 0-39 | Fundamental mismatch |
 
-**Strong match areas:** [YOUR_PRIMARY_SKILLS]
-**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
-**Weak match areas:** [SKILLS_YOU_LACK]
+**Strong match areas:** Full-stack web development (React/Next.js frontend, FastAPI/ASP.NET Core backend), Power Platform business automation (Power Apps, Power Automate, Power Pages, Dataverse, SharePoint), multi-tenant architecture, database design (Azure SQL/T-SQL, MySQL, SQL Server)
+**Moderate match areas:** AI/LLM integration (Groq/Llama 3 chatbots - applied use, not model training), DevOps/CI-CD (Docker, GitHub Actions), IT technical support (ITIL-aligned)
+**Weak match areas:** Machine learning/data science (model development, not just LLM API integration), formal degree not yet completed (in progress), enterprise-scale team leadership
 
 ### 2. Experience Match (0-100)
 Does work history align with what they're looking for?
@@ -30,9 +30,9 @@ Does work history align with what they're looking for?
 | 40-59 | Adjacent experience, would need to make the case |
 | 0-39 | Unrelated experience |
 
-**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
-**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
-**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+**Strong:** Full-stack developer roles (solo end-to-end delivery), IT support/helpdesk roles, business process automation/Power Platform roles
+**Moderate:** Backend/API engineer roles, junior DevOps roles, technical consultant/solutions engineer roles
+**Entry-level:** Senior/lead engineering roles, ML/data science roles, roles requiring a completed degree
 
 ### 3. Behavioral/Culture Fit (0-100)
 Does the role and company culture match the behavioral profile?

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -106,11 +106,11 @@ Write 5-7 lines that function as an "elevator pitch": a concise, compelling intr
 **Create 2-3 profile statement templates for your main role types:**
 
 <!-- SETUP: These are populated based on your background -->
-**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+**For Full-Stack Developer roles:**
+> Full-stack developer who has independently designed and shipped a multi-tenant corporate portal end to end - database, backend, and frontend - using FastAPI, Azure SQL Server, Next.js 15, and React 19. Comfortable owning a project from schema design and row-level security through CI/CD and deployment. Currently completing a Bachelor's in Computer Systems Engineering while working full-time.
 
-**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+**For IT Support / Technical Operations roles:**
+> IT Technical Support Specialist providing ITIL-aligned hardware, software, and connectivity support for enterprise operations, alongside hands-on experience automating internal business processes with the Power Platform. Combines day-to-day operational troubleshooting with the ability to build the tools that reduce recurring support load.
 
 ### Core Competencies / Skills Section (Best Practice)
 Reorder and emphasize based on the role. Use bold category labels.

--- a/.claude/skills/job-application-assistant/07-interview-prep.md
+++ b/.claude/skills/job-application-assistant/07-interview-prep.md
@@ -35,6 +35,33 @@ Keep answers to 1-2 minutes. Be specific. End with what you learned or would do 
 
 <!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
 
+## STAR Candidates (Complete Manually)
+
+### CRG Internal Portal - Multi-Tenant Row-Level Security (Full-Stack Ownership)
+**Source:** CV - CRG Solutions (on-site at Heineken), Full-Stack Developer (Solo)
+**What happened:** Independently designed and built a multi-tenant corporate portal end to end, including engine-level row-level security in Azure SQL across 3 schemas.
+**Why it matters:** Ownership/initiative questions, technical depth questions on security/database design, "biggest project you built alone"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Power Automate Reservation System Turnaround Time (Process Automation Impact)
+**Source:** CV - Business Technologies Automation Intern, Bimbo Global Services
+**What happened:** Automated internal workflows with Power Automate, reducing request and reservation management turnaround time.
+**Why it matters:** "Tell me about a time you improved a process", measurable-impact questions
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Wildlife Tracking System - Scalable GPS Data Platform (Academic Project Under Constraints)
+**Source:** CV - Academic Project (Wildlife Tracking System in National Parks)
+**What happened:** Built a web platform handling large volumes of real-time GPS tracking data with a responsive interface, for conservation use.
+**Why it matters:** "Tell me about a technically challenging project", questions on working independently/academically without a team
+
 ## Common Tough Questions
 
 ### "Why did you leave [previous company]?"

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -4,67 +4,70 @@
 
 ## Search Sites
 
-Primary (Danish job market):
-- **jobindex.dk** - largest Danish job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: Denmark / your city)
-- **karriere.dk** - IDA's job board (engineering/science roles)
-- **jobfinder.dk** - another major Danish job board
-- **akademikernes.dk** - academic union job board
+**Note:** This repo's built-in job-scraper CLI tools (`jobbank-search`, `jobdanmark-search`, `jobindex-search`, `jobnet-search`) are Denmark-specific job portals and are not relevant for a Costa Rica-based search. Only `linkedin-search` applies directly. Until a Costa Rica-specific portal integration is added (see `/add-portal`), rely on LinkedIn and Google `site:` searches against Costa Rican job boards below.
+
+Primary:
+- **linkedin.com/jobs** - LinkedIn job listings (filter: Costa Rica / remote)
+- **elempleo.com** - major Costa Rica/Central America job board
+- **computrabajo.co.cr** - Costa Rica job board
+- **tecoloco.com** - Costa Rica job board
+- **remoteok.com / weworkremotely.com** - remote-first international listings
 
 Secondary (company career pages via Google):
 - Direct Google searches with `site:` filters for known target companies
 
 ## Query Categories
 
-Queries are grouped by priority. Each query should be combined with your location terms (e.g. "Copenhagen", "Sjælland", "Hovedstaden") where the site supports it.
+Queries are grouped by priority. Each query should be combined with your location terms ("San Jose", "Costa Rica", "Remote") where the site supports it.
 
-### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+### Priority 1: Full-Stack Developer / Software Engineer
 
 These match your strongest and most desired career direction.
 
 ```
-site:jobindex.dk "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
-site:jobindex.dk "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
+site:linkedin.com/jobs "Full-Stack Developer" Costa Rica
+site:linkedin.com/jobs "Software Engineer" Costa Rica OR Remote
+site:computrabajo.co.cr "desarrollador full stack"
+site:elempleo.com "full stack developer" Costa Rica
 ```
 
-### Priority 2: [YOUR_DOMAIN_EXPERTISE]
+### Priority 2: Power Platform Developer / Automation
 
-These match your domain expertise.
-
-```
-site:jobindex.dk [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:jobindex.dk [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
-```
-
-### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
-
-Adjacent roles you could pivot into.
+These match your domain expertise (Power Platform, business process automation).
 
 ```
-site:jobindex.dk "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:jobindex.dk "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
+site:linkedin.com/jobs "Power Platform Developer" Costa Rica OR Remote
+site:linkedin.com/jobs "Power Automate" OR "Power Apps" Costa Rica
+site:computrabajo.co.cr "power apps" OR "power automate"
 ```
 
-### Priority 4: Broader Technical / Consulting
+### Priority 3: IT Support Specialist / Junior Developer
 
-Wider net for general technical roles.
+Adjacent roles you could pivot into or use as a stepping stone.
 
 ```
-site:jobindex.dk [YOUR_KEY_SKILL] developer [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:jobindex.dk "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+site:linkedin.com/jobs "IT Support Specialist" Costa Rica
+site:linkedin.com/jobs "Junior Developer" Costa Rica OR Remote
+site:computrabajo.co.cr "soporte tecnico" OR "junior developer"
+```
+
+### Priority 4: Broader Technical / AI Integration
+
+Wider net for general technical roles, including AI/LLM-adjacent postings.
+
+```
+site:linkedin.com/jobs "React developer" OR "Next.js developer" Remote
+site:linkedin.com/jobs "AI" "chatbot" developer Remote
+site:elempleo.com "desarrollador" Costa Rica
 ```
 
 ## Location Filter
 
-When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
-- [YOUR_CITY] and surrounding areas
-- [ACCEPTABLE_AREA_1]
-- [ACCEPTABLE_AREA_2]
-- [BORDERLINE_AREA] (borderline - ~X min by transit)
-- [TOO_FAR_AREA] (too far)
+When evaluating results, verify the job location fits the constraints below. Define acceptable areas:
+- San Jose, Costa Rica and surrounding metro area
+- Remote roles anywhere in Costa Rica
+- Fully remote international roles (no relocation required)
+- Roles requiring relocation (too far - deal-breaker, exclude)
 
 ## Date Filter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,7 @@
-# Job Application Assistant for [YOUR_NAME]
-
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
+# Job Application Assistant for Jesus Mejia Arcila
 
 ## Role
-This repo is a job application workspace. Claude acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+This repo is a job application workspace. Claude acts as a career advisor and application assistant for Jesus Mejia Arcila, helping with:
 1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
 2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
 3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
@@ -13,68 +10,60 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 
 ## Candidate Profile
 
-<!-- This section is auto-populated by /setup. You can also fill it in manually. -->
-
 ### Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
-- **Languages:** [YOUR_LANGUAGES]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+- **Name:** Jesus Mejia Arcila
+- **Location:** San Jose, Costa Rica (open to remote and roles across Costa Rica; not open to relocation)
+- **Languages:** Spanish (Native), English (Professional Working Proficiency, B2)
+- **Status:** Employed full-time (CRG Solutions), concurrently finishing Bachelor's degree
+- **LinkedIn headline:** "Full-Stack Developer | Systems Engineering Student"
 
 ### Education
-<!-- List your degrees, most recent first -->
-- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
-  - Thesis: "[THESIS_TITLE]"
-  - Topics: [KEY_TOPICS]
+- **Bachelor's Degree in Computer Systems Engineering** (2023-Present) - Universidad Fidelitas (UFide), San Jose, Costa Rica
+- **High School Diploma & Technical Degree, Service Center Executive** (2019-2021) - Colegio Tecnico Profesional de Pavas
 
 ### Professional Experience
-<!-- List your roles, most recent first -->
-- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
-  - [KEY_RESPONSIBILITY_1]
-  - [KEY_RESPONSIBILITY_2]
-  - [KEY_ACHIEVEMENT]
+- **IT Technical Support Specialist** (February 2025 - Present) - **CRG Solutions (on-site at Heineken)** (San Jose, Costa Rica)
+  - Provide technical IT support for Heineken operations, resolving hardware, software, and connectivity incidents
+  - Diagnose and escalate issues following ITIL-aligned support procedures
+  - Independently designed and developed the company's internal corporate portal (Next.js, Vercel) covering hardware inventory, software catalog with approval workflows, knowledge base, and Microsoft OAuth authentication
+- **Business Technologies Automation Intern** (March 2025 - September 2025) - **Bimbo Global Services**
+  - Developed and deployed internal applications using Power Apps and Power Pages with Dataverse and SharePoint
+  - Automated internal workflows with Power Automate, reducing request and reservation management turnaround time
+  - Designed end-to-end solutions for internal ticketing, parking/cubicle reservations, and digital inspections across DEV, QA, and PROD environments
+- **Administrative Intern** (October 2021 - December 2021) - **Office of the Attorney General of the Republic**
+  - Managed and digitized the institution's physical and digital document archives
+  - Improved retrieval times and contributed practical improvements to document management workflows
 
 ### Technical Skills
-- **Primary:** [YOUR_PRIMARY_SKILLS]
-- **Secondary:** [YOUR_SECONDARY_SKILLS]
-- **Domain:** [YOUR_DOMAIN_EXPERTISE]
-- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+- **Primary:** Python (FastAPI), JavaScript/TypeScript (React 19, Next.js 15), C# (ASP.NET Core), Java (Spring Boot)
+- **Secondary:** Docker, GitHub Actions (CI/CD), Azure SQL Server (T-SQL), MySQL, JWT/Microsoft SSO/Row-Level Security, Groq API/Llama 3
+- **Domain:** Full-stack web development (solo end-to-end delivery), business process automation (Power Platform), multi-tenant SaaS architecture, IT technical support (ITIL-aligned)
+- **Software:** Power Apps, Power Automate, Power Pages, Dataverse, SharePoint, Git/GitHub, Microsoft Office
 
 ### Certifications
-<!-- List relevant certifications with dates -->
-- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+None yet.
 
 ### Publications
-<!-- List peer-reviewed publications, if any -->
-- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+None yet.
 
 ### Awards
-<!-- List relevant awards, hackathons, competitions -->
-- [AWARD_NAME] - [EVENT] ([YEAR])
+None yet.
 
 ### Behavioral Profile
-<!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
-- **[TRAIT_1]** - [DESCRIPTION]
-- **[TRAIT_2]** - [DESCRIPTION]
-- **Strengths:** [YOUR_STRENGTHS]
-- **Growth areas:** [YOUR_GROWTH_AREAS]
-- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+See `.claude/skills/job-application-assistant/02-behavioral-profile.md` (not yet completed - run `/setup --section behavioral` or answer interview-mode questions to fill this in).
 
 ### What Excites You
-<!-- What motivates you professionally -->
-- [PASSION_1]
-- [PASSION_2]
+- Owning full-stack projects end-to-end with more scale and autonomy
+- Specializing further in applied AI/LLM integration (chatbots, LLM-powered features)
+- Deepening business process automation / Power Platform specialism
 
 ### Target Sectors
-<!-- Industries and companies you're targeting -->
-- [SECTOR_1]: [EXAMPLE_COMPANIES]
-- [SECTOR_2]: [EXAMPLE_COMPANIES]
+- Full-stack / software engineering roles (Costa Rica and remote)
+- IT automation / Power Platform roles
+- AI-integration-adjacent full-stack roles
 
 ### Deal-breakers
-<!-- Hard constraints on job search -->
-- [DEALBREAKER_1]
-- [DEALBREAKER_2]
+- Roles requiring relocation
 
 ## Repo Structure
 - `cv/` - LaTeX CV variants (moderncv template, banking style)

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -1,4 +1,4 @@
-%% Example CV - [YOUR_NAME]
+%% Example CV - Jesus Mejia Arcila
 %% Comprehensive overview of all competencies, experience, and achievements.
 %% Use as a master reference when tailoring role-specific CVs.
 %%
@@ -24,18 +24,18 @@
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Jesus Mejia Arcila - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}
 
 % personal data
-\name{[First]}{[Last]}
-\address{[Your Address, City, Country]}{}{}
-\phone[mobile]{[+XX XXXXXXXXXX]}
-\email{[your.email@example.com]}
-\extrainfo{\href{[https://linkedin.com/in/your-profile]}{LinkedIn}, \href{[https://github.com/your-username]}{GitHub}}
+\name{Jesus}{Mejia Arcila}
+\address{San Jose, Costa Rica}{}{}
+\phone[mobile]{(506) 7124-1800}
+\email{jesusdma03@gmail.com}
+\extrainfo{\href{https://linkedin.com/in/jesus-mejia}{LinkedIn}}
 
 \begin{document}
 
@@ -46,7 +46,7 @@
 % ============================================================
 
 \vspace{6pt}
-\small{[Write a 3-5 line profile statement tailored to the role you're applying for. Focus on what makes you uniquely qualified. Example: "Data scientist with a PhD in [field] and X years of industry experience. Combines deep domain expertise in [domain] with strong applied machine learning and Python development skills. Experienced in developing end-to-end ML pipelines, from data ingestion to stakeholder-facing dashboards."]}
+\small{Full-stack developer who has independently designed and shipped a multi-tenant corporate portal end to end - database, backend, and frontend - using FastAPI, Azure SQL Server, Next.js 15, and React 19. Comfortable owning a project from schema design and row-level security through CI/CD and deployment. Currently completing a Bachelor's in Computer Systems Engineering while working full-time.}
 
 % ============================================================
 %     CORE COMPETENCIES
@@ -56,15 +56,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item \textbf{[Skill Category 1]}: [Specific skills, frameworks, tools. Be concrete.]
+\item \textbf{Full-Stack Web Development}: FastAPI, Next.js 15, React 19, ASP.NET Core, TypeScript, Tailwind CSS
 
-\item \textbf{[Skill Category 2]}: [Specific skills, frameworks, tools.]
+\item \textbf{Databases \& Security}: Azure SQL Server (T-SQL), MySQL, JWT, Microsoft SSO, Row-Level Security
 
-\item \textbf{[Skill Category 3]}: [Specific skills, frameworks, tools.]
+\item \textbf{Cloud \& DevOps}: Docker, GitHub Actions (CI/CD), Vercel, Render, Azure
 
-\item \textbf{[Skill Category 4]}: [Domain expertise, methods, approaches.]
+\item \textbf{Business Process Automation}: Power Apps, Power Automate, Power Pages, Dataverse, SharePoint
 
-\item \textbf{[Skill Category 5]}: [Tools, platforms, software.]
+\item \textbf{AI Integration}: Groq API, Llama 3, context-aware chatbot integration
 
 \end{itemize}
 
@@ -77,31 +77,30 @@
 \begin{itemize}
 
 % --- Most Recent Role ---
-\item{\cventry{[YYYY--Present]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\item{\cventry{2025--Present}{IT Technical Support Specialist}{CRG Solutions (on-site at Heineken)}{San Jose, Costa Rica}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1 - be specific, use numbers where possible]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
-    \item [Achievement or responsibility 4]
+    \item Provide technical IT support for Heineken operations, resolving hardware, software, and connectivity incidents
+    \item Diagnose and escalate issues following ITIL-aligned support procedures
+    \item Independently designed and developed the company's internal corporate portal (Next.js, Vercel) covering hardware inventory, software catalog with approval workflows, knowledge base, and Microsoft OAuth authentication
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Previous Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\item{\cventry{2025--2025}{Business Technologies Automation Intern}{Bimbo Global Services}{Costa Rica}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
+    \item Developed and deployed internal applications using Power Apps and Power Pages with Dataverse and SharePoint
+    \item Automated internal workflows with Power Automate, reducing request and reservation management turnaround time
+    \item Designed end-to-end solutions for internal ticketing, parking/cubicle reservations, and digital inspections across DEV, QA, and PROD environments
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Earlier Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\item{\cventry{2021--2021}{Administrative Intern}{Office of the Attorney General of the Republic}{San Jose, Costa Rica}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
+    \item Managed and digitized the institution's physical and digital document archives, improving retrieval times
+    \item Contributed practical improvements to document management workflows
 \end{itemize}}}
 
 \end{itemize}
@@ -114,14 +113,13 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-Thesis: ``[Thesis Title].'' [Brief description of research focus.]
+\item{\cventry{2023--Present}{Bachelor's Degree in Computer Systems Engineering}{Universidad Fidelitas (UFide)}{San Jose, Costa Rica}{}{\vspace{1pt}
+In progress.
 }}
 
 \vspace{3pt}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-[Brief description or key topics.]
+\item{\cventry{2019--2021}{High School Diploma \& Technical Degree, Service Center Executive}{Colegio Tecnico Profesional de Pavas}{Costa Rica}{}{\vspace{1pt}
 }}
 
 \end{itemize}
@@ -133,28 +131,16 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Languages}
 \vspace{1pt}
 \begin{itemize}
-\item [Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).
+\item Spanish (native), English (professional working proficiency, B2).
 \end{itemize}
 
 % ============================================================
-%     PUBLICATIONS (optional)
+%     PUBLICATIONS (optional - none yet, add when applicable)
 % ============================================================
 
-\section{Publications}
-\vspace{1pt}
-\begin{itemize}
-\item [Author(s)] ([Year]). [Title]. [Journal/Conference]. \href{[DOI_URL]}{DOI link}
-\end{itemize}
-
 % ============================================================
-%     HONORS AND AWARDS (optional)
+%     HONORS AND AWARDS (optional - none yet, add when applicable)
 % ============================================================
-
-\section{Honors and Awards}
-\vspace{1pt}
-\begin{itemize}
-\item{\textbf{[Award Name]} -- [Event/Organization] ([Year]).}
-\end{itemize}
 
 % ============================================================
 %     REFERENCES


### PR DESCRIPTION
## Summary
- Populates `01-candidate-profile.md`, `04-job-evaluation.md`, `05-cv-templates.md`, `07-interview-prep.md`, `CLAUDE.md`, `cv/main_example.tex`, and `.claude/skills/job-scraper/search-queries.md` from the provided CV via `/setup` Path A (documents folder onboarding).
- Flags that the built-in Danish job-portal CLIs (jobbank/jobdanmark/jobindex/jobnet) don't apply for a Costa Rica-based search; search queries instead target LinkedIn and Costa Rican job boards (elempleo, computrabajo, tecoloco).

## Test plan
- [ ] Review CLAUDE.md and skill files for accuracy against actual CV/preferences
- [ ] Run `/scrape` to confirm search queries return relevant Costa Rica/remote results
- [ ] Fill in remaining placeholders (behavioral profile, references, STAR stubs) before using `/apply`