### PR TITLE
feat: add /timeline command 

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -16,7 +16,7 @@ Follow these steps **exactly in order**. Do not skip steps.
 
 - If `$ARGUMENTS` looks like a URL, use `WebFetch` to retrieve the job posting content.
 - If it is pasted text, use it directly.
-- Extract: **company name**, **role title**, **department** (if mentioned), **location**, and **language** of the posting (Danish or English).
+- Extract: **company name**, **role title**, **department** (if mentioned), **location**, **application deadline** (if listed), and **language** of the posting (Danish or English).
 - Store these for use throughout the workflow.
 
 ---
@@ -41,7 +41,8 @@ Present the evaluation to the user with:
 2. **Experience match** - how work history maps to the role
 3. **Behavioral/culture match** - how behavioral profile fits the role/company culture
 4. **Salary benchmark** - salary index for the company (if available)
-5. **Overall fit score** and recommendation (strong fit / moderate fit / weak fit)
+5. **Application deadline** - if extracted in Step 0, show the date prominently. If within 7 days, add a 🔥 marker with the number of days remaining.
+6. **Overall fit score** and recommendation (strong fit / moderate fit / weak fit)
 
 After presenting the evaluation, ask the user:
 > "Should I proceed with drafting the CV and cover letter for this role?"

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -24,9 +24,9 @@ Follow these steps **in order**.
 
 1. Read `job_search_tracker.csv`. If it does not exist, create it with the standard header:
    ```
-   date,company,sector,role,role_type,channel,status,contact_person,fit_rating,notes,cv_file,cover_letter_file,source
+   date,company,sector,role,role_type,channel,status,contact_person,fit_rating,notes,cv_file,cover_letter_file,source,deadline,follow_up_date,interview_date
    ```
-2. **With an argument:** match rows case-insensitively on company (and role, if given). One match → proceed. Several → list them and ask. None → the application was made outside the workflow; collect company, role, date applied, channel, and posting URL from the user and add a tracker row.
+2. **With an argument:** match rows case-insensitively on company (and role, if given). One match → proceed. Several → list them and ask. None → the application was made outside the workflow; collect company, role, date applied, channel, and posting URL from the user and add a tracker row. Also check `job_scraper/seen_jobs.json` for a matching entry (by URL or company+title) — if found and it has a `deadline`, use it. If not found, ask the user: "Do you know the application deadline?" and use their answer (or leave empty).
 3. **Without an argument:** list all rows whose status is not final (not hired / rejected / no response / withdrawn / offer declined) as a numbered table (company, role, date applied, current status) and ask which to update. If every row is resolved, say so and stop.
 4. Derive the archive folder name: `documents/applications/<company>_<role>/` - lowercase, underscores for spaces (the convention documented in `documents/README.md`). Check whether the folder and an `outcome.md` already exist - if so, you are updating, not creating.
 
@@ -48,7 +48,8 @@ Ask the user what happened, then classify:
 - `interview_only` - reached interviews but the process stalled or was abandoned without an explicit rejection
 
 Also collect, without interrogating - one or two open questions are enough:
-- Dates for the stages reached
+- Dates for the stages reached. If an interview is scheduled, capture the specific date — this goes into the tracker's `interview_date` column and will appear in `/timeline`.
+- For applications with no deadline recorded yet, ask: "Do you know the application deadline? Even an approximate date helps for tracking."
 - Any feedback received, verbatim where the user remembers it
 - What they'd do differently, and any signal about what the company valued (these feed `/setup`'s calibration and STAR-candidate mining, so concrete beats polished)
 
@@ -87,7 +88,13 @@ Update rules: tick stage checkboxes as they are reached (add the date in parenth
 
 ## Step 4: Update the Tracker
 
-Update the matched row's `status` column (e.g. `applied` → `interview` → `offer` → `hired` / `rejected` / `no response` / `offer declined` / `withdrawn`) and append a short dated note to the `notes` column. Never restructure the CSV, reorder rows, or touch other rows.
+Update the matched row:
+- `status` column (e.g. `applied` → `interview` → `offer` → `hired` / `rejected` / `no response` / `offer declined` / `withdrawn`)
+- `deadline` column — if you collected a deadline in Step 2 or found one in `seen_jobs.json`, write it here (format: `YYYY-MM-DD`)
+- `interview_date` column — if an interview was scheduled and you collected the date, write it here (format: `YYYY-MM-DD`)
+- `follow_up_date` column — if no response and the user wants to follow up, suggest a date (~2-3 weeks after application or last contact) and write it here
+- Append a short dated note to the `notes` column.
+Never restructure the CSV, reorder rows, or touch other rows.
 
 ---
 

--- a/.claude/commands/rank.md
+++ b/.claude/commands/rank.md
@@ -77,8 +77,8 @@ Sort by overall score (descending), urgency as tiebreaker.
 
 Update `job_scraper/seen_jobs.json` in place - these fields are additive to the scraper's schema:
 
-- Ranked jobs: set `"status": "ranked"` and add `"rank_score": <overall>`, `"rank_verdict": "<band>"`, `"rank_date": "YYYY-MM-DD"`
-- Dead or past-deadline jobs: set `"status": "expired"`
+- Ranked jobs: set `"status": "ranked"` and add `"rank_score": <overall>`, `"rank_verdict": "<band>"`, `"rank_date": "YYYY-MM-DD"`, and `"deadline": "<date>"` (from the agent's output; `null` if no deadline was found)
+- Dead or past-deadline jobs: set `"status": "expired"` and `"deadline": "<date>"` (so the expiry is traceable)
 
 Do not modify `job_search_tracker.csv` - that file records applications, and `/rank` never applies. Re-running `/rank` is idempotent: already-`ranked` jobs are skipped unless `--all` re-scores them.
 

--- a/.claude/commands/timeline.md
+++ b/.claude/commands/timeline.md
@@ -1,0 +1,176 @@
+# /timeline - Application Pipeline Date View
+
+You are presenting the user with a unified chronological view of everything time-sensitive across their active applications — upcoming deadlines, scheduled interviews, follow-up reminders, and applications that are missing deadline info. All data comes from `job_search_tracker.csv` — this command is about managing the pipeline of jobs you have already committed to, not the full scrape backlog.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Input
+
+`$ARGUMENTS` may contain:
+
+- Nothing → show all upcoming items and gaps
+- `--N` (e.g. `/timeline --14`) → only show items within the next N days (default: all upcoming)
+- `--all` → include historically resolved items (past deadlines, past interviews) for a full retrospective
+
+---
+
+## Step 1: Load State
+
+1. Read `job_search_tracker.csv`. If it does not exist or has only a header row, say:
+   > "No applications tracked yet. Run `/apply` on a posting, then `/outcome <company>` to record it in the tracker and start building your timeline."
+   and stop.
+2. Today's date: use the current date.
+
+---
+
+## Step 2: Collect Items
+
+Build a flat list of timeline items from the tracker rows. Skip the header row. For each row:
+
+### Skip resolved applications
+
+If `status` is a final resolution (`hired`, `rejected`, `offer_declined`, `withdrawn`, `no_response`, `interview_only`), skip the row entirely — unless `$ARGUMENTS` includes `--all`, in which case include past dates for the retrospective view.
+
+### Active applications — collect these items
+
+**Application deadline:**
+If `deadline` is non-empty and the date is today or in the future:
+
+| Field | Value |
+|-------|-------|
+| `date` | The `deadline` value |
+| `type` | `"Application deadline"` |
+| `company` | `company` column |
+| `role` | `role` column |
+
+**Upcoming interview:**
+If `interview_date` is non-empty and the date is today or in the future:
+
+| Field | Value |
+|-------|-------|
+| `date` | The `interview_date` value |
+| `type` | `"Interview"` |
+| `company` | `company` column |
+| `role` | `role` column |
+
+**Follow-up reminder:**
+If `follow_up_date` is non-empty and the date is today or in the future:
+
+| Field | Value |
+|-------|-------|
+| `date` | The `follow_up_date` value |
+| `type` | `"Follow-up"` |
+| `company` | `company` column |
+| `role` | `role` column |
+
+### Auto-detect overdue follow-ups
+
+For rows where:
+- `status` is `applied` or `interview` (not resolved)
+- `follow_up_date` is empty
+- `interview_date` is empty
+- `date` (application date) is **21+ days** before today
+
+| Field | Value |
+|-------|-------|
+| `date` | The `date` value (original application date — shown for reference, not as a timeline entry) |
+| `type` | `"⚠️ Overdue — no response for N days"` |
+| `company` | `company` column |
+| `role` | `role` column |
+
+These are applications that have gone silent. They go in a separate "Overdue" section, not the main timeline.
+
+### Missing deadline
+
+If `deadline` is empty and `status` is not a final resolution:
+
+Collect into a separate "No Deadline Set" list. These don't appear in the timeline itself but are flagged so the user can fill them in.
+
+---
+
+## Step 3: Sort and Filter
+
+1. Sort all timeline items (deadlines, interviews, follow-ups) by `date` ascending.
+2. Assign urgency:
+   - **🔥 Urgent**: date is 0–7 days from today (inclusive)
+   - **📅 Upcoming**: date is 8+ days from today
+3. If `$ARGUMENTS` specified `--N`, drop items beyond the N-day window.
+4. If `$ARGUMENTS` included `--all`, include resolved applications with their past dates.
+
+---
+
+## Step 4: Present
+
+```
+## 📅 Application Timeline — YYYY-MM-DD
+
+<if no items in all sections: "Nothing urgent or upcoming. You're on top of things." and stop>
+
+### 🔥 Urgent (next 7 days)
+
+| Date | Type | Company | Role |
+|------|------|---------|------|
+| Jul 12 | Application deadline | Novo Nordisk | Data Engineer |
+| Jul 14 | Interview | Ørsted | ML Engineer |
+
+### 📅 Upcoming
+
+| Date | Type | Company | Role |
+|------|------|---------|------|
+| Jul 22 | Application deadline | LEGO | Data Scientist |
+| Jul 28 | Follow-up | Systematic | Software Engineer |
+
+<if any overdue:>
+
+### ⚠️ Overdue Follow-ups
+
+These applications have gone silent. Consider a brief follow-up or mark as `no_response` via `/outcome`.
+
+| Applied | Company | Role | Days silent |
+|---------|---------|------|-------------|
+| Jun 10 | Rambøll | Consultant | 28 |
+| Jun 15 | Netcompany | Developer | 23 |
+
+<if any missing deadlines:>
+
+### 📋 No Deadline Set
+
+These applications are missing deadline info. Run `/outcome <company>` to add one.
+
+| Company | Role | Status |
+|---------|------|--------|
+| Systematic | SW Engineer | applied |
+
+---
+
+After presenting, offer **one** relevant suggestion (don't list every possibility — pick the most pressing):
+
+- If urgent items exist: "3 things need attention this week. Want me to help with any of them?"
+- If only upcoming items: "Nothing urgent right now. Next deadline is July 22."
+- If overdue items exist: "Netcompany and Rambøll have been silent for 3+ weeks. Want to send a follow-up or mark them resolved?"
+- If missing deadlines: "2 applications are missing deadlines. Run `/outcome <company>` to fill them in."
+```
+
+---
+
+## Step 5: Offer Actions
+
+Based on what's in the timeline, offer at most 2 specific, actionable suggestions:
+
+- **Interview coming up**: "Ørsted interview on July 14. The job posting should be archived in `documents/applications/orsted_ml_engineer/` — want me to generate likely interview questions from it?"
+- **Deadline approaching**: "Novo Nordisk closes in 4 days. All set with the application?"
+- **Overdue follow-up**: "Rambøll has been silent for 4 weeks. Consider a brief follow-up email or mark it `no_response` with `/outcome ramboll`."
+- **Missing deadline**: "Run `/outcome systematic` to add the deadline — takes 30 seconds."
+
+---
+
+## Important Rules
+
+1. **Tracker only.** `/timeline` reads only from `job_search_tracker.csv`. Scraped jobs that haven't been applied to live in the `/scrape` and `/rank` output — that's where their deadlines belong. This command manages your active pipeline.
+2. **Never fabricate dates.** Only show what's actually recorded. If a date looks wrong (e.g. deadline in 2019), flag it rather than silently correcting.
+3. **Respect final resolutions.** `hired`, `rejected`, `offer_declined`, `withdrawn`, `no_response`, `interview_only` rows are excluded unless `--all` is passed. The user doesn't need to see a deadline for a job they were already rejected from.
+4. **Respect the data.** `deadline`, `follow_up_date`, and `interview_date` are optional fields — many rows won't have them. That's expected (especially for applications made before these columns existed). Don't nag about missing data; present what you have and offer to fill gaps.
+5. **Keep it scannable.** The timeline is a dashboard, not a report. Each section should be glanceable — if a section would have 10+ items, consider grouping by week.
+6. **Idempotent.** `/timeline` reads only — it never writes to the tracker.

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -75,11 +75,13 @@ For each new job, do a rapid fit check (NOT the full evaluation from `04-job-eva
       "url": "...",
       "first_seen": "YYYY-MM-DD",
       "fit": "high/medium/low",
-      "status": "new/skipped/evaluated/ranked/expired"
+      "status": "new/skipped/evaluated/ranked/expired",
+      "deadline": "YYYY-MM-DD" | null
     }
   }
 }
 ```
+Include `deadline` whenever the posting lists an application deadline. Set to `null` if no deadline is found.
 2. Only present jobs NOT already in the seen list or tracker.
 
 ### Step 5: Present Results

--- a/.claude/skills/upskill/SKILL.md
+++ b/.claude/skills/upskill/SKILL.md
@@ -35,7 +35,7 @@ In targeted mode, derive a slug from the job title and company for the report fi
 
 ### Aggregate mode
 1. Read `job_search_tracker.csv`. Extract all rows. The columns are:
-   `date, company, sector, role, role_type, channel, status, contact_person, fit_rating, notes, cv_file, cover_letter_file, source`
+   `date, company, sector, role, role_type, channel, status, contact_person, fit_rating, notes, cv_file, cover_letter_file, source, deadline, follow_up_date, interview_date`
 2. For each row, note the `role`, `company`, and `fit_rating`. The `fit_rating` column is a 0–100 score where 100 = perfect fit. You will use it to weight gaps — a lower fit rating means the role exposed more gaps.
 3. Read `.claude/skills/job-application-assistant/01-candidate-profile.md` to get the candidate's current skills and experience.
 4. Check `upskill/` for the most recent aggregate report file (`report-YYYY-MM-DD.md`) — if one exists, note its date and load it for the diff in Step 8.

--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ This runs the full workflow: evaluate fit, draft CV + cover letter, review with 
 
 ## Other commands
 
-`/setup`, `/scrape`, and `/apply` form the core workflow. Six more commands extend it once your profile is in place:
+`/setup`, `/scrape`, and `/apply` form the core workflow. Seven more commands extend it once your profile is in place:
 
 - **`/outcome`** records what happened to an application - interview stages, offers, rejections, silence. It archives the submitted CV, cover letter, and posting text into `documents/applications/<company>_<role>/`, keeps `outcome.md` in the format `/setup` Path A parses, and updates the tracker. Once a few applications resolve, it points you back to `/setup` to calibrate the fit framework from what actually got interviews.
 - **`/rank`** bridges `/scrape` and `/apply`: it batch-scores all newly scraped postings against the fit framework (parallel agents fetch each posting and score the five evaluation dimensions) and returns a ranked shortlist with honest per-job strengths and gaps. Deal-breakers veto, deadlines get urgency flags, dead postings get marked expired. Pick a number and it hands off to the full `/apply` workflow.
+- **`/timeline`** gives you a single view of every deadline and key date across your active applications — upcoming deadlines, scheduled interviews, follow-up reminders, and applications that have gone silent. Reads from the tracker, flags urgent items (within 7 days), auto-detects overdue follow-ups, and suggests concrete next actions. Run it whenever you need to know "what needs my attention this week?"
 - **`/expand`** enriches your profile by scanning public sources you've already linked in it (GitHub repos, portfolio site, Kaggle, Google Scholar) and looking up syllabi for named courses and certifications. Discovered competencies are added to your profile with a source tag. Useful right after `/setup` to surface skills that documents alone don't make explicit.
 - **`/upskill`** analyzes the gap between your profile and your tracked job postings (or a single posting via `/upskill <URL>`). Produces a prioritized heatmap of skill gaps and a learning plan with web-searched study resources and time estimates. Useful for career planning between applications.
 - **`/add-template`** registers your own LaTeX CV or cover letter template in place of the stock ones. It captures the template's instructions (compile engine, fonts, style rules, page limit), runs a mandatory test compile, and wires the template into `/apply`. See [LaTeX templates](#latex-templates) below.
@@ -124,6 +125,7 @@ ai-job-search/
 │   │   ├── add-portal.md              # /add-portal generate a job-portal search skill for your market
 │   │   ├── rank.md                    # /rank triage scraped jobs into a ranked shortlist
 │   │   ├── outcome.md                 # /outcome record application results, archive materials
+│   │   ├── timeline.md               # /timeline centralized deadline and interview date view
 │   │   └── reset.md                   # /reset wipe profile data or documents folder
 │   ├── skills/
 │   │   ├── job-application-assistant/  # Core application skill

--- a/job_search_tracker.csv
+++ b/job_search_tracker.csv
@@ -1,1 +1,1 @@
-date,company,sector,role,role_type,channel,status,contact_person,fit_rating,notes,cv_file,cover_letter_file,source
+date,company,sector,role,role_type,channel,status,contact_person,fit_rating,notes,cv_file,cover_letter_file,source,deadline,follow_up_date,interview_date


### PR DESCRIPTION
  ---
  Problem

  Deadlines are extracted twice (by /scrape and /rank) and discarded both times. Interview dates get buried in free-text
  notes. Users have no way to answer "what needs my attention this week" without hunting through three different files
  and their conversation history.

  What this PR adds

  /timeline — a single dashboard for everything time-sensitive

  One command shows you:

  - 🔥 What's urgent — deadlines or interviews in the next 7 days
  - 📅 What's coming — everything beyond 7 days
  - ⚠️ What's gone silent — applications with no reply for 3+ weeks, auto-detected so you don't have to remember to
  follow up
  - 📋 What's missing — applications with no deadline recorded, so you can fill them in

  /timeline        → show everything upcoming
  /timeline --14   → only next 14 days
  /timeline --all  → include past/resolved items

  Deadlines now survive the pipeline

  Before: /scrape extracts the deadline, shows it, then throws it away. /rank does the same. After /apply you have no
  record of when the application is due.

  After: deadline flows from scrape → seen_jobs.json → /outcome → tracker. Then /timeline reads it.