### PR TITLE
Add Codex setup support

### DIFF
--- a/.agents/skills/add-portal/SKILL.md
+++ b/.agents/skills/add-portal/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: add-portal
+description: Generate a job portal search skill for a local market. Use when the user asks for /add-portal, adding a job board, or creating a portal search CLI.
+---
+
+# /add-portal - Generate a Job-Portal Search Skill for Your Local Market
+
+You are helping the user build a job-portal search skill for a job board in their market. The repo ships worked examples of the pattern (four Danish portals plus the country-agnostic `linkedin-search`), and the README invites users elsewhere to build equivalents — this command turns that invitation into a guided workflow: investigate the portal, scaffold the skill from the canonical structure, and test-run a live query before registering anything.
+
+The generator is **country-agnostic**: it works for any portal in any market and language. The skills it produces are typically market-specific and live in the user's fork (per repo policy, country-specific portal skills are not merged upstream — the generator is the upstream feature, its output is yours).
+
+`the user request arguments` may contain a subcommand, a portal URL, or nothing.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Arguments
+
+- If `the user request arguments` contains `--list`: Use available file-search tools with `.agents/skills/*/SKILL.md`, print a table of installed portal skills (name, market from the description, data source from `url-reference.md`), and stop.
+- If `the user request arguments` contains a URL: treat it as the portal URL and carry it into Step 1.
+- Otherwise: start the interview at Step 1.
+
+---
+
+## Step 1: Interview - Portal Basics
+
+Ask the user (skip anything already answered by `the user request arguments`):
+
+1. **Portal URL** - the job board's public site (e.g. `https://www.seek.com.au`, `https://www.stepstone.de`).
+2. **Skill name** - kebab-case, suffixed `-search` (e.g. `seek-search`, `stepstone-search`). Must not collide with an existing folder in `.agents/skills/`.
+3. **Market and language** - which country/region the portal covers and what language its postings use. This drives the trigger phrases in `SKILL.md` (include local-language terms like the Danish skills do: "ledige stillinger", "jobsøgning").
+4. **A realistic test query** - a job title or skill the user would actually search for, used for the live test in Step 4.
+
+---
+
+## Step 2: Investigate the Portal
+
+Do reconnaissance before writing any code. Use available web fetch tools (or `curl` via Bash) on the portal:
+
+1. **Find the search URL pattern.** Load the portal's search page, run a search in the URL bar mentally or via fetch, and identify: the search endpoint, the query parameter, and any parameters for location, posting age, and pagination. Prefer a JSON API if one backs the site (check for `/api/` XHR endpoints in the page source); otherwise plan to parse the HTML results page.
+2. **Fetch one search-results response** for the test query and identify the per-result fields: **id, title, company, location, posting date, and URL**. For HTML, note the class names / attributes that anchor each field. For JSON, note the field paths.
+3. **Find the detail-page pattern** - the URL that returns a single posting's full description, and where the description, deadline, employment type, and apply link live in it.
+4. **Check access requirements and terms.**
+   - Fetch `robots.txt` and check whether the search/detail paths are disallowed.
+   - If the portal requires login/authentication to view listings, **stop**: this pattern only works on public pages. Tell the user and suggest checking whether the portal has an official API.
+   - If robots.txt disallows the paths or the portal's terms prohibit automated access, tell the user plainly and let them decide whether to proceed for personal use. If they proceed, the generated `SKILL.md` **must** carry a prominent personal-use-only warning (copy the tone of `linkedin-search`'s "⚠️ Personal use only" section: keep volume low, no commercial or bulk use, own responsibility).
+
+Record everything you found - endpoints, parameters, field anchors, quirks - you will write it into `url-reference.md` in Step 3.
+
+---
+
+## Step 3: Scaffold the Skill
+
+**Canonical reference:** read `.agents/skills/linkedin-search/` before generating - it is the zero-dependency worked example of this exact structure. Copy its architecture, not its LinkedIn-specific parsing.
+
+Create `.agents/skills/<name>/` with:
+
+```
+<name>/
+├── SKILL.md              # Skill definition with trigger phrases
+├── url-reference.md      # Endpoint documentation from Step 2
+└── cli/
+    ├── package.json
+    ├── tsconfig.json
+    ├── README.md
+    ├── src/
+    │   ├── cli.ts        # Arg parsing, help text, command dispatch
+    │   ├── helpers.ts    # Fetch with backoff, parsers, error writer
+    │   └── commands/
+    │       ├── search.ts
+    │       └── detail.ts
+    └── tests/
+        └── helpers.ts    # runCLI + parseJSON test utilities (copy from jobindex-search)
+```
+
+### The portal-skill contract (every generated skill MUST honor this)
+
+These conventions are what make portal skills interchangeable for `/scrape` and for users reading any skill's docs:
+
+- **Commands:** `search` and `detail <id|url>`.
+- **Search flags:** `--query`/`-q`, `--jobage <days>` (posting age; map to the portal's parameter, note in SKILL.md if unsupported), `--page <n>` (1-indexed), `--limit <n>` (client-side cap), `--format json|table|plain` (default `json`). Add `--location`/`-l` if the portal supports location as a parameter; if it only supports location inside the keyword query, document that in SKILL.md the way `jobindex-search` does ("include the city in `--query`").
+- **JSON output shape:** `{ "meta": { "count": ..., "page": ... }, "results": [...] }` where each result has at least `id`, `title`, `company`, `location`, `date`, `url` (missing values are `null`, never omitted).
+- **Errors:** written to **stderr** as `{ "error": "...", "code": "..." }`, exit code `1`. Never write errors to stdout.
+- **Fetching:** browser User-Agent, exponential backoff with jitter on 429/5xx (max ~6 retries), `""`/`null` on 404 rather than a crash.
+- **HTML parsing:** split the response into per-result chunks and parse each independently, so one malformed card cannot break the rest (see `parseJobCards` in `linkedin-search/cli/src/helpers.ts`).
+- **Dependencies:** default to **zero runtime dependencies** (plain `bun` + `fetch` + regex parsing) like `linkedin-search` - `bun install` should only pull dev types. Only add a parsing library if the portal's markup genuinely defeats chunked regex parsing, and say so in the README.
+
+### File specifics
+
+- **`SKILL.md` frontmatter:** `name`, `version: 1.0.0`, and a `description` written for skill triggering - it must name the portal, the market, and include trigger phrases in English **and** the market's language. If adding tool metadata, use the repository-root path: `Bash(bun run .agents/skills/<name>/cli/src/cli.ts *)`.
+- **`SKILL.md` body:** what the skill searches, the personal-use warning if Step 2 found terms restrictions, command reference with flags, 4-6 usage examples using the user's market (real cities, realistic roles), output-format table, and a Notes section recording portal quirks found in Step 2.
+- **`url-reference.md`:** the endpoints, parameters table, and response-structure notes from Step 2 - this is the file a future maintainer needs when the portal changes its markup.
+- **`package.json`:** name `<portal>-cli`, `"type": "module"`, scripts `start`, `test` (`bun test --timeout 30000`), and `typecheck` (`tsc --noEmit`); dev-only dependencies in the zero-dependency default.
+- **`tests/`:** copy `runCLI`/`parseJSON` from `jobindex-search/cli/tests/helpers.ts`, then add a small live smoke-test file: `search` with the test query returns exit code 0 and ≥1 result with non-null `id`/`title`/`url`; a bogus flag or missing required arg exits 1 with a JSON error on stderr.
+
+---
+
+## Step 4: Test-Run a Live Query (MANDATORY)
+
+Never register a portal skill that has not returned real results. Markup assumptions from Step 2 routinely miss quirks that only show up live.
+
+1. Install dev types and typecheck:
+   ```bash
+   cd .agents/skills/<name>/cli && bun install && bun run typecheck
+   ```
+2. Run the live search with the user's test query:
+   ```bash
+   bun run src/cli.ts search -q "<test query>" --limit 5 --format table
+   ```
+3. Verify the results are real and complete: titles and companies are populated (not empty strings or HTML fragments), URLs resolve to the portal, dates parse. If fields come back null or garbled, fix the parsers in `helpers.ts` and re-run. Iterate until clean.
+4. Take one `id` from the results and run `detail`:
+   ```bash
+   bun run src/cli.ts detail <id> --format plain
+   ```
+   Verify the description is readable text (entities decoded, tags stripped, paragraph breaks preserved).
+5. Run the test suite: `bun run test`.
+6. Keep volume low during iteration - a handful of requests, not a crawl. If the portal rate-limits you mid-test, back off and tell the user.
+
+Do not proceed to Step 5 until search, detail, and tests all pass.
+
+---
+
+## Step 5: Register
+
+1. Ask whether the user wants the new portal added to their `/scrape` search strategy. If yes, add the portal's site to the relevant query categories in `.agents/skills/job-scraper/search-queries.md` (site-specific queries, like the existing `jobindex.dk` entries) so `/scrape` includes it.
+2. Remind the user to add the install line for their own records if they maintain a fork README:
+   ```bash
+   cd .agents/skills/<name>/cli && bun install && cd ../../../..
+   ```
+   (Skip if the skill is zero-dependency and they don't care about typecheck types.)
+3. Note that the skill auto-triggers from its `SKILL.md` description - no other wiring is needed.
+
+---
+
+## Step 6: Confirm
+
+Present a summary:
+
+> **Portal skill `<name>` generated and verified.**
+>
+> - Files: `.agents/skills/<name>/` (SKILL.md, url-reference.md, CLI with tests)
+> - Live test: `search "<test query>"` returned <N> results; `detail` verified on one posting
+> - Data source: <endpoint summary>; <personal-use warning noted, if applicable>
+>
+> Try it: `bun run .agents/skills/<name>/cli/src/cli.ts search -q "<test query>" --format table`
+>
+> Per upstream policy, market-specific skills like this live in your fork rather than being PR'd upstream. If the portal changes its markup later, `url-reference.md` records the parsing anchors to update.
+
+---
+
+## Design Principles
+
+- The generator is country-agnostic; its output is market-specific and stays in the user's fork. This matches the repo policy that upstream stays a universal template.
+- Investigation before scaffolding: the command never generates parsers from guesses - Step 2 fetches real responses first, and Step 4 verifies against live data before anything is registered.
+- The portal-skill contract keeps every generated skill interchangeable with the shipped ones: same commands, same flags, same output shape, same error convention.
+- Zero runtime dependencies by default, matching `linkedin-search` - a portal skill should run on a fresh clone with nothing but `bun`.
+- Access rules are surfaced, not silently bypassed: auth-walled portals are declined, robots.txt/ToS restrictions are reported to the user, and restricted portals get a prominent personal-use-only warning in the generated skill.

--- a/.agents/skills/add-template/SKILL.md
+++ b/.agents/skills/add-template/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: add-template
+description: Register a custom LaTeX CV or cover letter template. Use when the user asks for /add-template, listing templates, activating templates, or adding a CV/cover-letter template.
+---
+
+# /add-template - Register a Custom CV or Cover Letter Template
+
+You are helping the user register their own LaTeX template with the AI Job Search framework. The framework ships with moderncv (banking style) for CVs and a custom `cover.cls` for cover letters. This command lets the user swap in their own template: store the template files, capture usage instructions (compile engine, fonts, style rules, page limits), verify the template compiles, and wire it into the `/apply` workflow so every future application uses it.
+
+`the user request arguments` may contain a subcommand, a file path, or nothing.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Arguments
+
+- If `the user request arguments` contains `--list`: run **List Mode** below and stop.
+- If `the user request arguments` contains `--use <name>`: skip to **Step 5: Activate** with that template name. `--use default` deactivates any custom template and restores the stock guidance (see Step 5).
+- If `the user request arguments` contains a file path or @-mentioned file: treat it as the template source and carry it into Step 1.
+- Otherwise: start the registration flow at Step 1.
+
+### List Mode
+
+Use available file-search tools with `templates/**/TEMPLATE.md` to find registered templates. For each, read the manifest and print a table:
+
+```
+## Registered Templates
+
+| Name | Type | Engine | Fonts | Active |
+|------|------|--------|-------|--------|
+| <name> | CV / Cover letter | lualatex/xelatex/pdflatex | <main font> | yes/no |
+```
+
+A template is **active** if `05-cv-templates.md` (CV) or `06-cover-letter-templates.md` (cover letter) contains an `ACTIVE-TEMPLATE` managed block naming it. If no custom templates exist, say so and explain that `/add-template` registers one. Stop here.
+
+---
+
+## Step 1: Template Type and Source
+
+Ask the user (skip anything already answered by `the user request arguments`):
+
+1. **Type:** Is this a **CV** template or a **cover letter** template?
+2. **Source:** Where is the template? Accept any of:
+   - A path or @-mention of a `.tex` file (plus optional `.cls`/`.sty` files)
+   - Pasted LaTeX content
+   - A directory containing the template and its assets (class files, fonts, images)
+
+Read every provided file. If the template references a document class or package that is not part of standard TeX distributions (e.g. a custom `.cls`), confirm the user has the file and ask for it if missing — the template cannot compile without it.
+
+---
+
+## Step 2: Capture Template Instructions
+
+Interview the user for the metadata that `/apply` needs to use the template correctly. Infer as much as possible from the LaTeX source first (documentclass, `\fontspec` calls, geometry, colors) and present your inferences for confirmation rather than asking blind questions.
+
+Collect:
+
+1. **Name** - short kebab-case identifier (e.g. `awesome-cv`, `classic-serif`). Must not collide with an existing folder in `templates/`.
+2. **Compile engine** - `lualatex`, `xelatex`, or `pdflatex`. If the source uses `fontspec` or loads font files by path, it requires `xelatex` or `lualatex`; tell the user this rather than letting them pick `pdflatex`.
+3. **Fonts** - which font(s) the template uses and where they come from:
+   - **Bundled font files** (`.ttf`/`.otf` shipped with the template): copy them into the template folder in Step 3 and record the relative `Path` used in `\fontspec` calls.
+   - **System / TeX-distribution fonts**: record the font name and note that the user's machine must have it installed.
+4. **Style rules** - anything the drafter must preserve when filling the template: color scheme, section order, heading style, spacing conventions, bullet formatting, date format.
+5. **Page limit** - hard page count for the compiled PDF. Default: **2 pages** for a CV, **1 page** for a cover letter. `/apply`'s compile-and-inspect loop enforces this.
+6. **Known pitfalls** (optional) - macros that break with certain content (like the stock template's `\lettercontent{}`/`itemize` interaction), characters that need escaping, sections that must not be reordered.
+
+---
+
+## Step 3: Store the Template
+
+Create the template folder:
+
+- CV: `templates/cv/<name>/`
+- Cover letter: `templates/cover_letters/<name>/`
+
+Write into it:
+
+1. **`template.tex`** - the template skeleton. Replace all personal data in the source with `[PLACEHOLDER]` tokens (`[YOUR_NAME]`, `[YOUR_EMAIL]`, `[YOUR_PHONE]`, `[YOUR_LINKEDIN_URL]`, ...) so the template is shareable and profile-agnostic. Keep the structure, preamble, and styling exactly as provided.
+2. **Class/style files** - copy any `.cls`/`.sty` files alongside `template.tex`.
+3. **`fonts/`** - copy bundled font files here, preserving any directory layout the `\fontspec` `Path` options expect. Adjust `Path` values in `template.tex` to be relative to the template folder.
+4. **`TEMPLATE.md`** - the manifest. Use exactly this format:
+
+```markdown
+# Template: <name>
+
+- **Type:** CV | Cover letter
+- **Engine:** lualatex | xelatex | pdflatex
+- **Page limit:** <N> page(s)
+- **Fonts:** <main font> (<bundled in fonts/ | system font - must be installed>)
+- **Class/packages:** <documentclass and any non-standard packages, or "standard">
+
+## Compile command
+
+    cd <output dir> && <engine> -interaction=nonstopmode <file>.tex
+
+## Style rules
+
+- <rule 1: colors, section order, heading style, ...>
+- <rule 2>
+
+## Known pitfalls
+
+- <pitfall and its fix, or "none recorded">
+```
+
+---
+
+## Step 4: Verify the Template Compiles (MANDATORY)
+
+Never register a template without a successful test compile. LaTeX templates that "look fine" routinely fail on missing fonts, missing classes, or engine mismatches.
+
+1. Copy `template.tex` to a scratch file in the same folder (e.g. `_compile_test.tex`) and fill every `[PLACEHOLDER]` with realistic dummy data (name, contact line, one education entry, one job entry with 3 bullets — enough content to exercise the layout).
+2. Compile with the declared engine:
+   ```bash
+   cd templates/<type>/<name> && <engine> -interaction=nonstopmode _compile_test.tex
+   ```
+3. If the compile fails: show the user the relevant error lines, diagnose (missing font file, wrong engine, missing class), fix what you can (e.g. font `Path` values), and re-compile. If the fix needs input only the user has (a missing font file, a license-restricted class), ask for it and wait.
+4. On success, Read the PDF and confirm the layout renders sensibly (no overlapping text, fonts loaded, page count plausible for dummy content). Record any surprises in the manifest's "Known pitfalls".
+5. Delete the scratch files: `_compile_test.tex`, `_compile_test.pdf`, and all `.aux`/`.log`/`.out` artifacts.
+
+Do not proceed to Step 5 until the test compile passes.
+
+---
+
+## Step 5: Activate the Template
+
+Activation wires the template into `/apply` by adding a **managed block** to the top of the relevant guidance file — `05-cv-templates.md` for CVs, `06-cover-letter-templates.md` for cover letters. `/apply` reads these files in its drafting step, so the block is all it takes.
+
+Insert (or replace, if one exists) this block immediately after the file's H1 title:
+
+```markdown
+<!-- BEGIN ACTIVE-TEMPLATE (managed by /add-template - do not edit by hand) -->
+> **Active template override: `<name>`**
+>
+> A custom template is active. Where this block conflicts with the stock guidance below, this block wins. Structural advice below (tailoring, page-budget, cutting rules) still applies.
+>
+> - **Template skeleton:** `templates/<type>/<name>/template.tex` — use this as the structural reference instead of the stock template
+> - **Manifest:** `templates/<type>/<name>/TEMPLATE.md` — read this for style rules and known pitfalls before drafting
+> - **Compile with:** `<engine>` (not the engine named in the stock guidance below)
+> - **Fonts:** <font summary, including any Path note for bundled fonts>
+> - **Page limit:** exactly <N> page(s)
+> - **Output file:** unchanged (`cv/main_<company>.tex` / `cover_letters/cover_<company>_<role>.tex`); copy any class/font files the template needs into the output directory, or reference them by relative path
+<!-- END ACTIVE-TEMPLATE -->
+```
+
+Rules:
+
+- Exactly **one** managed block per guidance file. Replace the whole block between the `BEGIN`/`END` markers when switching templates; never stack blocks.
+- **`--use default`**: remove the managed block entirely. The stock moderncv / cover.cls guidance below it is untouched and takes over again.
+- Do not modify anything outside the markers.
+
+---
+
+## Step 6: Confirm
+
+Present a summary:
+
+> **Template `<name>` registered and activated.**
+>
+> - Files: `templates/<type>/<name>/` (skeleton, manifest<, class files><, fonts>)
+> - Test compile: passed with `<engine>` (<N> page(s))
+> - `/apply` will now draft <CVs | cover letters> from this template.
+>
+> Useful follow-ups:
+> - `/add-template --list` — see all registered templates
+> - `/add-template --use <other-name>` — switch templates
+> - `/add-template --use default` — go back to the stock <moderncv | cover.cls> template
+
+---
+
+## Design Principles
+
+- Registration is idempotent: re-running with the same name offers to update the existing template rather than duplicating it.
+- Templates are stored profile-agnostic (`[PLACEHOLDER]` tokens) so they can be shared or committed without leaking personal data.
+- The compile check in Step 4 is non-negotiable — a template that has never compiled will fail mid-`/apply`, which is the worst place to discover it.
+- Activation is a small managed block, not a rewrite of the guidance files: `/setup` and manual edits to `05`/`06` survive template switches, and `--use default` is a clean revert.

--- a/.agents/skills/apply/SKILL.md
+++ b/.agents/skills/apply/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: apply
+description: Run the Codex job application workflow. Use when the user asks for /apply, applying to a job, evaluating a posting, tailoring a CV, or writing a cover letter.
+---
+
+# /apply - Drafter-Reviewer Job Application Workflow
+
+You are running a drafter-reviewer job application workflow. The job posting is provided by the user request (either a URL or pasted text).
+
+Follow these steps **exactly in order**. Do not skip steps.
+
+**Token-efficiency rules for this workflow:**
+- Never re-Read a file whose contents are already in your context from an earlier step. If you read it in Step 1, it is still available in Step 2.
+- Run the reviewer pass from the root Codex agent by default. Use a reviewer subagent only when the user explicitly asks for subagents or an active goal workflow permits it.
+- Run the full verification checklist exactly once, at the end (Step 6). The reviewer focuses on content critique, not verification.
+- Step 5 (compile and inspect PDFs) is mandatory and non-skippable — LaTeX page-break decisions are unpredictable, and `.tex` files that look fine often produce broken PDFs (orphaned entry titles, cover letters spilling to page 2, bullet fonts mismatching).
+
+---
+
+## Step 0: Parse Input
+
+- If `the user request arguments` looks like a URL, use `available web fetch tools` to retrieve the job posting content.
+- If it is pasted text, use it directly.
+- Extract: **company name**, **role title**, **department** (if mentioned), **location**, and **language** of the posting (Danish or English).
+- Store these for use throughout the workflow.
+
+---
+
+## Step 1: DRAFTER - Evaluate Fit
+
+Read the evaluation framework:
+- `.agents/skills/job-application-assistant/04-job-evaluation.md`
+- `.agents/skills/job-application-assistant/01-candidate-profile.md`
+
+Using the framework from `04-job-evaluation.md`, evaluate the job posting against the candidate's profile. If the salary lookup tool is configured, run:
+
+```bash
+python salary_lookup.py "<Company Name>" --json
+```
+
+If the posting specifies a city, add `--city "<City>"` to narrow results. Parse the JSON output and include the salary benchmark in the evaluation. If the tool is not configured or returns an error, skip the salary benchmark.
+
+Present the evaluation to the user with:
+
+1. **Skills match** - which required/preferred skills match vs. gaps
+2. **Experience match** - how work history maps to the role
+3. **Behavioral/culture match** - how behavioral profile fits the role/company culture
+4. **Salary benchmark** - salary index for the company (if available)
+5. **Overall fit score** and recommendation (strong fit / moderate fit / weak fit)
+
+After presenting the evaluation, ask the user:
+> "Should I proceed with drafting the CV and cover letter for this role?"
+
+**If the user says no, stop here.** If yes, continue to Step 2.
+
+---
+
+## Step 2: DRAFTER - Draft CV + Cover Letter
+
+You already have `01-candidate-profile.md` and `04-job-evaluation.md` in context from Step 1. **Do not re-read them.**
+
+Read only the reference files you do not yet have:
+- `.agents/skills/job-application-assistant/03-writing-style.md`
+- `.agents/skills/job-application-assistant/05-cv-templates.md`
+- `.agents/skills/job-application-assistant/06-cover-letter-templates.md`
+
+Also read the most recent existing CV and cover letter files for concrete structural reference (one of each is enough):
+- Read any existing `cv/main_*.tex` file as a LaTeX template reference
+- Read any existing `cover_letters/cover_*.tex` or `cover_letters/Cover_*.tex` file as a template reference
+
+### CV (`cv/main_<company>.tex`)
+- Always in **English**
+- Follow the moderncv/banking format from `05-cv-templates.md`
+- Tailor the profile statement and experience bullets to the specific role
+- Reframe skills and achievements to match job requirements
+- Keep to 2 pages
+
+### Cover Letter (`cover_letters/cover_<company>_<role>.tex`)
+- **Match the language of the job posting** (Danish posting -> Danish cover letter, English posting -> English cover letter)
+- Follow the structure from `06-cover-letter-templates.md`
+- Use the `cover.cls` template
+- Tailor the opening paragraph to the specific role and company
+- Address to a named person if available in the posting, otherwise "Dear Hiring Manager" (or equivalent in posting language)
+- Keep to approximately one page
+- Any mention of agentic coding or AI tooling must reference **Codex** by name
+
+Write both files to disk. Keep the exact text of both drafts in working memory — you will use them in the reviewer pass in Step 3 and revise them in Step 4 without re-reading.
+
+---
+
+## Step 3: REVIEWER - Research & Critique
+
+Run a separate reviewer pass in the root Codex context. Treat the block below as the reviewer brief. Do not use a subagent unless the user explicitly asks for one or an active goal workflow permits it.
+
+Use the drafts already in context. Scope any additional file reads to content-critique essentials only — the reviewer pass does not need the LaTeX template files (`05`, `06`) to critique content, since those govern structural/LaTeX concerns the drafter already applied.
+
+Replace `<COMPANY>`, `<ROLE>`, `<INSERT_JOB_POSTING_TEXT_HERE>`, `<INSERT_CV_DRAFT_HERE>`, and `<INSERT_COVER_LETTER_DRAFT_HERE>` with actual values before running the reviewer pass.
+
+```
+You are a hiring manager proxy reviewing a job application. Your job is to make the application as targeted and compelling as possible.
+
+## Your Tasks
+
+### 1. Research the Company
+Use available web search tools and available web fetch tools to research:
+- The company's website, mission, and recent news
+- The specific department or team (if mentioned in the posting)
+- Any recent projects, press releases, or strategic initiatives relevant to the role
+- Company culture and values
+
+### 2. Read Reference Materials (content-critique only)
+Read these four files — and only these — to ground your critique:
+- `.agents/skills/job-application-assistant/01-candidate-profile.md`
+- `.agents/skills/job-application-assistant/02-behavioral-profile.md` — use this specifically to check whether the cover letter's voice matches the candidate's natural register. A "Collaborator" PI profile, for example, should not be given a combative, solo-hero tone; a "Persuader" profile should not be given over-hedged, apologetic phrasing.
+- `.agents/skills/job-application-assistant/03-writing-style.md`
+- `.agents/skills/job-application-assistant/04-job-evaluation.md`
+
+Do NOT read `05-cv-templates.md` or `06-cover-letter-templates.md` — those govern LaTeX structure the drafter already applied and are not needed for content critique.
+
+### 3. Drafts to Review
+Both drafts are provided inline below. Do NOT use the available file/PDF reading tools on the draft files — use these exact texts.
+
+<CV_DRAFT file="cv/main_<COMPANY>.tex">
+<INSERT_CV_DRAFT_HERE>
+</CV_DRAFT>
+
+<COVER_LETTER_DRAFT file="cover_letters/cover_<COMPANY>_<ROLE>.tex">
+<INSERT_COVER_LETTER_DRAFT_HERE>
+</COVER_LETTER_DRAFT>
+
+### 4. Job Posting
+<JOB_POSTING>
+<INSERT_JOB_POSTING_TEXT_HERE>
+</JOB_POSTING>
+
+### 5. Produce Feedback
+
+Return your feedback in **two parts**:
+
+**Part A — Structured edits (preferred format whenever possible):**
+A JSON array of concrete edits the drafter can apply directly without re-reading the files. Each edit is an object:
+```json
+{
+  "file": "cv/main_<COMPANY>.tex" | "cover_letters/cover_<COMPANY>_<ROLE>.tex",
+  "old_string": "<exact text currently in the draft>",
+  "new_string": "<replacement text>",
+  "reason": "<one-line rationale: keyword match / company angle / reframing / style>"
+}
+```
+Only use this format when you can quote the exact `old_string` from the drafts above. Make `old_string` unique — include enough surrounding context so it matches exactly once per file.
+
+**Part B — Narrative suggestions (for judgment calls that are not mechanical edits):**
+Prose suggestions grouped by category. Produce each category even if your finding is "no issues" — silence on a category can be mistaken for skipping it.
+- **Missed keywords/requirements** — what to add and roughly where, if it cannot be expressed as a clean string replacement
+- **Company/department-specific angles** — connections between experience and the company's strategic priorities, based on your research
+- **Action-oriented reframing** — identify passive, generic, or low-energy statements and suggest action-oriented rewrites. Use this category especially for structural weakness that doesn't fit a single-sentence swap (e.g., "the whole opening paragraph reads as passive — restructure around your single strongest match to the posting").
+- **Tone and style issues** — check against `03-writing-style.md` AND `02-behavioral-profile.md`. Flag any issues with tone, formality, or voice (cliches, hedging, over-humility, inconsistent register), and specifically flag any mismatch between the letter's voice and the candidate's natural register as described in the behavioral profile.
+
+**CRITICAL RULE:** All suggestions must be grounded in actual profile data. Do NOT suggest fabricating skills, experience, or achievements. If a requirement is a gap, say so honestly and suggest how to frame adjacent experience instead.
+
+Do **not** run a verification checklist — the drafter will do that in the final step. Focus on content critique.
+
+Return Part A and Part B together as a single structured message.
+```
+
+---
+
+## Step 4: DRAFTER - Revise Based on Feedback
+
+Once the reviewer pass returns its feedback:
+
+1. **Apply Part A (structured edits) directly with targeted file-editing tools.** Do NOT re-read the draft files — you already have them in context from Step 2, and the reviewer's `old_string` values were quoted from that same text. For each edit in the JSON array, replace the given `old_string` with `new_string` in `file`. Skip any whose rationale would require fabricating content.
+2. **Apply Part B (narrative suggestions)** using judgment. These need interpretation, not mechanical replacement. Walk through every Part B category the reviewer returned and address it:
+   - **Missed keywords/requirements:** add the keyword or capability where it fits naturally in the CV or cover letter. Prefer the experience bullets (concrete evidence) over the profile statement (abstract claim).
+   - **Company/department-specific angles:** weave the reviewer's research into the cover letter opening or motivation paragraph. Verify every company claim via available web/search tools before including it — do not trust reviewer research at face value.
+   - **Action-oriented reframing:** rewrite passive or generic phrasing (CV profile statement, cover letter opening, bullet leads). Structural weakness that the reviewer flagged without a clean JSON edit lives here.
+   - **Tone and style issues:** apply the writing-style-guide fixes (no em-dashes, no cliches, no apologetic hedging, consistent first-person active voice).
+   Make targeted file edits; only re-read a file if an edit fails because the surrounding text has shifted.
+3. Do NOT incorporate any suggestion that would fabricate skills or experience. If a posting requirement is a genuine gap, acknowledge it honestly and frame adjacent experience instead.
+
+After all edits are applied, the two files on disk are the final drafts.
+
+---
+
+## Step 5: DRAFTER - Compile & Inspect PDFs (MANDATORY)
+
+**Never skip this step.** The `.tex` files looking fine is not sufficient — LaTeX page-break decisions are unpredictable and commonly produce broken layouts (orphaned job titles separated from their bullets, cover letters spilling to 2 pages, bullet fonts not matching body text). Compile both documents and visually verify the PDFs before presenting.
+
+### 5a. Compile
+
+```bash
+cd cv && lualatex -interaction=nonstopmode main_<company>.tex
+cd ../cover_letters && xelatex -interaction=nonstopmode cover_<company>_<role>.tex
+```
+
+- CV uses **lualatex** — pdflatex fails on modern MiKTeX with fontawesome5 font-expansion errors. lualatex handles the same sources cleanly.
+- Cover letter uses **xelatex** — cover.cls requires fontspec.
+
+If either compile fails, fix the error and re-compile until clean.
+
+### 5b. Inspect layout
+
+Read both PDFs via the available file/PDF reading tools and verify:
+
+**CV (`cv/main_<company>.pdf`):**
+- [ ] Exactly 2 pages (not 1, not 3)
+- [ ] No orphaned `\cventry` titles — a job/education title line must never sit alone at the bottom of page 1 with its bullets on page 2. This is the most common failure.
+- [ ] Section headings are not isolated at the top of page 2 with only 1-2 lines below
+- [ ] No awkward whitespace gaps
+
+**Cover letter (`cover_letters/cover_<company>_<role>.pdf`):**
+- [ ] Exactly 1 page
+- [ ] Signature block visible, not cut off or pushed to a second page
+- [ ] Bullet list font matches surrounding body text (both should be Raleway-Medium)
+
+### 5c. Iterate until clean
+
+If the layout has problems, edit the `.tex` files and recompile. Common fixes (see `05-cv-templates.md` and `06-cover-letter-templates.md` for full details):
+
+- **Orphaned CV entry title:** `\usepackage{needspace}` in preamble, then `\needspace{5\baselineskip}` immediately before the problematic `\cventry`
+- **CV spills to page 3 with only a trailing section:** `\enlargethispage{2-3\baselineskip}` before a late section
+- **Substantial content on page 3:** cut content using **relevance-weighted cutting** (see `05-cv-templates.md` → "Relevance-weighted cutting"). Score each candidate line by (a) relevance to THIS posting's keywords and responsibilities, (b) uniqueness (is it duplicated elsewhere?), (c) narrative load (does the cover letter depend on it?). Cut the lowest-total-score line first, regardless of section. Do NOT mechanically apply a static section-based priority order — an older-role bullet that hits posting keywords is worth more than a recent-role bullet that does not.
+- **Cover letter itemize breaks compile or uses wrong font:** close `\lettercontent{}` before the list, wrap the list in `{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont \begin{itemize}...\end{itemize}\par}`
+- **Cover letter spills to 2 pages:** trim using the same relevance-weighted logic. First cut: sentences that restate what a bullet already said. Second cut: a bullet that does not hit posting keywords. Last resort: a bullet that does hit posting keywords. Never reduce geometry or line spacing.
+
+Do not proceed to Step 6 until both PDFs pass inspection.
+
+### 5d. ATS & keyword verification (CV)
+
+An ATS parser reads the PDF's embedded **text layer**, not the rendered page — a CV that passed visual inspection can still extract as garbage (icon glyphs where the contact details should be, scrambled reading order in multi-column layouts). This step verifies what a parser actually sees. It applies to the **CV only**; cover letters rarely go through keyword screening.
+
+**Availability check:** run `pdftotext -v`. `pdftotext` (poppler) is an optional dependency, not part of TeX distributions. If it is missing, print a one-line warning that the mechanical parse check is skipped, do the keyword-coverage check (item 3 below) against your visual Read of the PDF instead, and note the degraded mode in the Step 6 report. Same graceful-skip pattern as the salary lookup.
+
+**1. Extract the text layer:**
+
+```bash
+cd cv && pdftotext -layout main_<company>.pdf main_<company>.txt
+```
+
+Read the `.txt` file.
+
+**2. Parseability checks** on the extracted text:
+
+- [ ] **Text extracted at all**, with no garbage runs: no `(cid:NNN)` markers, no `�` replacement characters, no stretches of missing text that are visible in the PDF
+- [ ] **Email and phone survive as literal text.** Icon fonts extract as glyph names (the stock template's contact line extracts as `MOBILE-ALT [+XX ...] • Envelope [your.email@...]`) — that noise is harmless, but the actual address and digits must be present. A contact detail carried only by an icon or a hyperlink target (like the `LinkedIn` link text) is invisible to an ATS; the email must be printed as text.
+- [ ] **Reading order matches the visual order** — section headings appear in the same sequence as on the page, and lines from different sections are not interleaved. The stock banking template is single-column and safe; custom templates registered via `/add-template` with sidebars or multi-column layouts are where this breaks.
+- [ ] **Dates recognizable** — each role and degree has its years present in the extraction.
+
+Failures here are template-level problems: fix them in the `.tex` (e.g. print the email as text rather than icon-only), then re-run 5a–5c and re-extract. If a custom template's layout fundamentally scrambles extraction order, tell the user prominently — they may be trading ATS compatibility for looks.
+
+**3. Keyword coverage.** Reuse the required/preferred keyword list you extracted in Step 1 — do not re-derive it. Match each keyword against the extracted text, **in the posting's language** (a Danish posting's keywords are matched in Danish even though the CV is in English — where the CV legitimately covers the concept in English, count it as synonym-only and note the language difference). Report a table:
+
+| Keyword | Priority | Status | Note |
+|---------|----------|--------|------|
+| ... | required/preferred | covered / synonym-only / missing (have it) / missing (gap) | where it appears, or why absent |
+
+- **covered** — the term appears (verbatim or trivial inflection).
+- **synonym-only** — the concept is present under a different term. If the posting's exact term is truthfully applicable per the profile, prefer the posting's term (ATS keyword matches are often literal).
+- **missing (have it)** — the profile shows the candidate genuinely has this skill but the CV never says it: add it where it fits naturally, preferring experience bullets (concrete evidence) over the profile statement, then re-run 5a–5c.
+- **missing (gap)** — a genuine gap: leave it missing. **Never stuff keywords.** This is the same honesty rule the reviewer follows — a gap gets acknowledged in the cover letter's framing, not hidden in the CV.
+
+**4. Clean up:** delete the extracted `.txt` file.
+
+### 5e. Clean up build artifacts
+
+After the final clean compile, delete the `.aux`, `.log`, `.out` files (keep the `.tex` and `.pdf`).
+
+---
+
+## Step 6: Present Final Output
+
+Run the full verification checklist from `AGENTS.md` now — this is the **only** verification pass in the workflow. Re-read both files once here to verify final state on disk matches your mental model after the Step 4 and Step 5 edits.
+
+### Verification Checklist
+Report pass/fail for each item in the AGENTS.md verification checklist (factual accuracy, targeting, consistency, quality).
+
+### Key Tailoring Decisions
+Summarize 3-5 key decisions made to tailor the application:
+- What was emphasized and why
+- What company-specific angles were incorporated
+- What the reviewer suggested that was most impactful
+- Any gaps that were acknowledged or reframed
+
+### Files Created
+List the files written:
+- `cv/main_<company>.tex`
+- `cover_letters/cover_<company>_<role>.tex`
+
+Tell the user: "Both files are ready for your review. Open them to check the final output before compiling."
+
+Also mention: once they have actually submitted the application, `/outcome <company>` logs it in the tracker and starts the per-application record that `/setup` later uses to calibrate the fit framework.

--- a/.agents/skills/expand/SKILL.md
+++ b/.agents/skills/expand/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: expand
+description: Expand the candidate profile from documents and online presence. Use when the user asks for /expand, competency discovery, or enriching profile skills.
+---
+
+# /expand - Competency Expansion from Documents and Online Presence
+
+You are enriching the candidate profile by discovering competencies hidden in documents and public online presence. This command is additive only — it never modifies existing profile content, only extends it.
+
+Follow these steps **exactly in order**. Do not skip steps.
+
+---
+
+## Step 0: Read Existing Profile Files
+
+Read these two files in parallel before doing anything else. You must know what is already there so you do not propose duplicates.
+
+- `.agents/skills/job-application-assistant/01-candidate-profile.md`
+- `.agents/skills/job-application-assistant/02-behavioral-profile.md`
+
+Hold this content in context throughout the command. Do not re-read these files later.
+
+---
+
+## Step 1: Discovery — Scan All Sources
+
+Scan every available source for "experience items" — anything that implies skill, knowledge, or competency. Process sources in this order.
+
+### 1a. documents/cv/
+Read all files in `documents/cv/`. Extract:
+- Every course or module listed (including university coursework and online courses)
+- Every certification mentioned, with issuer and date
+- Every job responsibility bullet point (tools, methods, outcomes)
+- Every independent project or side project
+- Every volunteer or extracurricular role
+
+### 1b. documents/linkedin/
+Read all files in `documents/linkedin/`. Extract:
+- Courses and certifications in the "Licenses & Certifications" section
+- Skills and endorsements list
+- Volunteer experiences
+- Projects section
+- Any platform-specific items not already found in the CV
+
+### 1c. documents/diplomas/
+Read all files in `documents/diplomas/`. Extract:
+- All course/module names listed on transcripts
+- Thesis title and subject area
+- Any specialisation or track name
+
+### 1d. documents/references/
+Read all files in `documents/references/`. Extract:
+- Competency language used by the referee (what skills or qualities they mention)
+- Any specific projects, tools, or methods named
+
+### 1e. GitHub Profile
+Look up the GitHub username from `01-candidate-profile.md`. If a GitHub URL or username is present:
+
+1. Use available web fetch tools or available web search tools to retrieve the public profile and pinned repositories
+2. For each repository found:
+   - Fetch the repository README
+   - Note: name, description, primary language(s), topics/tags, any frameworks or libraries mentioned in the README
+3. Also retrieve the full repository list if available (to catch unpinned repos)
+
+If no GitHub username or URL is found in the profile, skip this source and note it was skipped.
+
+### 1f. Other URLs in Profile
+Check `01-candidate-profile.md` for any other URLs (portfolio site, personal website, Kaggle, Google Scholar, ResearchGate, publication links). For each:
+- Fetch the page
+- Extract any tools, methods, datasets, awards, or skills mentioned
+
+---
+
+## Step 2: Web Enrichment
+
+For each experience item discovered in Step 1, search the web to extract the competencies it implies. Apply both approaches below — do not choose one over the other.
+
+### Approach A: Direct lookup (explicit tools and frameworks)
+If the item names a specific tool, framework, library, method, or platform, search for it directly:
+- `"[Course name] [Provider] syllabus learning outcomes"`
+- `"[Certification name] skills covered exam guide"`
+- `"[Tool/framework name] skills what you learn"`
+
+Fetch the most relevant page and extract the competency list.
+
+### Approach B: Inferred competencies (from description and context)
+For each item, regardless of whether Approach A found anything, also reason from the description:
+- What problem domain does this item address?
+- What methods, skills, or knowledge does someone need to do this work?
+- What is the standard toolchain for this kind of work?
+
+Combine both approaches into a single competency list for each item.
+
+### Prioritise web lookup for:
+- Named online courses (Coursera, edX, Udemy, LinkedIn Learning, DataCamp, fast.ai, etc.)
+- Named certifications (AWS, GCP, Azure, Databricks, Tableau, etc.)
+- University courses with a standard syllabus
+- GitHub repositories with a README that names specific technologies
+
+### Infer (without web lookup) for:
+- Generic job responsibility bullets with no named tool
+- Vague project descriptions
+- Reference letter language (already phrased as competency — just record it)
+
+---
+
+## Step 3: Build Competency Map
+
+After enriching all items, build a deduplicated competency map. Group findings into these categories:
+
+- **Technical Skills — Primary** (core languages, frameworks, methods you use regularly)
+- **Technical Skills — Secondary** (tools you have used but are not primary)
+- **Domain Knowledge** (subject matter expertise: geophysics, ML, NLP, etc.)
+- **Methods and Practices** (agile, version control, reproducibility, testing, etc.)
+- **Soft / Behavioral** (leadership, communication, collaboration signals from references and project descriptions)
+
+For each competency, record:
+- The competency name
+- The source item it came from (e.g. "Coursera — Deep Learning Specialisation", "GitHub — repo-name", "Reference letter — Jens Jensen")
+- Whether it came from direct lookup (A), inference (B), or both
+
+Remove anything already present in `01-candidate-profile.md` or `02-behavioral-profile.md`.
+
+---
+
+## Step 4: Present Grouped Summary
+
+Present all new competencies for the user's review before writing anything. Format:
+
+```
+## /expand found [N] new competency signals across [M] sources
+
+**COURSES & CERTIFICATIONS**
+Source: [Course/cert name — Provider]
+  + [Competency 1]
+  + [Competency 2]
+  ...
+
+**GITHUB — [repo-name]**
+Source: README + inferred from tech stack
+  + [Competency 1]
+  + [Competency 2]
+  ...
+
+**JOB RESPONSIBILITIES — [Company, Role]**
+Source: CV bullets + direct tool lookup
+  + [Competency 1]
+  ...
+
+**BEHAVIORAL SIGNALS**
+Source: [Reference letter — Name / LinkedIn About / Project leadership]
+  + [Signal 1]
+  ...
+
+[more sections as needed]
+```
+
+Then ask:
+
+> **How would you like to proceed?**
+>
+> - **`all`** — Add everything above to your profile
+> - **`review`** — I'll walk you through each source group one at a time
+> - **`skip`** — Cancel without writing anything
+>
+> Or list specific groups to skip (e.g. "skip GitHub, add everything else").
+
+Wait for the user's response before writing anything.
+
+---
+
+## Step 5: Write Confirmed Additions
+
+Apply only the confirmed items. Use the targeted file-editing tools to add to the relevant sections of each file — do not rewrite entire files.
+
+### Additions to `01-candidate-profile.md`
+- Technical skills (primary and secondary) → append to the Technical Skills section
+- Domain knowledge → append to the Domain Knowledge or Technical Skills section (match the existing structure)
+- Methods and practices → append appropriately
+
+For each addition, add a brief source annotation in a comment or parenthetical: *(Coursera — Deep Learning Specialisation)*, *(GitHub — project-name)*, etc. This makes future `/expand` runs idempotent.
+
+### Additions to `02-behavioral-profile.md`
+- Soft/behavioral signals → append to the "Strongest Behavioral Traits" or "How I Work Best" section (match existing structure)
+- Always label inferred behavioral additions: *[Inferred from reference letter — Name / review before relying on this]*
+
+---
+
+## Step 6: Summary Report
+
+After writing, present:
+
+```
+## /expand Complete
+
+### Added to 01-candidate-profile.md
+[List each competency added, with source]
+
+### Added to 02-behavioral-profile.md
+[List each behavioral signal added, with source]
+
+### Sources processed
+[List each source scanned and how many competencies it yielded]
+
+### Sources skipped
+[List any sources that were missing, empty, or yielded nothing new — with brief reason]
+
+### Needs manual review
+[Any items that were ambiguous, partially readable, or where web lookup returned no clear syllabus]
+```
+
+---
+
+## Design Principles
+
+- **Additive only.** This command never modifies existing profile content. It only appends.
+- **Source-traceable.** Every addition records where it came from, so future runs are idempotent and the user can verify or remove individual items later.
+- **Both approaches, always.** Web lookup and inference are applied together — not as alternatives. A named course gets its official syllabus AND a reasoned competency list.
+- **User confirms before writing.** The full competency map is shown and confirmed before a single file is touched.
+- **Behavioral signals are labeled.** Anything inferred from tone, language, or indirect signals is marked as inferred so it is reviewed critically.
+- **GitHub is fully scanned.** All public repositories are checked, not just pinned ones — unpinned repos often contain significant competency signals.

--- a/.agents/skills/job-application-assistant/01-candidate-profile.md
+++ b/.agents/skills/job-application-assistant/01-candidate-profile.md
@@ -1,0 +1,60 @@
+# Candidate Profile
+
+<!-- SETUP: This file is populated by running /setup -->
+<!-- After running /setup, all sections will be filled with your actual information -->
+
+## Identity
+- **Name:** [YOUR_NAME]
+- **Location:** [YOUR_ADDRESS]
+- **Phone:** [YOUR_PHONE]
+- **Email:** [YOUR_EMAIL]
+- **LinkedIn:** [YOUR_LINKEDIN_URL]
+- **GitHub:** [YOUR_GITHUB_URL]
+- **Languages:** [YOUR_LANGUAGES with proficiency levels]
+- **Status:** [YOUR_EMPLOYMENT_STATUS]
+- **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
+
+## Education
+
+| Degree | Period | Institution | Key Topics |
+|--------|--------|-------------|------------|
+| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+
+## Professional Experience
+
+### [JOB_TITLE] - [COMPANY] ([START] - [END])
+[LOCATION]
+- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
+- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
+- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+
+<!-- Add more roles as needed -->
+
+## Independent Projects
+<!-- Projects outside of employment: freelance, open source, personal -->
+- **[PROJECT_NAME]**: [DESCRIPTION]
+
+## Technical Skills
+
+### Programming & ML
+- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
+- [OTHER_SKILLS]
+
+### Domain Expertise
+- [DOMAIN_1]
+- [DOMAIN_2]
+
+### Software & Tools
+- [TOOL_LIST]
+
+## Publications
+<!-- List peer-reviewed publications, if any -->
+1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+
+## Awards
+- [AWARD] - [EVENT] ([YEAR])
+
+## References
+- [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])
+
+More references available upon request.

--- a/.agents/skills/job-application-assistant/02-behavioral-profile.md
+++ b/.agents/skills/job-application-assistant/02-behavioral-profile.md
@@ -1,0 +1,50 @@
+# Behavioral Profile
+
+<!-- SETUP: This file is populated by running /setup -->
+<!-- You can use results from PI, DISC, Myers-Briggs, StrengthsFinder, or a self-assessment -->
+
+## Overview
+[YOUR_NAME]'s behavioral assessment identifies them as a **[PROFILE_TYPE]** pattern. [1-2 SENTENCE_SUMMARY].
+
+## Core Behavioral Drives
+
+| Drive | Level | Meaning |
+|-------|-------|---------|
+| [DRIVE_1] | [LEVEL] | [DESCRIPTION] |
+| [DRIVE_2] | [LEVEL] | [DESCRIPTION] |
+| [DRIVE_3] | [LEVEL] | [DESCRIPTION] |
+| [DRIVE_4] | [LEVEL] | [DESCRIPTION] |
+
+## Strongest Behaviors
+- **[BEHAVIOR_1]:** [DESCRIPTION]
+- **[BEHAVIOR_2]:** [DESCRIPTION]
+- **[BEHAVIOR_3]:** [DESCRIPTION]
+
+## How You Work Best
+- [ENVIRONMENT_PREFERENCE_1]
+- [ENVIRONMENT_PREFERENCE_2]
+- [ENVIRONMENT_PREFERENCE_3]
+
+## Growth Areas (frame positively in applications)
+- **[AREA_1]:** [HOW_TO_FRAME_IT_POSITIVELY]
+- **[AREA_2]:** [HOW_TO_FRAME_IT_POSITIVELY]
+
+## Mapping to Job Posting Language
+
+When a job posting mentions these keywords, it's a **strong behavioral fit**:
+- [KEYWORD_OR_PHRASE_THAT_MATCHES_YOUR_STYLE]
+- [ANOTHER_KEYWORD]
+
+When a job posting mentions these, flag as **potential friction** (not deal-breaker):
+- [KEYWORD_OR_PHRASE_THAT_MIGHT_CLASH]
+- [ANOTHER_KEYWORD]
+
+## Management Style Preferences
+- [WHAT_MANAGEMENT_STYLE_WORKS_FOR_YOU]
+- [WHAT_DOESN'T_WORK]
+
+## Using This in Applications
+- **Cover letters:** [HOW_TO_WEAVE_IN_BEHAVIORAL_STRENGTHS]
+- **CV:** [WHAT_TO_EMPHASIZE]
+- **Interviews:** [WHAT_STAR_EXAMPLES_TO_USE]
+- **Don't overstate:** [WHAT_NOT_TO_CLAIM]

--- a/.agents/skills/job-application-assistant/03-writing-style.md
+++ b/.agents/skills/job-application-assistant/03-writing-style.md
@@ -1,0 +1,106 @@
+# Writing Style Guide
+
+## Critical Rules
+
+1. **NO em-dashes (--).**  Use commas, periods, or restructure the sentence instead.
+2. **NO cliches or filler phrases.** Cut: "I am passionate about", "I believe I would be a great fit", "leverage my skills", "hit the ground running", "drive results", "synergies".
+3. **NO generic buzzwords** without concrete backing. Every claim must be supported by a specific example or fact.
+4. **NO apologetic or overly humble language.** Not "I think I could contribute" but "I bring X, demonstrated by Y."
+5. **NO unverified company claims.** Every company-specific statement in a cover letter (partnerships, product names, technology descriptions, expansions) must be independently verified with available web/search tools before inclusion. Do not trust reviewer research at face value. If a claim cannot be verified, rephrase it in general terms or omit it.
+6. **Reframe emphasis, not substance.** Some framing of experience toward the target role is expected. But apply the **interview backtrack test**: could the candidate comfortably explain this bullet in an interview without backtracking? If they'd have to say "well, what I actually meant was..." then it's too far. Specifically:
+   - **OK:** Reordering experience to lead with what's most relevant; using natural synonyms for the target domain; emphasizing one aspect of a broad role.
+   - **Flag it:** Combining academic + industry experience into a single claim that implies it was all industry; describing work using the posting's specific terminology when the actual work was adjacent but not the same.
+   - **Never:** Claiming experience the candidate doesn't have; implying they worked in a domain they haven't.
+   When a bullet falls in the "flag it" zone, present it to the user after drafting with: "This bullet is a stretch because X. Keep, soften, or drop?" If the evaluation experience match score is below 50, warn before proceeding to drafting that extensive reframing would be needed.
+
+## Tone
+- **Warm but direct.** Friendly and approachable, but confident without arrogance.
+- **Conversational professional.** Not stiff corporate-speak, not casual chat. Think: how a confident person talks in a good job interview.
+- **First person, active voice.** "I built" not "a system was developed by the candidate."
+- **Demonstrate, don't state.** Instead of "I am a team player", write a specific example of teamwork and its outcome.
+
+## Application Headline (Best Practice)
+
+The subject line / headline of the application should be engaging and specific, not generic.
+
+**Bad:** "Application for Sales Engineer Position" / "Ansogning til stilling som ingeniør"
+**Good:** "[Your specialty] specializing in [relevant keyword from posting]"
+
+Formula: **[Title/education] + [relevant keyword from the job posting]**
+
+## Scannable Structure (Best Practice)
+
+Employers scan applications quickly. Structure for easy reading:
+- Use descriptive subheadings that reflect content (not just "Introduction" / "Body")
+- Include industry-specific keywords in headings where natural
+- Write concisely - eliminate filler language
+- One page maximum (hard rule)
+
+## Forward-Looking Framing (Best Practice)
+
+The cover letter is **not a CV repetition**. It should be forward-looking:
+- Focus on **tasks you can solve for the employer**, not just what you've done before
+- Describe your approach: methods, tools, knowledge you'll bring
+- Explain what positive outcomes the employer can expect from hiring you
+- Use 1-2 brief past examples only to back up forward-looking claims
+
+## Cover Letter Structure
+
+### Opening Paragraph
+- State the role and why you're writing (1 sentence)
+- Immediately connect your background to the role (1-2 sentences)
+- Make it specific to this company/role, not a template opener
+
+### Body Paragraphs - Task-Solving Focus
+- Lead with the most relevant experience for this specific role
+- Frame content around **which of their tasks you can solve and how**
+- Describe your approach: methods, tools, and knowledge you'll bring
+- Use bullet lists for concrete skills/achievements when appropriate (3-5 bullets)
+- Each bullet should be specific and outcome-oriented
+- Include at least one example that shows initiative
+- Include 1-2 brief examples of past success, but keep the focus forward-looking
+
+### Motivation / Why This Company (place early)
+- The **first section** after the opening should explain why you're applying to *this specific company*
+- Use language and themes from the job posting and company website
+- Focus on how you'll contribute to their goals, not what you gain from employment
+- If you spoke with someone at the company, reference the conversation naturally
+
+### Company-Specific Paragraph
+- Show you've researched the company (mention specific projects, values, or market position)
+- Explain why this company specifically, not just "a company like yours"
+- Connect domain knowledge to their business context
+
+### Closing
+- Brief, confident, forward-looking
+- "I look forward to hearing from you" or "I would welcome the opportunity to discuss..."
+- No begging or over-enthusiasm
+
+## Bullet Point Style
+- Start with action verb or bold category label
+- Be specific: numbers, tools, outcomes
+- Vary the structure (not every bullet starts the same way)
+
+## Language for Different Role Types
+
+### Technical/ML roles
+- Lead with programming languages, ML frameworks, specific model architectures
+- Mention datasets, data volumes, pipeline complexity
+- Include independent projects
+
+### Domain-specific roles
+- Lead with domain expertise and specific methods
+- Frame technical skills as tools that enhance domain analysis
+
+### Consulting/Advisory roles
+- Lead with stakeholder communication, project coordination, client interaction
+- Emphasize ability to bridge technical and business perspectives
+
+### Leadership/Senior roles
+- Lead with project management, mentoring, course development
+- Frame advanced degrees as evidence of independent project delivery
+
+## Multi-language Applications
+- Default to the language of the job posting
+- Cover letters in the posting's language should feel natural, not translated
+- Slightly warmer, more personal tone may be acceptable in some languages

--- a/.agents/skills/job-application-assistant/04-job-evaluation.md
+++ b/.agents/skills/job-application-assistant/04-job-evaluation.md
@@ -1,0 +1,173 @@
+# Job Evaluation Framework
+
+<!-- SETUP: Skill match areas and career goals are personalized by running /setup -->
+
+## Scoring Dimensions
+
+Evaluate each job posting against these five dimensions:
+
+### 1. Technical Skills Match (0-100)
+How well do the required/preferred skills align with the candidate's capabilities?
+
+| Score | Meaning |
+|-------|---------|
+| 80-100 | Core requirements are primary skills |
+| 60-79 | Most requirements match, 1-2 gaps that are learnable |
+| 40-59 | Partial match, significant upskilling needed |
+| 0-39 | Fundamental mismatch |
+
+**Strong match areas:** [YOUR_PRIMARY_SKILLS]
+**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
+**Weak match areas:** [SKILLS_YOU_LACK]
+
+### 2. Experience Match (0-100)
+Does work history align with what they're looking for?
+
+| Score | Meaning |
+|-------|---------|
+| 80-100 | Direct experience in the same domain and role type |
+| 60-79 | Related experience, transferable skills clear |
+| 40-59 | Adjacent experience, would need to make the case |
+| 0-39 | Unrelated experience |
+
+**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
+**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
+**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+
+### 3. Behavioral/Culture Fit (0-100)
+Does the role and company culture match the behavioral profile?
+
+| Score | Meaning |
+|-------|---------|
+| 80-100 | Culture strongly matches behavioral preferences |
+| 60-79 | Mixed signals but mostly compatible |
+| 40-59 | Some friction areas |
+| 0-39 | Significant culture mismatch |
+
+**Red flags to research:** Department disorganization, work dominated by maintenance over development, poor chemistry with leadership, culture mismatches. Check reviews, media coverage, LinkedIn connections, and network contacts for insider perspective.
+
+### 4. Location & Logistics (Pass/Fail + Notes)
+- Within commute range: PASS
+- Remote with occasional office: PASS
+- Requires relocation: FAIL (deal-breaker)
+- Frequent international travel: FLAG (discuss with user)
+
+### 5. Career Alignment & Motivation (0-100)
+Does this role advance career goals and contain tasks that energize?
+
+| Score | Meaning |
+|-------|---------|
+| 80-100 | Strongly aligned with career direction, clear growth path |
+| 60-79 | Good role but only partially aligned with long-term goals |
+| 40-59 | Decent job but doesn't build toward career goals |
+| 0-39 | Dead end or backwards step |
+
+**Career goals:**
+- [YOUR_CAREER_GOAL_1]
+- [YOUR_CAREER_GOAL_2]
+- [YOUR_CAREER_GOAL_3]
+
+**Motivation filter:** Evaluate not just whether you *can* do the tasks, but whether the tasks will *energize* you. Consider:
+- Tasks that energize: [YOUR_ENERGIZING_TASKS]
+- Tasks that drain: [YOUR_DRAINING_TASKS]
+- Non-task factors: leadership style, department culture, company values, degree of autonomy
+
+**Life situation alignment:** Consider personal constraints:
+- **Security**: [YOUR_FINANCIAL_SITUATION_CONTEXT]
+- **Flexibility**: [YOUR_SCHEDULE_CONSTRAINTS]
+- **Professional development**: [YOUR_GROWTH_PRIORITIES]
+
+### 6. Salary Benchmark (Optional)
+
+If the salary lookup tool is configured (`salary_data.json` exists), look up the company:
+```
+python salary_lookup.py "<Company Name>" --json
+```
+
+If a city is known from the posting, add `--city "<City>"` to narrow results.
+
+Present findings as:
+```
+### Salary Benchmark
+| Metric | Value |
+|--------|-------|
+| [Category] index | XX.X (+/-X.X% vs baseline) |
+| Overall index | XX.X (+/-X.X% vs baseline) |
+```
+
+Interpret results relative to the baseline defined in the data file's metadata. For index-based data, higher typically means above-market compensation.
+
+If the salary tool is not configured, skip this section.
+
+## Output Format
+
+Present the evaluation as:
+
+```
+## Job Fit Evaluation: [Role] at [Company]
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Technical Skills | XX/100 | [brief note] |
+| Experience Match | XX/100 | [brief note] |
+| Behavioral Fit | XX/100 | [brief note] |
+| Location | PASS/FAIL | [brief note] |
+| Career Alignment | XX/100 | [brief note] |
+
+**Overall Score: XX/100** (weighted average of scored dimensions)
+
+### Verdict: [Strong Fit / Good Fit / Moderate Fit / Weak Fit / Poor Fit]
+
+### Key Strengths for This Role
+- [bullet points]
+
+### Gaps to Address
+- [bullet points]
+
+### Recommendation
+[1-2 sentences: apply/skip/apply with caveats]
+
+### Company Research Checklist
+- [ ] Checked company website (mission, values, recent news)
+- [ ] Checked review sites (Glassdoor, Jobindex, etc.)
+- [ ] Checked LinkedIn for team size, recent hires, connections
+- [ ] Checked media for restructuring, growth, or workplace issues
+- [ ] Identified network contacts who may know the team/manager
+```
+
+## Weighting
+- Technical Skills: 30%
+- Experience Match: 25%
+- Behavioral Fit: 15%
+- Career Alignment: 30%
+
+(Location is pass/fail, not weighted)
+
+## Thresholds
+- **Strong Fit** (75+): Definitely apply, tailor everything
+- **Good Fit** (60-74): Apply, address gaps in cover letter
+- **Moderate Fit** (45-59): Consider carefully, discuss with user
+- **Weak Fit** (30-44): Probably skip unless strategic reasons
+- **Poor Fit** (<30): Skip
+
+## Pre-Application: Call the Employer (Best Practice)
+
+Before writing the application, consider whether the candidate should call the contact person listed in the posting. **Only call if there are substantive questions** - never call just to "be remembered."
+
+### When to Suggest Calling
+- The posting has unclear or ambiguous requirements
+- It's unclear which competencies are essential vs. nice-to-have
+- The role description is vague about day-to-day tasks
+- There's a named contact person who invites questions
+
+### Good Questions to Ask
+- "What are the primary challenges in this role?"
+- "How is time typically divided across the listed responsibilities?"
+- "Which competencies are most critical for success in this position?"
+- "What does success look like in the first 6-12 months?"
+
+### Rules for the Call
+- Prepare a 30-second "elevator pitch" about your background in case they ask
+- The call's purpose is **gathering information**, not delivering a pitch
+- Take notes - use what you learn to tailor the application
+- Reference the conversation naturally in the cover letter ("After speaking with [name], I was especially drawn to...")

--- a/.agents/skills/job-application-assistant/05-cv-templates.md
+++ b/.agents/skills/job-application-assistant/05-cv-templates.md
@@ -1,0 +1,258 @@
+# CV Templates and Tailoring Guide
+
+<!-- SETUP: Profile statements and section ordering are personalized by running /setup -->
+
+## Template: LaTeX moderncv (Banking Style)
+
+All CVs use the moderncv LaTeX package with the "banking" style and "blue" color scheme.
+
+**Output file:** `cv/main_<company>.tex`
+**Compile with:** **lualatex** on MiKTeX/TeX Live. pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors; lualatex handles the same sources cleanly.
+**Master reference:** `cv/main_example.tex` (comprehensive CV with all competencies, experience, and achievements - use as source when building targeted CVs)
+
+### Compile command
+
+```bash
+cd cv && lualatex -interaction=nonstopmode main_<company>.tex
+```
+
+Expected output: `Output written on main_<company>.pdf (2 pages, ...)`. Any page count other than 2 is a failure that must be fixed before presenting to the user.
+
+## Document Structure
+
+```latex
+\documentclass[11pt,a4paper,sans]{moderncv}
+\moderncvstyle{banking}
+\moderncvcolor{blue}
+
+% Force both first and last name AND section headings to render in moderncv
+% blue (color1). Default banking on lualatex+MiKTeX leaves these black, which
+% looks inconsistent with the rest of the blue accent scheme.
+\renewcommand*{\firstnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
+\renewcommand*{\lastnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
+\renewcommand*{\sectionstyle}[1]{{\sectionfont\color{color1}#1}}
+
+\usepackage[utf8]{inputenc}
+\usepackage{hyperref}
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue,
+    filecolor=magenta,
+    urlcolor=blue,
+    pdftitle={[YOUR_NAME] - CV},
+    pdfpagemode=FullScreen,
+}
+\usepackage[scale=0.77]{geometry}
+\usepackage{import}
+
+% Personal data
+\name{[FIRST_NAME]}{[LAST_NAME]}
+\address{[YOUR_ADDRESS]}{}{}
+\phone[mobile]{[YOUR_PHONE]}
+\email{[YOUR_EMAIL]}
+\extrainfo{\href{[YOUR_LINKEDIN_URL]}{LinkedIn}, \href{[YOUR_GITHUB_URL]}{GitHub}}
+
+\begin{document}
+\makecvtitle
+
+% 1. Profile statement (1-3 sentences, tailored per role)
+% 2. Skills section
+% 3. Education section
+% 4. Professional Experience section
+% 5. Selected Publications (if applicable)
+% 6. Honors and Awards (if applicable)
+% 7. References
+
+\end{document}
+```
+
+### Color overrides
+
+The three `\renewcommand*` lines in the preamble are required on lualatex+MiKTeX. Without them the firstname, lastname, and section headings render in black even though `\moderncvcolor{blue}` is set, which looks inconsistent with the rest of the blue accent scheme (links, bullet markers, contact icons). The override forces all three to use `color1` (moderncv's accent colour, which becomes blue under `\moderncvcolor{blue}`). Both names render bold; if you prefer the firstname in regular weight, change the firstnamestyle override from `\bfseries` to `\mdseries`. Don't drop the override - on most modern installs the defaults render visibly wrong.
+
+### Spacing inside itemize lists (important)
+
+**Do not place `\vspace{...}` between `\item` entries in an `itemize` list.** Even though the source looks symmetric, this pattern occasionally produces a noticeably oversized gap before a single item: the inter-item `\vspace` creates a paragraph break that interacts unpredictably with the list's internal `\itemsep`, so LaTeX renders one of the gaps wider than the rest. Remove the inter-item `\vspace` and let `itemize` use its native uniform spacing.
+
+```latex
+% WRONG - intermittently produces an oversized gap before one bullet
+\begin{itemize}
+\item \textbf{Foo}: ...
+\vspace{1pt}
+\item \textbf{Bar}: ...
+\vspace{1pt}
+\item \textbf{Baz}: ...
+\end{itemize}
+
+% RIGHT - uniform spacing using the list's native itemsep
+\begin{itemize}
+\item \textbf{Foo}: ...
+\item \textbf{Bar}: ...
+\item \textbf{Baz}: ...
+\end{itemize}
+```
+
+Two related patterns are fine and should be kept:
+- `\vspace{1pt}` immediately after `\section{...}` (between section heading and first item) - this is between the heading and the list, not between list items.
+- `\vspace{3pt}` between top-level `\cventry` blocks in Professional Experience or Education - this gives breathing room between roles and renders consistently.
+
+## Section-by-Section Tailoring
+
+### Profile Statement / Elevator Pitch (Best Practice)
+This is the most important section to customize. It appears right after `\makecvtitle`.
+
+Write 5-7 lines that function as an "elevator pitch": a concise, compelling introduction explaining why you're qualified for *this specific role*. Focus on what the employer gains from hiring you.
+
+**Create 2-3 profile statement templates for your main role types:**
+
+<!-- SETUP: These are populated based on your background -->
+**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
+> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+
+**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
+> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+
+### Core Competencies / Skills Section (Best Practice)
+Reorder and emphasize based on the role. Use bold category labels.
+
+List **5-7 key competencies** in bullet format, tailored to the specific job. For each competency, briefly explain how it adds value to the position.
+
+### Education
+- Always include your highest degrees
+- For senior roles, keep education brief (dates and titles only)
+- Include thesis topics when relevant to the target role
+
+### Professional Experience
+- Rewrite bullet points to emphasize aspects most relevant to the target role
+- Use 4-6 bullets for most recent role, 3-4 for previous, 2-3 for older
+- **Emphasize measurable results** where possible: "Reduced processing time by X%", "Model adopted by the team"
+
+### Handling Employment Gaps (Best Practice)
+If there is a gap in your employment history:
+- The gap should be explained matter-of-factly if needed
+- Describe how professional development continued during the gap
+- Frame as deliberate skill-building and career repositioning
+
+### Publications
+- Include Google Scholar link if applicable
+- Select 3-4 most relevant publications (not always all of them)
+- For non-academic roles, keep brief
+
+### Honors and Awards
+- Keep format brief, one line each
+
+### References
+- List 2-4 references with name, title, company, and contact
+- End with: "More references are available upon request."
+- **Do not attach reference letters** - employers typically contact references directly
+
+## Compile-and-Inspect Loop (MANDATORY)
+
+After writing the CV and before presenting to the user, always compile and visually inspect the PDF. Iterate until the layout is clean. Workflow:
+
+1. Run `lualatex -interaction=nonstopmode main_<company>.tex`
+2. Check the output page count: must be exactly 2
+3. Read the PDF with available PDF/file-reading tools and visually inspect both pages
+4. Check for **orphaned entries**: a `\cventry` title line must never sit alone at the bottom of page 1 with its bullets on page 2
+
+### Fixing common page-break problems
+
+**Problem: entry title on page 1, bullets orphaned to page 2**
+Add `\needspace{5\baselineskip}` immediately before the problematic `\cventry`:
+```latex
+\needspace{5\baselineskip}
+\item{\cventry{YEAR--YEAR}{Role Title}{Organization}{Location}{}{...}}
+```
+Include `\usepackage{needspace}` in the preamble.
+
+**Problem: one trailing section spills to page 3 (e.g., References alone on page 3)**
+Add `\enlargethispage{2-3\baselineskip}` before a late section (e.g., before `\section{Honors and Awards}`) to stretch page 2 by a few lines. This is the standard LaTeX rescue for near-miss overflows.
+
+**Problem: 3 pages with significant content on page 3**
+Cut content — do not compress geometry or `\vspace`. See "Relevance-weighted cutting" below for the rule.
+
+**Problem: content finishes early on page 2 (feels thin)**
+Restore the highest-relevance item that was previously cut — a CV that ends mid-page 2 looks incomplete.
+
+## ATS Parseability
+
+Most employers run CVs through an ATS before a human sees them, and the ATS reads the PDF's embedded **text layer**, not the rendered page. A CV can pass visual inspection and still extract as garbage. After the layout passes the compile-and-inspect loop, verify the text layer:
+
+```bash
+cd cv && pdftotext -layout main_<company>.pdf main_<company>.txt
+```
+
+`pdftotext` comes from [poppler](https://poppler.freedesktop.org/), not the TeX distribution - it is an **optional** dependency. If it is not installed, skip the mechanical check with a warning and rely on the visual PDF read for keyword coverage.
+
+What to check in the extraction:
+
+- **Contact details as literal text.** The stock template's fontawesome contact icons extract as glyph names (`MOBILE-ALT`, `Envelope`) - harmless noise, because the actual address and number are printed beside them. The failure mode is a contact detail carried *only* by an icon or a hyperlink (like the `LinkedIn` link text, whose URL is not in the text layer): invisible to an ATS. The email address must always appear as printed text.
+- **No garbled output.** `(cid:NNN)` markers or `�` characters mean a font is embedded without a Unicode mapping - an ATS sees the same garbage. This shows up with unusual fonts in custom templates, not with the stock moderncv setup under lualatex.
+- **Reading order.** The stock banking style is single-column, so extraction order matches visual order. Custom templates (via `/add-template`) with sidebars or multi-column layouts can interleave unrelated lines; if extraction order is scrambled, the user is trading ATS compatibility for looks and should be told.
+- **Keyword coverage.** Match the posting's required/preferred terms against the extracted text, in the posting's language. Prefer the posting's exact term over a synonym when it is truthfully applicable - ATS matching is often literal. Never add a keyword the profile does not support.
+
+## Page Budget - Hard 2-Page Limit
+
+The CV **must** fit on exactly 2 pages when compiled. Use these content limits as a guide:
+
+| Section | Max budget |
+|---------|-----------|
+| Profile statement | 3-4 lines |
+| Skills | 5 items, each 1-2 lines |
+| Most recent role | 4-5 bullets |
+| Previous role | 2-3 bullets |
+| Older roles | 2 bullets (1 line each) |
+| Education | 2-3 entries |
+| Publications | 2-3 entries |
+| Awards | 3 entries, single line each |
+| References | "Available upon request." (single line) |
+
+**If in doubt, cut rather than squeeze.** Reducing `\vspace` or geometry scale to force-fit content makes the CV look cramped.
+
+## Relevance-weighted cutting (the right way to shrink a CV)
+
+**Cut by signal, not by section.** Static priority lists ("remove oldest education first, then shorten the earliest role...") are wrong when a relevant "lower-priority" item is competing with an irrelevant "higher-priority" item. An older-role bullet that speaks directly to the posting is worth more than a recent-role bullet that does not.
+
+For every candidate line, score three things:
+
+1. **Relevance to THIS posting** — does the line hit a named tool, keyword, or stated responsibility in the job ad?
+2. **Uniqueness** — is it the only place this claim appears, or is it duplicated elsewhere in the CV?
+3. **Narrative load** — does the cover letter depend on it? If cutting the line would force you to rewrite a cover-letter paragraph, it is load-bearing.
+
+Cut the lowest-total-score line first, regardless of which section it sits in.
+
+### Practical order of cuts (easiest → last resort)
+
+1. **Redundancy.** If an achievement appears in both Core Competencies AND a role bullet, the Core Competencies version is usually the cleaner cut (the experience bullet is more concrete evidence).
+2. **Profile-statement fluff.** A sentence that just restates what Publications or Skills will show. ("Peer-reviewed publications on X..." is already a Publications entry — profile can claim it once and stop.)
+3. **Low-relevance experience bullets.** A bullet about work that does not touch posting keywords, wherever it sits. This cuts across sections before touching the structural list.
+4. **Low-relevance supporting content.** An older-role bullet that does not speak to the target role. A certification that does not touch the posting's stack. A language entry that can be condensed to one line.
+5. **Low-relevance publications.** Keep 1-2 publications that best match the posting. Cut the rest before touching experience bullets.
+6. **Last-resort structural cuts.** Oldest education entry, tightening an older role to 2 bullets, collapsing Certifications into a single line. These only happen if the relevance-weighted cuts above have already been exhausted.
+
+### Pitfalls to avoid
+
+- Do not mechanically cut from the bottom of a static section list without checking relevance. "Cut the oldest role first" is wrong if that role is literally about the skill the posting asks for.
+- Do not cut the one concrete example the cover letter leans on. Relevance is measured against the cover letter you wrote, not just the job posting — interviewers will have read both.
+- Do not cut to fit if the fit is borderline (2.02 pages). Prefer `\enlargethispage{2-3\baselineskip}` on a late section for near-misses; reserve content cuts for genuine overflow (content on page 3 that is more than a single trailing section).
+
+## Recommended Section Order
+
+The section order varies by role type:
+
+**For technical / data science / ML roles:**
+1. Profile statement / elevator pitch
+2. Core competencies / Skills
+3. Professional Experience (reverse chronological)
+4. Education (reverse chronological)
+5. Languages
+6. Publications & Awards
+7. References
+
+**For domain-specific / specialist roles:**
+1. Profile statement / elevator pitch
+2. Core competencies / Skills
+3. Education (reverse chronological) - credentials are a key qualifier
+4. Professional Experience (reverse chronological)
+5. Publications & Awards
+6. References

--- a/.agents/skills/job-application-assistant/06-cover-letter-templates.md
+++ b/.agents/skills/job-application-assistant/06-cover-letter-templates.md
@@ -1,0 +1,169 @@
+# Cover Letter Templates and Tailoring Guide
+
+## Template: Custom cover.cls (XeLaTeX)
+
+Cover letters use a custom LaTeX document class (`cover.cls`) with Lato/Raleway fonts.
+
+**Output file:** `cover_letters/cover_<company>_<role>.tex`
+**Compile with:** XeLaTeX (cover.cls requires fontspec)
+**Font directory:** `cover_letters/OpenFonts/fonts/`
+
+### Compile command
+
+```bash
+cd cover_letters && xelatex -interaction=nonstopmode cover_<company>_<role>.tex
+```
+
+Expected output: `Output written on cover_<company>_<role>.pdf (1 page, ...)`. Any page count other than 1 is a failure that must be fixed before presenting to the user.
+
+## Compile-and-Inspect Loop (MANDATORY)
+
+After writing the cover letter and before presenting to the user, always compile and visually inspect the PDF. Iterate until the layout is clean:
+
+1. Run `xelatex -interaction=nonstopmode cover_<company>_<role>.tex`
+2. Confirm page count is exactly 1 and compile succeeded
+3. Read the PDF with available PDF/file-reading tools and visually check: signature fits at the bottom, no text cut off, bullet font matches body
+
+### Known template pitfall: itemize inside `\lettercontent{}`
+
+The `\lettercontent{}` macro appends `\\` to its argument. This breaks when the argument ends in `\end{itemize}` because `\\` has no line to break after the environment closes, producing `! LaTeX Error: There's no line here to end.` and no PDF output.
+
+**Wrong (breaks compile):**
+```latex
+\lettercontent{Here is how my experience maps:
+\begin{itemize}
+    \item ...
+\end{itemize}}
+```
+
+**Correct — close `\lettercontent{}` before the list and wrap the list in the matching Raleway-Medium font so typography stays consistent:**
+```latex
+\lettercontent{Here is how my experience maps:}
+
+{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont
+\begin{itemize}
+    \item ...
+\end{itemize}\par}
+\vspace{6pt}
+
+\lettercontent{[next paragraph]}
+```
+
+The font wrapper is mandatory — if you just move `\begin{itemize}` outside `\lettercontent{}` without the `\fontspec` block, bullets render in the default body font (Lato) and visually mismatch the rest of the letter.
+
+## Document Structure
+
+```latex
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Cover Letter - [Company], [Role]
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\documentclass[]{cover}
+\usepackage{fancyhdr}
+
+\pagestyle{fancy}
+\fancyhf{}
+
+\rfoot{Page \thepage \hspace{0pt}}
+\thispagestyle{empty}
+\renewcommand{\headrulewidth}{0pt}
+\begin{document}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%     TITLE NAME
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\namesection{}{\Huge{[YOUR_NAME]}}{  \href{mailto:[YOUR_EMAIL]}{[YOUR_EMAIL]} | [YOUR_PHONE] |  \urlstyle{same}\href{[YOUR_LINKEDIN_URL]}{LinkedIn}
+}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%     MAIN COVER LETTER CONTENT
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\currentdate{\today}
+\lettercontent{Dear [Name/Team],}
+
+\lettercontent{[Opening paragraph - role, connection to background, 2-3 sentences]}
+
+\lettercontent{[Body paragraph - most relevant experience, then bullet list]
+
+\begin{itemize}
+    \item [Concrete achievement/skill 1]
+    \item [Concrete achievement/skill 2]
+    \item [Concrete achievement/skill 3]
+\end{itemize}
+
+[Connection to company - why this role, why this company specifically]}
+
+\lettercontent{[Personal fit paragraph - behavioral strengths, team contribution, 2-3 sentences]}
+
+\lettercontent{I look forward to hearing from you.}
+
+\begin{flushright}
+\closing{Kind regards,\\}
+
+\signature{[YOUR_NAME]}
+\end{flushright}
+\end{document}
+```
+
+## Key Commands Reference
+
+| Command | Purpose |
+|---------|---------|
+| `\namesection{}{Name}{contact info}` | Header with name and contact |
+| `\currentdate{date}` | Date field (use `\today` or explicit date) |
+| `\lettercontent{text}` | Body paragraph (adds spacing after) |
+| `\closing{text}` | Closing line |
+| `\signature{name}` | Printed name below signature |
+
+## Tailoring Guidelines
+
+### Salutation
+- If you know the hiring manager's name: "Dear [First Last],"
+- If you know the team: "Dear [Company] hiring team,"
+- Generic: "Dear [Company]," (avoid "To whom it may concern")
+
+### Length - Hard 1-Page Limit
+- Target: 1 page including signature block
+- Maximum: **never exceed 1 page**
+- **Word budget: 250-300 words** of body text (not counting LaTeX markup). This is the safe maximum. 350 words will overflow.
+- **Always count**: opening paragraph + bullet list paragraph + closing paragraph = 3 blocks. Add a 4th only if the others are short.
+- When adding company-specific content, trim other content to compensate rather than adding net length
+
+### Line Spacing
+- Add `\usepackage{setspace}` and `\setstretch{1.0}` if the letter is long and needs to fit on one page
+- Use `\vspace{.5cm}` between major sections for readability (only if space permits)
+
+### Bullet Lists
+- Place `\begin{itemize}...\end{itemize}` **outside** a `\lettercontent{}` block (see "Known template pitfall" above), wrapped in the matching Raleway-Medium `\fontspec` so the bullet font matches the body
+- 3-5 bullets is ideal
+- Start each bullet with bold label or action verb
+- Use `\textbf{Label:}` for category-style bullets
+
+### LaTeX Special Characters
+- Underscore: `\_`
+- Ampersand: `\&`
+
+### Non-English Cover Letters
+- Same template structure, just write content in the posting's language
+- Adjust date format to local convention
+- Adjust closing to local convention (e.g. "Med venlig hilsen," for Danish)
+
+## Checklist Before Finalizing
+- [ ] No em-dashes (use commas or periods instead)
+- [ ] No cliches or empty filler
+- [ ] Every claim backed by specific example
+- [ ] Forward-looking framing: focuses on tasks you'll solve, not just past duties
+- [ ] Motivation section references this specific company's mission/values
+- [ ] Company name and role are correct throughout
+- [ ] Date is current
+- [ ] Fits on one page
+- [ ] Language matches the job posting language
+- [ ] Salutation is appropriate (named person if possible)
+- [ ] Headline is engaging and specific, not generic
+
+## Submission Guidelines (Best Practice)
+- Submit only the documents the employer requests
+- Export as PDF to preserve formatting
+- Name files clearly: "[Your Name] CV" and "[Your Name] Cover Letter"
+- Follow all employer instructions regarding anonymity or specific materials

--- a/.agents/skills/job-application-assistant/07-interview-prep.md
+++ b/.agents/skills/job-application-assistant/07-interview-prep.md
@@ -1,0 +1,109 @@
+# Interview Preparation Guide
+
+<!-- SETUP: STAR examples are personalized by running /setup based on your actual experience -->
+
+## STAR Format
+
+Structure answers as: **Situation** (context), **Task** (your responsibility), **Action** (what you did), **Result** (outcome).
+
+Keep answers to 1-2 minutes. Be specific. End with what you learned or would do differently.
+
+## Ready-Made STAR Examples
+
+<!-- These are populated by /setup from your actual experience. Below are templates showing the format. -->
+
+### 1. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
+**S:** [CONTEXT - what was happening, what was the problem]
+**T:** [YOUR RESPONSIBILITY - what you specifically needed to do]
+**A:** [WHAT YOU DID - specific actions, tools, methods]
+**R:** [OUTCOME - measurable results, adoption, impact]
+**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+
+### 2. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
+**S:** [CONTEXT]
+**T:** [YOUR RESPONSIBILITY]
+**A:** [WHAT YOU DID]
+**R:** [OUTCOME]
+**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+
+### 3. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
+**S:** [CONTEXT]
+**T:** [YOUR RESPONSIBILITY]
+**A:** [WHAT YOU DID]
+**R:** [OUTCOME]
+**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+
+<!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
+
+## Common Tough Questions
+
+### "Why did you leave [previous company]?"
+> [PREPARE YOUR ANSWER - be honest, forward-looking, no negativity about former employer]
+
+### "You don't have [specific skill/experience]."
+> [PREPARE YOUR ANSWER - acknowledge the gap, bridge to adjacent experience, show willingness to learn]
+
+### "Where do you see yourself in 5 years?"
+> [PREPARE YOUR ANSWER - show ambition aligned with the role's growth path]
+
+### "What's your biggest weakness?"
+> [PREPARE YOUR ANSWER - genuine weakness with concrete mitigation strategy]
+
+### "Why this company specifically?"
+> Customize per company. Must reference: specific projects, company values, market position, or team structure. Never give a generic answer.
+
+## Questions You Should Ask Interviewers
+
+### About the Role
+- "What does a typical week look like in this role?"
+- "What would success look like in the first 6 months?"
+- "What's the biggest challenge the team is facing right now?"
+
+### About the Team
+- "How big is the team, and how do you divide work?"
+- "What does the development/project lifecycle look like, from idea to production?"
+- "How do you onboard new team members?"
+
+### About Tech & Growth
+- "What's your current tech stack for [relevant area]?"
+- "Is there room to grow into more architectural or strategic decisions?"
+- "How does the team stay current with new tools and methods?"
+
+### About Culture (use these to prevent disappointment)
+- "How would you describe the team culture?"
+- "What does professional development look like here?"
+- "Is there flexibility for remote/hybrid work?"
+- "What's the balance between development/new projects and maintenance work?"
+- "How would you describe the leadership style in this team?"
+- "What do people who thrive here have in common?"
+
+## Phone/Video Interview Tips
+- Have STAR examples written out (use this file)
+- Keep a glass of water nearby
+- Smile when speaking (it changes your tone)
+- Ask for clarification if a question is vague
+- It's OK to take 5 seconds to think before answering
+- End with: "Is there anything else you'd like to know about my background?"
+
+## After the Application (Best Practice)
+
+### Follow-Up Etiquette
+- **Don't call to "stand out"** or to learn more about the role post-submission - this risks a negative impression
+- If the employer specified a timeline, respect it and wait
+- If no timeline was given and significant time has passed (2+ weeks), a brief call to ask about status is acceptable
+- If you have genuinely new, relevant information to share, a short follow-up is fine
+
+### Thank-You Notes
+- When you receive any update (interview invitation, rejection, or status update), send a brief thank-you message
+- Express appreciation for their time and the process
+- Keep it short (2-3 sentences)
+
+## Roleplay Guidelines
+When the user asks for interview practice:
+1. Ask which role/company to simulate
+2. Start with easy warm-up questions ("Tell me about yourself")
+3. Progress to role-specific technical questions
+4. Include 1-2 behavioral questions using the competencies from the job posting
+5. End with a tough question or curveball
+6. After each answer, give brief feedback: what worked, what to sharpen
+7. Suggest which STAR example would work best for each question

--- a/.agents/skills/job-application-assistant/SKILL.md
+++ b/.agents/skills/job-application-assistant/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: job-application-assistant
+description: >
+  Assists with job applications: evaluating job postings, tailoring CVs, writing cover letters,
+  and preparing for interviews. Triggers on keywords like: job posting, job application, CV,
+  cover letter, resume, interview prep, job fit, career, application, apply, ansøgning, stilling
+---
+
+# Job Application Assistant
+
+---
+
+## Workflow
+
+When the user provides a job posting (URL or text), follow this workflow:
+
+### Step 1: Research & Evaluate Fit
+- Fetch the job posting content with available web tools when the input is a URL
+- Analyze the posting for required competencies, keywords, and priorities
+- Research the company (website, LinkedIn, mission, recent news)
+- Score the posting against the candidate's profile using the framework in `04-job-evaluation.md`
+- Present the evaluation table and verdict
+- Suggest whether the candidate should call the employer before applying (see `04-job-evaluation.md` for guidance)
+- Ask the user if they want to proceed with an application
+
+### Step 2: Tailor CV
+- Read the most relevant existing CV variant from `cv/` as a starting point
+- Follow the guidelines in `05-cv-templates.md`
+- Create `cv/main_<company>.tex` with tailored content
+- Adjust: profile statement, skills section, experience bullet emphasis, section order
+
+### Step 3: Write Cover Letter
+- Follow the writing style rules in `03-writing-style.md` (critical: no em-dashes, no cliches)
+- Follow the template structure in `06-cover-letter-templates.md`
+- Create `cover_letters/cover_<company>_<role>.tex`
+- Ensure the letter connects specific experience to the role requirements
+
+### Step 4: Interview Preparation
+- Follow the framework in `07-interview-prep.md`
+- Prepare STAR-format answers for likely questions
+- Identify role-specific talking points
+- Draft questions the candidate should ask the interviewer
+
+---
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `01-candidate-profile.md` | Education, experience, skills, publications, awards |
+| `02-behavioral-profile.md` | Behavioral assessment, strengths, ideal environments |
+| `03-writing-style.md` | Tone, structure, do's and don'ts |
+| `04-job-evaluation.md` | Scoring framework for job fit |
+| `05-cv-templates.md` | LaTeX CV structure and tailoring rules |
+| `06-cover-letter-templates.md` | LaTeX cover letter structure and tailoring rules |
+| `07-interview-prep.md` | STAR examples, tough questions, roleplay guidelines |
+
+---
+
+## Quick Commands
+
+The user may also ask for individual steps without the full workflow:
+- "Evaluate this job posting" - Step 1 only
+- "Write a CV for [company]" - Step 2 only
+- "Write a cover letter for [role] at [company]" - Step 3 only
+- "Help me prepare for an interview at [company]" - Step 4 only
+- "What jobs should I look for?" - Career strategy discussion using profile + evaluation framework

--- a/.agents/skills/job-scraper/SKILL.md
+++ b/.agents/skills/job-scraper/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: job-scraper
+description: >
+  Scrapes Danish job sites for new positions matching your profile. Deduplicates across runs.
+  Triggers on: job scrape, find jobs, search jobs, new jobs, job search, scrape jobs, /scrape
+---
+
+# Job Scraper
+
+---
+
+## How It Works
+
+This skill searches multiple Danish job sites using targeted queries based on your profile, deduplicates against previously seen jobs and the application tracker, and presents new matches with a quick fit assessment.
+
+## Invocation
+
+The user triggers this skill by saying things like:
+- "Find new jobs"
+- "Scrape for jobs"
+- "Any new positions?"
+- "/scrape"
+
+Optional arguments:
+- A focus area, e.g. "/scrape data science" or "/scrape geophysics"
+- "broad" to run all search categories, e.g. "/scrape broad"
+
+---
+
+## Execution Steps
+
+### Step 0: Load State
+
+1. Read `job_scraper/seen_jobs.json` (create if missing - start with `{"seen": {}}`)
+2. Read `job_search_tracker.csv` to extract already-applied companies+roles
+3. Read `search-queries.md` (this directory) for the search strategy
+
+### Step 1: Search
+
+Run web search queries from `search-queries.md`. By default, run the top 3 priority categories. If the user said "broad", run all categories.
+
+If the user specified a focus area (e.g. "data science"), prioritize queries from that category.
+
+For each search:
+- Use available web search tools with site-specific queries (jobindex.dk, linkedin.com/jobs, karriere.dk, etc.)
+- Target your configured geographic area
+- Look for postings from the last 14 days
+
+### Step 2: Fetch & Parse
+
+For each promising result from Step 1:
+- Use available web fetch tools to retrieve the job posting page
+- Extract: **job title**, **company**, **location**, **posting date** (or "recent"), **URL**, **key requirements** (brief), **application deadline** (if listed)
+- Skip if the URL or company+title combo already exists in `seen_jobs.json`
+- Skip if the company+role already appears in `job_search_tracker.csv`
+
+### Step 3: Quick Fit Assessment
+
+For each new job, do a rapid fit check (NOT the full evaluation from `04-job-evaluation.md` - just a quick signal):
+
+- **High match**: Role directly involves your core skills
+- **Medium match**: Role is adjacent to your experience
+- **Low match**: Role requires significant skills you lack
+
+### Step 4: Deduplicate & Store
+
+1. Add ALL fetched jobs (new and skipped) to `seen_jobs.json` with structure:
+```json
+{
+  "seen": {
+    "<url_or_company_title_key>": {
+      "title": "...",
+      "company": "...",
+      "url": "...",
+      "first_seen": "YYYY-MM-DD",
+      "fit": "high/medium/low",
+      "status": "new/skipped/evaluated/ranked/expired"
+    }
+  }
+}
+```
+2. Only present jobs NOT already in the seen list or tracker.
+
+### Step 5: Present Results
+
+Present new jobs in a table sorted by fit (high first):
+
+```
+## New Job Matches - YYYY-MM-DD
+
+Found X new positions (Y high, Z medium, W low match).
+
+| # | Fit | Title | Company | Location | Deadline | URL |
+|---|-----|-------|---------|----------|----------|-----|
+| 1 | High | ... | ... | ... | ... | [Link](...) |
+
+### High-Match Highlights
+For each high-match job, add 2-3 bullet points:
+- Why it matches your profile
+- Key requirements to check
+- Any red flags
+```
+
+After presenting, ask:
+> "Want me to evaluate any of these in detail? Just give me the number(s)."
+
+If the user picks a number, invoke the **job-application-assistant** skill workflow (fit evaluation first, then CV + cover letter if approved).
+
+If the run found many new jobs (roughly 8+), also suggest `/rank` - it batch-scores all new postings against the full fit framework and returns a ranked shortlist, which beats eyeballing a long table. (`/rank` sets the `ranked` and `expired` status values in `seen_jobs.json`; treat both as already-seen for dedup purposes.)
+
+### Step 6: Update Tracker (Optional)
+
+If the user decides to apply to any job, add a row to `job_search_tracker.csv`.
+
+---
+
+## Important Rules
+
+1. **Never fabricate job postings.** Only present jobs found via actual web search/fetch results.
+2. **Respect deduplication.** Always check seen_jobs.json AND job_search_tracker.csv before presenting.
+3. **Focus on configured geographic area.** Skip jobs that require relocation or are clearly outside commute range.
+4. **Only open positions.** Skip postings with expired deadlines or those marked as closed.
+5. **Be efficient with web fetches.** Don't fetch every search result - use titles and snippets to pre-filter before fetching.
+6. **Search efficiently.** Use batched or parallel web search calls when available. Use subagents only if the user explicitly asks for them or an active goal workflow permits it.

--- a/.agents/skills/job-scraper/search-queries.md
+++ b/.agents/skills/job-scraper/search-queries.md
@@ -1,0 +1,76 @@
+# Search Queries for Job Scraper
+
+<!-- SETUP: Customize these queries based on your skills, target roles, and location -->
+
+## Search Sites
+
+Primary (Danish job market):
+- **jobindex.dk** - largest Danish job board
+- **linkedin.com/jobs** - LinkedIn job listings (filter: Denmark / your city)
+- **karriere.dk** - IDA's job board (engineering/science roles)
+- **jobfinder.dk** - another major Danish job board
+- **akademikernes.dk** - academic union job board
+
+Secondary (company career pages via Google):
+- Direct Google searches with `site:` filters for known target companies
+
+## Query Categories
+
+Queries are grouped by priority. Each query should be combined with your location terms (e.g. "Copenhagen", "Sjælland", "Hovedstaden") where the site supports it.
+
+### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+
+These match your strongest and most desired career direction.
+
+```
+site:jobindex.dk "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
+site:jobindex.dk "[YOUR_KEY_SKILL]" [YOUR_CITY]
+site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
+```
+
+### Priority 2: [YOUR_DOMAIN_EXPERTISE]
+
+These match your domain expertise.
+
+```
+site:jobindex.dk [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
+site:jobindex.dk [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
+site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+```
+
+### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
+
+Adjacent roles you could pivot into.
+
+```
+site:jobindex.dk "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
+site:jobindex.dk "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
+```
+
+### Priority 4: Broader Technical / Consulting
+
+Wider net for general technical roles.
+
+```
+site:jobindex.dk [YOUR_KEY_SKILL] developer [YOUR_CITY]
+site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
+site:jobindex.dk "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+```
+
+## Location Filter
+
+When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
+- [YOUR_CITY] and surrounding areas
+- [ACCEPTABLE_AREA_1]
+- [ACCEPTABLE_AREA_2]
+- [BORDERLINE_AREA] (borderline - ~X min by transit)
+- [TOO_FAR_AREA] (too far)
+
+## Date Filter
+
+Only include jobs posted within the last 14 days, or with an application deadline that has not yet passed. If a posting date cannot be determined, include it but flag as "date unknown".
+
+## Adapting Queries
+
+If the user specifies a focus area, select queries from the matching category and also generate 2-3 custom queries for that focus. For example:
+- "/scrape [focus_area]" -> relevant category queries + custom focus-specific queries

--- a/.agents/skills/jobbank-search/SKILL.md
+++ b/.agents/skills/jobbank-search/SKILL.md
@@ -19,7 +19,7 @@ description: >
   jobbank søgning, find stilling, data scientist job, software developer job,
   projektleder stilling, konsulent job, data analyse job.
 context: fork
-allowed-tools: Bash(bun run skills/jobbank-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobbank-search/cli/src/cli.ts *)
 ---
 
 # Jobbank Search Skill
@@ -43,7 +43,7 @@ Invoke this skill when the user wants to:
 ### Search jobs
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -66,7 +66,7 @@ Key flags:
 ### Full job detail
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts detail <id> [--format json|plain]
+bun run .agents/skills/jobbank-search/cli/src/cli.ts detail <id> [--format json|plain]
 ```
 
 `id` is the numeric job ID from `search` results. Fetches the job page and parses the embedded Schema.org `JobPosting` JSON-LD for structured data.
@@ -84,7 +84,7 @@ bun run skills/jobbank-search/cli/src/cli.ts detail <id> [--format json|plain]
 
 ```bash
 # IT or Finance industry, Copenhagen or Aarhus
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --industry 10331 --industry 10358 \
   --location 2 --location 8
 ```
@@ -98,7 +98,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Find data scientist jobs in Copenhagen
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --key "data scientist" \
   --location 2 \
   --format table
@@ -107,7 +107,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Graduate trainee positions for new graduates
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --type 6 \
   --suitable-for 2 \
   --format table
@@ -116,7 +116,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Remote IT software jobs
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --work-area 31 \
   --remote helt \
   --format table
@@ -125,7 +125,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Ph.d. and postdoc positions in research
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --type 12 \
   --industry 10442 \
   --format table
@@ -134,7 +134,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Recent full-time jobs posted since March 1
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --type 3 \
   --since 2026-03-01 \
   --format table
@@ -143,13 +143,13 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Full details for a specific job
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts detail 1234567 --format plain
+bun run .agents/skills/jobbank-search/cli/src/cli.ts detail 1234567 --format plain
 ```
 
 ### IT jobs in Aarhus or Copenhagen
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --key developer \
   --location 2 --location 8 \
   --work-area 31 \

--- a/.agents/skills/jobdanmark-search/SKILL.md
+++ b/.agents/skills/jobdanmark-search/SKILL.md
@@ -17,7 +17,7 @@ description: >
   work in denmark, employment denmark, job denmark, jobs near me denmark,
   apprentice denmark, internship denmark, part-time denmark, full-time denmark.
 context: fork
-allowed-tools: Bash(bun run skills/jobdanmark-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobdanmark-search/cli/src/cli.ts *)
 ---
 
 # Jobdanmark Search Skill
@@ -42,7 +42,7 @@ Invoke this skill when the user wants to:
 ### Search job listings
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -62,7 +62,7 @@ Key flags:
 ### Full job detail
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts detail <slug> [--format json|plain]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts detail <slug> [--format json|plain]
 ```
 
 `slug` is the URL path segment returned as `slug` in `search` results (e.g. `it-chef-soeges-til-rah`).
@@ -71,7 +71,7 @@ Returns full structured job data from the job page's JSON-LD, including title, o
 ### List categories with live counts
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts categories [--format json|table|plain]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts categories [--format json|table|plain]
 ```
 
 Returns all 10 job categories with current live job counts. Useful for giving the user an overview of the job market.
@@ -79,7 +79,7 @@ Returns all 10 job categories with current live job counts. Useful for giving th
 ### Autocomplete job titles and categories
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "<text>" [--limit <n>]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "<text>" [--limit <n>]
 ```
 
 Use this to resolve search terms into precise job title IDs (`--jobtitle-id`) or category IDs (`--category`) for `search`. The `value` field in results is the ID to pass to `search`.
@@ -87,7 +87,7 @@ Use this to resolve search terms into precise job title IDs (`--jobtitle-id`) or
 ### Suggest locations
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts locations --query "<text>" [--limit <n>]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts locations --query "<text>" [--limit <n>]
 ```
 
 Returns matching municipalities, zip codes, and regions. Use `value` from results as `--municipality` or `--zip` in `search`.
@@ -116,13 +116,13 @@ Returns matching municipalities, zip codes, and regions. Use `value` from result
 **Resolve locations first.** Use `locations` to find the correct municipality name or zip code before passing them to `search`:
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts locations --query "Aarhus" --format plain
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts locations --query "Aarhus" --format plain
 ```
 
 **Resolve job titles for precision.** Use `autocomplete` to get the exact job title ID when the user wants a specific role:
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "sygeplejerske" --format plain
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "sygeplejerske" --format plain
 ```
 
 **Natural workflow: `search` → `detail`.**
@@ -142,7 +142,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "sygeplejer
 ### IT jobs in Copenhagen
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --category 227978 \
   --municipality "København" \
   --job-type fuldtid \
@@ -152,7 +152,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### Nursing jobs anywhere in Denmark
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --text "sygeplejerske" \
   --category 227975 \
   --format table
@@ -161,7 +161,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### Student jobs in Aarhus
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --municipality "Aarhus" \
   --job-type studiejob \
   --format table
@@ -170,25 +170,25 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### What job categories are most active right now?
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts categories --format table
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts categories --format table
 ```
 
 ### Full details for a specific job posting
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts detail it-chef-soeges-til-rah --format plain
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts detail it-chef-soeges-til-rah --format plain
 ```
 
 ### Find jobs in zip code 8000
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search --zip 8000 --format table
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search --zip 8000 --format table
 ```
 
 ### What electrician jobs are available?
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --text "elektriker" \
   --category 227973 \
   --job-type "fuldtid,deltid" \
@@ -198,7 +198,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### Apprentice positions in all of Denmark
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --job-type elev \
   --page 1 \
   --format table

--- a/.agents/skills/jobindex-search/SKILL.md
+++ b/.agents/skills/jobindex-search/SKILL.md
@@ -17,7 +17,7 @@ description: >
   hiring denmark, job listings denmark, python jobs denmark, grafisk designer job,
   data engineer job, softwareudvikler job, full stack developer job danmark.
 context: fork
-allowed-tools: Bash(bun run skills/jobindex-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobindex-search/cli/src/cli.ts *)
 ---
 
 # Jobindex Search Skill
@@ -40,7 +40,7 @@ Invoke this skill when the user wants to:
 ### Search job listings
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -56,7 +56,7 @@ Key flags:
 ### Fetch full job detail
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts detail <id> [--format json|plain]
+bun run .agents/skills/jobindex-search/cli/src/cli.ts detail <id> [--format json|plain]
 ```
 
 `id` is the job ID from `search` results (e.g. `h1647303`). You may also pass the full Jobindex URL. Returns the full job description, deadline, employment type, hours, and apply link.
@@ -86,7 +86,7 @@ bun run skills/jobindex-search/cli/src/cli.ts detail <id> [--format json|plain]
 ### Find Python jobs posted in the last 7 days
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query python \
   --jobage 7 \
   --sort date \
@@ -96,7 +96,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Data engineer jobs in Copenhagen
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "data engineer københavn" \
   --sort score \
   --format table
@@ -105,7 +105,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Graphic designer jobs — all time, by relevance
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "grafisk designer" \
   --limit 10 \
   --format table
@@ -114,7 +114,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Full-stack developer jobs, page 2
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "full stack developer" \
   --page 2 \
   --format json
@@ -123,7 +123,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Jobs posted today across all sectors
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --jobage 1 \
   --sort date \
   --limit 20 \
@@ -133,13 +133,13 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Get full details for a specific job
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts detail h1647303 --format plain
+bun run .agents/skills/jobindex-search/cli/src/cli.ts detail h1647303 --format plain
 ```
 
 ### Marketing jobs in Aarhus
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "marketing aarhus" \
   --jobage 30 \
   --sort date \

--- a/.agents/skills/jobnet-search/SKILL.md
+++ b/.agents/skills/jobnet-search/SKILL.md
@@ -18,7 +18,7 @@ description: >
   social worker job denmark, occupation search denmark, esco occupation, job deadline,
   ansøgningsfrist, søg efter job, full time job denmark, part time job denmark.
 context: fork
-allowed-tools: Bash(bun run skills/jobnet-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobnet-search/cli/src/cli.ts *)
 ---
 
 # Jobnet-Search Skill
@@ -45,7 +45,7 @@ Invoke this skill when the user wants to:
 ### Search for job ads
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -65,7 +65,7 @@ Key flags:
 ### Full job ad detail
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts detail <jobAdId> [--format json|plain]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts detail <jobAdId> [--format json|plain]
 ```
 
 `jobAdId` is the UUID from `search` results (the `jobAdId` field). Returns the complete job
@@ -74,7 +74,7 @@ description, contact persons, application deadline, employer details, and direct
 ### Search occupation types
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts occupations --search-string <text> [--per-page <n>]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts occupations --search-string <text> [--per-page <n>]
 ```
 
 Use this to discover ESCO occupation identifiers before passing them to `search` with
@@ -83,7 +83,7 @@ Use this to discover ESCO occupation identifiers before passing them to `search`
 ### Typeahead suggestions
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts suggestions --query <text> [--limit <n>]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts suggestions --query <text> [--limit <n>]
 ```
 
 Returns Danish job title autocomplete strings. Useful for exploring valid Danish
@@ -97,8 +97,8 @@ job titles before constructing a `search` query.
 term or ESCO identifier before running a `search`:
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts suggestions --query "syge"
-bun run skills/jobnet-search/cli/src/cli.ts occupations --search-string "sygeplejerske"
+bun run .agents/skills/jobnet-search/cli/src/cli.ts suggestions --query "syge"
+bun run .agents/skills/jobnet-search/cli/src/cli.ts occupations --search-string "sygeplejerske"
 ```
 
 **Natural workflow: `search` → `detail`.**
@@ -128,7 +128,7 @@ CLI outputs. Use `--page` + `--per-page` to iterate through large result sets.
 ### Jobs in Copenhagen area
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --region HovedstadenOgBornholm \
   --per-page 10 \
   --format table
@@ -137,7 +137,7 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### Nurse jobs nationwide
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --search-string "sygeplejerske" \
   --work-hours FullTime \
   --duration Permanent \
@@ -149,7 +149,7 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### IT jobs near Aarhus within 30km
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --search-string "udvikler" \
   --postal-code 8000 \
   --radius 30 \
@@ -160,13 +160,13 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### Full details of a job ad
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts detail 9ef43bce-d82b-4ea1-a098-7ff6520f99be --format plain
+bun run .agents/skills/jobnet-search/cli/src/cli.ts detail 9ef43bce-d82b-4ea1-a098-7ff6520f99be --format plain
 ```
 
 ### Jobs sorted by application deadline (urgent first)
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --search-string "pædagog" \
   --region OevrigeSjaelland \
   --order ApplicationDate \
@@ -176,8 +176,8 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### Discover occupation terms
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts suggestions --query "ingeniør" --limit 5
-bun run skills/jobnet-search/cli/src/cli.ts occupations --search-string "lærer" --per-page 5
+bun run .agents/skills/jobnet-search/cli/src/cli.ts suggestions --query "ingeniør" --limit 5
+bun run .agents/skills/jobnet-search/cli/src/cli.ts occupations --search-string "lærer" --per-page 5
 ```
 
 ---

--- a/.agents/skills/linkedin-search/SKILL.md
+++ b/.agents/skills/linkedin-search/SKILL.md
@@ -11,7 +11,7 @@ description: >
   positions open, remote jobs, "are there any X jobs in <place>", look up this
   job posting.
 context: fork
-allowed-tools: Bash(bun run skills/linkedin-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/linkedin-search/cli/src/cli.ts *)
 ---
 
 # LinkedIn Search Skill
@@ -42,7 +42,7 @@ Run it on your own responsibility.
 ### Search job listings
 
 ```bash
-bun run skills/linkedin-search/cli/src/cli.ts search --location "<place>" [flags]
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search --location "<place>" [flags]
 ```
 
 Key flags:
@@ -57,7 +57,7 @@ Key flags:
 ### Fetch full job detail
 
 ```bash
-bun run skills/linkedin-search/cli/src/cli.ts detail <id|url> [--format json|plain]
+bun run .agents/skills/linkedin-search/cli/src/cli.ts detail <id|url> [--format json|plain]
 ```
 
 `id` is the job ID from `search` results (e.g. `4426311357`). You may also pass a full
@@ -68,16 +68,16 @@ seniority, employment type, job function, industries, and apply link.
 
 ```bash
 # Data engineer roles in Bengaluru, last 30 days
-bun run skills/linkedin-search/cli/src/cli.ts search -q "data engineer" -l "Bengaluru, Karnataka, India" --jobage 30 --format table
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "data engineer" -l "Bengaluru, Karnataka, India" --jobage 30 --format table
 
 # Product manager roles in Berlin, remote
-bun run skills/linkedin-search/cli/src/cli.ts search -q "product manager" -l "Berlin, Germany" --remote remote --format table
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "product manager" -l "Berlin, Germany" --remote remote --format table
 
 # Any role, fully remote
-bun run skills/linkedin-search/cli/src/cli.ts search -q "paralegal" -l "Remote" --format table
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "paralegal" -l "Remote" --format table
 
 # Full details for a specific job
-bun run skills/linkedin-search/cli/src/cli.ts detail 4426311357 --format plain
+bun run .agents/skills/linkedin-search/cli/src/cli.ts detail 4426311357 --format plain
 ```
 
 ## Output formats

--- a/.agents/skills/outcome/SKILL.md
+++ b/.agents/skills/outcome/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: outcome
+description: Record job application outcomes. Use when the user asks for /outcome, logging application results, interview updates, offers, rejections, or no-response outcomes.
+---
+
+# /outcome - Record the Result of an Application
+
+You are recording what happened to a job application: progress updates (interview invitations, stages completed, offers) and final resolutions (hired, rejected, no response). The data lands in two places the framework already reads but nothing systematically writes:
+
+- `job_search_tracker.csv` - the status column that `/scrape` and `/rank` use for dedup and exclusion
+- `documents/applications/<company>_<role>/` - the per-application archive (posting, submitted drafts, `outcome.md`) that `/setup` Path A mines to calibrate `04-job-evaluation.md` and surface STAR candidates
+
+`/outcome` writes the data; `/setup` interprets it. This command never edits the evaluation framework or profile files itself.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Input
+
+`the user request arguments` may contain:
+
+- Nothing → list open applications and ask which one to update
+- A company name (optionally with a role), e.g. `/outcome acme` or `/outcome acme ml engineer` → target that application
+
+---
+
+## Step 1: Load State and Identify the Application
+
+1. Read `job_search_tracker.csv`. If it does not exist, create it with the standard header:
+   ```
+   date,company,sector,role,role_type,channel,status,contact_person,fit_rating,notes,cv_file,cover_letter_file,source
+   ```
+2. **With an argument:** match rows case-insensitively on company (and role, if given). One match → proceed. Several → list them and ask. None → the application was made outside the workflow; collect company, role, date applied, channel, and posting URL from the user and add a tracker row.
+3. **Without an argument:** list all rows whose status is not final (not hired / rejected / no response / withdrawn / offer declined) as a numbered table (company, role, date applied, current status) and ask which to update. If every row is resolved, say so and stop.
+4. Derive the archive folder name: `documents/applications/<company>_<role>/` - lowercase, underscores for spaces (the convention documented in `documents/README.md`). Check whether the folder and an `outcome.md` already exist - if so, you are updating, not creating.
+
+---
+
+## Step 2: Collect What Happened
+
+Ask the user what happened, then classify:
+
+**Progress updates** (application still open):
+- Interview invitation / stage scheduled or completed (phone screen, technical, case, final round)
+- Offer received (not yet accepted or declined)
+
+**Resolutions** (application closed) - these map to the status enum in `documents/README.md` that `/setup` parses:
+- `hired` - accepted an offer
+- `offer_declined` - received an offer, turned it down
+- `rejected` - explicit rejection at any stage
+- `no_response` - no reply; if the user is unsure whether to call it, note how long it has been since the last contact and let them decide - do not impose a cutoff
+- `interview_only` - reached interviews but the process stalled or was abandoned without an explicit rejection
+
+Also collect, without interrogating - one or two open questions are enough:
+- Dates for the stages reached
+- Any feedback received, verbatim where the user remembers it
+- What they'd do differently, and any signal about what the company valued (these feed `/setup`'s calibration and STAR-candidate mining, so concrete beats polished)
+
+---
+
+## Step 3: Archive the Application Materials
+
+Create or update `documents/applications/<company>_<role>/`. All content here is personal data - the folder is already gitignored (`documents/applications/**`), so nothing needs redacting.
+
+1. **`cv_draft.tex` and `cover_letter.tex`** - copy (never move) the submitted files. Locate them via the tracker row's `cv_file`/`cover_letter_file` columns; if those are empty, look for `cv/main_<company>.tex` and `cover_letters/cover_<company>_*.tex`. If a file already exists in the archive, leave it - the archived version is what was actually submitted. If no draft files exist (application made outside `/apply`), skip with a note.
+2. **`job_posting.md`** - if it already exists, leave it. Otherwise try available web fetch tools on the tracker row's `source` URL and save the posting text. If the URL is dead (postings expire fast - this is exactly why the archive matters), ask the user to paste the posting, or write a stub noting the posting is unavailable. **Never reconstruct a posting from memory.**
+3. **`outcome.md`** - write or update it in exactly the format documented in `documents/README.md`, so `/setup` Path A parses it without special cases:
+
+```markdown
+# Outcome: <Company> — <Role>
+
+**Status:** in_progress | hired | offer_declined | rejected | no_response | interview_only
+
+**Date resolved:** YYYY-MM-DD   <- only when resolved; omit while in_progress
+
+## Interview stages reached
+- [x] Phone screen (YYYY-MM-DD)
+- [ ] Technical interview
+- [ ] Case interview
+- [ ] Final round
+- [ ] Offer received
+
+## Notes
+<feedback received, what to do differently, signals about what they valued -
+appended per update with a date, never overwritten>
+```
+
+Update rules: tick stage checkboxes as they are reached (add the date in parentheses), append dated entries to Notes, and only change `Status` from `in_progress` to a final value on resolution. Re-running `/outcome` on the same application is idempotent - it appends new information, never duplicates or rewrites history.
+
+---
+
+## Step 4: Update the Tracker
+
+Update the matched row's `status` column (e.g. `applied` → `interview` → `offer` → `hired` / `rejected` / `no response` / `offer declined` / `withdrawn`) and append a short dated note to the `notes` column. Never restructure the CSV, reorder rows, or touch other rows.
+
+---
+
+## Step 5: Calibration Handoff
+
+Count the `outcome.md` files under `documents/applications/` with a **final** status (not `in_progress`).
+
+- If 3 or more are resolved (or 2+ share a pattern - same role type rejected twice, same sector going silent), suggest:
+  > "You now have <N> resolved applications on record. Run `/setup` (Path A) to fold them into your evaluation framework - it calibrates fit scoring from what actually got interviews, and mines your interview feedback for STAR examples."
+- Do **not** write anything into `04-job-evaluation.md` or other skill files yourself. `/setup` Path A owns that merge - it is read-before-write and idempotent, and duplicating its logic here would race it.
+
+---
+
+## Step 6: Confirm
+
+Summarize what was recorded:
+
+> **Outcome recorded for <Role> at <Company>.**
+>
+> - `documents/applications/<company>_<role>/outcome.md` - status: <status>, <what changed>
+> - Archived: <which of cv_draft.tex / cover_letter.tex / job_posting.md were copied or fetched, and which were skipped and why>
+> - Tracker: status → <new status>
+>
+> [Calibration suggestion from Step 5, if triggered]
+
+---
+
+## Important Rules
+
+1. **Write data, don't interpret it.** The archive and tracker are the outputs; calibration belongs to `/setup`. This command never edits profile or framework files.
+2. **The archived version is the submitted version.** Existing files in the application folder are never overwritten by fresher drafts.
+3. **Never fabricate.** A dead posting URL gets a user-pasted copy or an explicit "unavailable" stub, not a reconstruction. Feedback is recorded as the user reports it.
+4. **Stay schema-compatible.** `outcome.md` follows the format in `documents/README.md` exactly (`in_progress` is the one addition, for open applications); the tracker keeps its columns.
+5. **Idempotent updates.** Re-running on the same application appends new stages and notes; it never duplicates folders, rows, or history.

--- a/.agents/skills/rank/SKILL.md
+++ b/.agents/skills/rank/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: rank
+description: Rank scraped job postings into a shortlist. Use when the user asks for /rank, ranking jobs, triaging scraped jobs, or choosing which jobs to apply to.
+---
+
+# /rank - Triage Scraped Jobs into a Ranked Shortlist
+
+You are batch-scoring the jobs that `/scrape` has collected, so the user can decide where to spend `/apply` effort. `/scrape` finds and dedupes postings; `/apply` evaluates one at a time in depth. `/rank` is the bridge: it scores every new posting against the fit framework and returns a ranked shortlist.
+
+`/rank` produces **triage scores**, not final evaluations. It scores from the posting text and the candidate profile only - no company research, no reviewer agent. `/apply`'s Step 1 evaluation (which adds company research) remains authoritative and always re-runs when the user applies.
+
+Follow these steps **in order**.
+
+---
+
+## Step 0: Parse Input
+
+`the user request arguments` may contain:
+
+- Nothing → rank all jobs with status `new` in `job_scraper/seen_jobs.json`
+- A focus area (e.g. `/rank data science`) → rank only jobs whose title or stored fit-notes match the focus
+- `--all` → re-rank every job that has not been applied to, including previously ranked ones (useful after the profile changes)
+- `--top <N>` → shortlist size (default 5)
+
+---
+
+## Step 1: Load State
+
+1. Read `job_scraper/seen_jobs.json`. If the file is missing or has no entries, tell the user to run `/scrape` first and stop.
+2. Read `job_search_tracker.csv`. Build the exclusion set: any company+role already in the tracker is out of scope regardless of flags - it has been applied to or consciously tracked.
+3. Select candidates: entries with status `new` (or all non-applied entries with `--all`), minus the exclusion set, filtered by the focus area if one was given.
+4. If no candidates remain, say so ("Nothing new to rank - run /scrape to find fresh postings") and stop.
+5. Read the scoring framework and profile **once**:
+   - `.agents/skills/job-application-assistant/04-job-evaluation.md`
+   - `.agents/skills/job-application-assistant/01-candidate-profile.md`
+
+State how many jobs will be ranked before proceeding.
+
+---
+
+## Step 2: Batch-Fetch and Score
+
+Batch the selected jobs in the root Codex context, roughly 5 jobs per batch. Use subagents only when the user explicitly asks for them or an active goal workflow permits them.
+
+Token-efficiency rules, consistent with `/apply`:
+
+- Keep the compact scoring rubric in context: the strong/moderate/weak skill match areas, direct/adjacent experience domains, behavioral thrive/drain factors, career goals, deal-breakers, and the location constraints. Do **not** re-read the profile files for each batch.
+- Fetch each posting URL with available web fetch tools and score **only from actually fetched content**. If a URL is dead, redirects to a listing page, or the posting has expired, mark that job `expired` - never score from the title alone and never fabricate posting content.
+- Scope is triage: posting text vs. rubric. **No company research, no salary lookup, no web searches** - that depth belongs to `/apply`.
+
+For each batch, produce a JSON array with one object per job:
+
+```json
+{
+  "key": "<the job's key in seen_jobs.json>",
+  "status": "scored" | "expired",
+  "scores": { "technical": 0-100, "experience": 0-100, "behavioral": 0-100, "career": 0-100 },
+  "location": "PASS" | "FAIL" | "FLAG",
+  "deadline": "YYYY-MM-DD" | null,
+  "strengths": ["1-3 bullets, grounded in the posting text"],
+  "gaps": ["1-3 bullets, honest"],
+  "language": "<posting language>"
+}
+```
+
+Scoring uses the dimension definitions from `04-job-evaluation.md` verbatim. The honesty rule applies to triage too: gaps are stated, never smoothed over, and a posting that is a poor fit gets a low score even if it looks prestigious.
+
+---
+
+## Step 3: Aggregate and Rank
+
+Back in the main context, for each scored job:
+
+1. Compute the overall score with the weighting from `04-job-evaluation.md` (Technical 30%, Experience 25%, Behavioral 15%, Career Alignment 30%; location is unweighted).
+2. Map to the framework's verdict bands (Strong Fit 75+, Good Fit 60-74, Moderate Fit 45-59, Weak Fit 30-44, Poor Fit <30).
+3. **Location veto:** `FAIL` (e.g. requires relocation) excludes the job from the shortlist no matter the score - list it separately with the reason. `FLAG` (e.g. heavy travel) stays in the ranking but carries a visible ⚠ marker for the user to judge.
+4. **Deadline urgency:** a deadline within 7 days gets a 🔥 marker and wins ties. A deadline that has already passed moves the job to `expired`.
+
+Sort by overall score (descending), urgency as tiebreaker.
+
+---
+
+## Step 4: Update State
+
+Update `job_scraper/seen_jobs.json` in place - these fields are additive to the scraper's schema:
+
+- Ranked jobs: set `"status": "ranked"` and add `"rank_score": <overall>`, `"rank_verdict": "<band>"`, `"rank_date": "YYYY-MM-DD"`
+- Dead or past-deadline jobs: set `"status": "expired"`
+
+Do not modify `job_search_tracker.csv` - that file records applications, and `/rank` never applies. Re-running `/rank` is idempotent: already-`ranked` jobs are skipped unless `--all` re-scores them.
+
+---
+
+## Step 5: Present the Shortlist
+
+```
+## Job Ranking - YYYY-MM-DD
+
+Ranked <N> new postings (<X> shortlisted, <Y> below threshold, <Z> expired/vetoed).
+
+### Shortlist
+
+| # | Score | Verdict | Title | Company | Location | Deadline | |
+|---|-------|---------|-------|---------|----------|----------|---|
+| 1 | 78 | Strong Fit | ... | ... | ... | ... | 🔥 |
+
+### Why these ranked highest
+**1. <Title> at <Company> (78)** - [2-3 strength bullets and the honest gap, from the agent's findings]
+[repeat for each shortlisted job]
+
+### Below threshold
+| Score | Verdict | Title | Company | One-line reason |
+
+### Excluded
+- <Title> at <Company> - location FAIL: requires relocation
+- <Title> at <Company> - expired <date>
+```
+
+Rules for the presentation:
+
+- Every claim traces to fetched posting text or the profile - no invented details.
+- Say explicitly that these are **triage scores from the posting text only**, and that `/apply` will re-evaluate with company research before anything is drafted.
+- Then ask: "Want to apply to any of these? Give me the number(s) and I'll start with the full `/apply` workflow."
+- If the user picks one, run the `/apply` workflow on that job's URL, passing the triage verdict as prior context but **re-running the full Step 1 evaluation** - triage never substitutes for it.
+
+---
+
+## Important Rules
+
+1. **Never rank unfetched postings.** A job whose posting cannot be retrieved is marked expired, not guessed at.
+2. **Triage depth only.** No company research, no salary lookups, no reviewer agents - `/rank` exists to be cheap enough to run on every scrape batch.
+3. **Deal-breakers veto scores.** A 90-point job that fails a location deal-breaker is excluded, not ranked first.
+4. **Honest scoring.** Gaps are reported per job; a low-scoring posting is presented as such. The score bands and weights come from `04-job-evaluation.md` - if the user disagrees with a ranking, the fix is updating their profile or the framework, not bending scores.
+5. **State stays consistent.** `seen_jobs.json` fields are only added, never restructured, so `/scrape`'s dedup keeps working; the tracker is read-only for this command.

--- a/.agents/skills/reset/SKILL.md
+++ b/.agents/skills/reset/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: reset
+description: Reset candidate profile data or personal documents. Use when the user asks for /reset, clearing profile files, clearing documents, or starting setup over.
+---
+
+# /reset - Reset Candidate Profile Data
+
+You are resetting parts of the job search framework back to a blank state so the user can start fresh with `/setup`.
+
+**This command is destructive.** Nothing is deleted until the user explicitly confirms. Follow these steps exactly in order.
+
+---
+
+## Step 0: Parse Scope from Arguments
+
+Check `the user request arguments` for a scope keyword:
+
+- `profile` — clears candidate profile data from skill files only
+- `documents` — deletes user-provided files from the `documents/` folder only
+- `all` — both of the above
+
+If `the user request arguments` is empty or does not contain a recognized scope keyword, ask:
+
+> **What would you like to reset?**
+>
+> - **`profile`** — Clears candidate data from the skill files (profile, behavioral, STAR examples, profile statements). The framework structure and writing rules are preserved. Use this to re-run `/setup` from scratch.
+>
+> - **`documents`** — Deletes all files you've placed in the `documents/` folder (CV PDFs, LinkedIn export, diplomas, references, past applications). The folder structure and `README.md` are preserved.
+>
+> - **`all`** — Both of the above.
+>
+> Reply with `profile`, `documents`, or `all`.
+
+Wait for the user's response before continuing.
+
+---
+
+## Step 1: Show Exactly What Will Be Cleared
+
+Before doing anything, show the user precisely what will be wiped.
+
+### If scope includes `profile`:
+
+Read the current state of these files and report whether each has content or is already empty:
+
+- `.agents/skills/job-application-assistant/01-candidate-profile.md`
+- `.agents/skills/job-application-assistant/02-behavioral-profile.md`
+- `.agents/skills/job-application-assistant/05-cv-templates.md` *(profile statements section only — framework structure is preserved)*
+- `.agents/skills/job-application-assistant/07-interview-prep.md` *(STAR examples and STAR candidates sections only — framework structure is preserved)*
+
+Present as:
+
+```
+## Profile reset will clear:
+
+- 01-candidate-profile.md — [has content / already empty]
+  Full file will be replaced with a blank template.
+
+- 02-behavioral-profile.md — [has content / already empty]
+  Full file will be replaced with a blank template.
+
+- 05-cv-templates.md — [has profile statements / already blank]
+  Profile statement templates will be cleared. LaTeX structure and tailoring guidelines are preserved.
+
+- 07-interview-prep.md — [has STAR examples / already blank]
+  STAR examples and any STAR candidate stubs will be cleared. Framework, tough questions, and roleplay guidelines are preserved.
+
+The following files are NOT touched (they contain framework rules, not candidate data):
+  - 03-writing-style.md
+  - 04-job-evaluation.md
+  - 06-cover-letter-templates.md
+```
+
+### If scope includes `documents`:
+
+Use available file-search tools to list all files present in `documents/cv/`, `documents/linkedin/`, `documents/diplomas/`, `documents/references/`, and `documents/applications/`. Present as:
+
+```
+## Documents reset will delete:
+
+documents/cv/
+  - [filename] or "(empty)"
+
+documents/linkedin/
+  - [filename] or "(empty)"
+
+documents/diplomas/
+  - [filename] or "(empty)"
+
+documents/references/
+  - [filename] or "(empty)"
+
+documents/applications/
+  - [subfolder/filename] or "(empty)"
+
+documents/README.md — NOT deleted (instructions file)
+```
+
+If all document subfolders are already empty, state "All document subfolders are already empty — nothing to delete." and skip the confirmation step for this scope.
+
+---
+
+## Step 2: Require Explicit Confirmation
+
+Present the confirmation prompt:
+
+> **This cannot be undone.**
+>
+> Type **`RESET`** (all caps) to confirm, or anything else to cancel.
+
+Wait for the user's response.
+
+- If the user types exactly `RESET`: proceed to Step 3.
+- If the user types anything else: abort and tell them "Reset cancelled. Nothing was changed."
+
+---
+
+## Step 3: Execute the Reset
+
+### Profile reset
+
+**For `01-candidate-profile.md`**, replace the file content with:
+
+```markdown
+# Candidate Profile
+
+<!-- Run /setup to populate this file -->
+
+## Identity
+
+## Education
+
+## Professional Experience
+
+## Independent Projects
+
+## Technical Skills
+
+## Publications
+
+## Awards
+
+## References
+```
+
+**For `02-behavioral-profile.md`**, replace the file content with:
+
+```markdown
+# Behavioral Profile
+
+<!-- Run /setup to populate this file -->
+
+## Overview
+
+## Strongest Behavioral Traits
+
+## How I Work Best
+
+## Growth Areas
+
+## Mapping to Job Posting Language
+
+## Management Style Preferences
+
+## Using This in Applications
+```
+
+**For `05-cv-templates.md`**, locate the section that begins with `**Profile statement templates` and extends through the role-specific template blocks. Replace only that section with:
+
+```markdown
+**Profile statement templates:**
+
+<!-- Run /setup to populate role-specific profile statements -->
+```
+
+Leave all other content in `05-cv-templates.md` intact.
+
+**For `07-interview-prep.md`**, locate and remove:
+- The entire `## Ready-Made STAR Examples` section and all numbered STAR examples under it
+- Any `## STAR Candidates (Complete Manually)` section added by `/setup` Path A
+
+Replace with:
+
+```markdown
+## Ready-Made STAR Examples
+
+<!-- Run /setup to populate STAR examples from your actual experience -->
+```
+
+Leave all other content in `07-interview-prep.md` intact (STAR format explanation, tough questions, questions to ask interviewers, phone/video tips, follow-up etiquette, roleplay guidelines).
+
+### Documents reset
+
+For each non-empty document subfolder, delete all files within it using Bash `rm`. Do not delete the folder itself, and do not delete `documents/README.md`.
+
+```bash
+rm -f documents/cv/*
+rm -f documents/linkedin/*
+rm -f documents/diplomas/*
+rm -f documents/references/*
+rm -rf documents/applications/*/
+```
+
+---
+
+## Step 4: Confirm What Was Done and Next Steps
+
+After the reset is complete, report:
+
+```
+## Reset complete
+
+### Cleared
+[List each file/folder that was actually modified or cleared]
+
+### Unchanged
+[List anything that was already empty or was intentionally preserved]
+```
+
+Then tell the user what to do next based on what was reset:
+
+**If profile was reset:**
+> Your candidate profile is now blank. Run `/setup` to repopulate it. The command auto-detects any files in your `documents/` folder and offers to read from there; otherwise it walks you through a CV import or interactive interview.
+
+**If documents were reset:**
+> The `documents/` folder is now empty. Add your career documents and run `/setup` to populate your profile. See `documents/README.md` for instructions on what to put where.
+
+**If both were reset:**
+> Both your profile files and documents folder are now empty. Add documents to `documents/` (or skip and use the CV import / interview path), then run `/setup`.

--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: setup
+description: Run Codex onboarding for the AI Job Search framework. Use when the user asks for /setup, profile setup, onboarding, or updating profile/search sections.
+---
+
+# /setup - Profile Onboarding
+
+You are running the onboarding setup for the AI Job Search framework. Your goal is to collect the user's professional information and populate all profile files so the `/apply` workflow works out of the box.
+
+There are three paths into setup. Step 0 picks the right one; all three converge on Step 3 (file generation) and Step 4 (confirmation).
+
+---
+
+## Step 0: Welcome & Choose Path
+
+If `the user request arguments` contains `--section <name>`, skip directly to that section in Path C for an update-only flow. Do not run the path-selection prompt below.
+
+Otherwise, before greeting the user, scan the `documents/` folder. Use available file-search tools with `documents/**/*` and count files per subfolder (`cv/`, `linkedin/`, `diplomas/`, `references/`, `applications/`). Ignore placeholder `.gitkeep` files when deciding whether a folder has user-provided documents.
+
+Then welcome the user with a single message that lists three paths. The wording changes based on what was found.
+
+**If `documents/` has user-provided files** in one or more subfolders, lead with Path A:
+
+> **Welcome to the AI Job Search setup!**
+>
+> I'll help you build your professional profile so Codex can evaluate job postings, tailor CVs, write cover letters, and prepare you for interviews.
+>
+> I see files in your `documents/` folder: [list per subfolder, e.g. "2 in cv/, 1 in linkedin/, 3 in references/"]. Three ways to start:
+>
+> **Path A: Read my documents folder** (recommended for what you have) - I'll read everything in `documents/`, cross-reference for consistency, and build your profile from real source materials. Idempotent and safe to re-run as you add more documents.
+>
+> **Path B: Single CV import** - Paste or @-mention a single CV/resume here. I'll extract it and ask follow-up questions for what's missing.
+>
+> **Path C: Interview mode** - I'll walk you through structured questions section by section.
+>
+> Which would you like?
+
+**If `documents/` is empty or missing**, surface Path A as a "do this if you have materials" option:
+
+> **Welcome to the AI Job Search setup!**
+>
+> I'll help you build your professional profile so Codex can evaluate job postings, tailor CVs, write cover letters, and prepare you for interviews.
+>
+> Three ways to start:
+>
+> **Path A: Documents folder** (best signal if you have several materials) - Drop your CV / LinkedIn export / diplomas / reference letters in the `documents/` folder, then say "go". I'll read everything and build your profile from it. See `documents/README.md` for the folder layout.
+>
+> **Path B: Single CV import** - Paste or @-mention a single CV/resume here. I'll extract it and ask follow-up questions for what's missing.
+>
+> **Path C: Interview mode** - I'll walk you through structured questions section by section. Good if you're starting from scratch.
+>
+> Which would you like?
+
+Wait for the user's choice. If they pick A but the folder is still empty, tell them what to add (point at `documents/README.md`) and stop.
+
+---
+
+## Path A: Documents Folder
+
+Reads structured documents in `documents/`, cross-references them for consistency, and merges extracted data into the seven profile skill files. Read-before-write and idempotent: changes already present will not be proposed again.
+
+Follow these steps **exactly in order**.
+
+### Step A1: Inventory
+
+Use available file-search tools with `documents/**/*` to scan the full tree. Ignore placeholder `.gitkeep` files when deciding whether a subfolder is empty. Print:
+
+```
+## Documents Found
+
+**cv/**: [list files, or "(empty)"]
+**linkedin/**: [list files, or "(empty)"]
+**diplomas/**: [list files, or "(empty)"]
+**references/**: [list files, or "(empty)"]
+**applications/**: [list subfolders with their files, or "(empty)"]
+
+I will read these and cross-reference before proposing any changes.
+```
+
+If every subfolder is empty or contains only `.gitkeep` placeholders, stop and tell the user to populate the folder. Point at `documents/README.md` for the layout.
+
+### Step A2: Read Existing Skill Files
+
+Read these in parallel before extracting anything. You must know what is already there to make the merge intelligent.
+
+- `.agents/skills/job-application-assistant/01-candidate-profile.md`
+- `.agents/skills/job-application-assistant/02-behavioral-profile.md`
+- `.agents/skills/job-application-assistant/03-writing-style.md`
+- `.agents/skills/job-application-assistant/04-job-evaluation.md`
+- `.agents/skills/job-application-assistant/05-cv-templates.md`
+- `.agents/skills/job-application-assistant/06-cover-letter-templates.md`
+- `.agents/skills/job-application-assistant/07-interview-prep.md`
+
+Hold this content in context throughout Path A. Do not re-read.
+
+### Step A3: Parse Documents
+
+Read each document found in Step A1. Process subfolders in this order: `cv/`, `linkedin/`, `diplomas/`, `references/`, `applications/`.
+
+**`cv/` documents:** name, contact (email, phone, LinkedIn, GitHub), education (degree, institution, dates, thesis), work experience (title, company, dates, location, bullets), skills, publications, awards, profile/summary.
+
+**`linkedin/` documents:** About/summary section (full text, used for behavioral inference), work experience, education, skills and endorsements, certifications, volunteer work, publications, recommendations received (full text). If multiple LinkedIn exports are present, use the most recently modified file.
+
+**`diplomas/` documents:** official degree title and level, institution name (official spelling), graduation date, grade or distinction or GPA if visible.
+
+**`references/` documents:** referee name, title, organization; full text of the letter (extract specific quotes); competency language used.
+
+**`applications/<company>_<role>/` subfolders:**
+- `job_posting.md`: role title, company, required skills, experience level, sector, role type
+- `cover_letter.tex`: opening structure, body structure, bullet style, closing, recurring phrases
+- `cv_draft.tex`: profile statement, section ordering, framing for this role type
+- `outcome.md`: status (in_progress/hired/offer_declined/rejected/no_response/interview_only), interview stages, notes. Skip `in_progress` applications for calibration — they have no final signal yet.
+
+After reading, proceed to Step A4 without intermediate output. The user sees a complete picture in Step A6.
+
+### Step A4: Cross-Reference Check
+
+Before mapping anything to skill files, check for inconsistencies:
+
+- Date mismatches between CV / LinkedIn / diploma
+- Title mismatches across documents for the same role
+- Education mismatches (degree name, graduation date)
+- Employer name variations
+
+If inconsistencies are found, present them as a numbered list and wait for the user to resolve each one before continuing:
+
+```
+## Cross-Reference Issues Found
+
+These need to be resolved before I continue. For each one, tell me which version is correct.
+
+1. **Role title mismatch - [COMPANY]:**
+   CV says: "[TITLE_A]"
+   LinkedIn says: "[TITLE_B]"
+   Which is correct?
+
+2. ...
+```
+
+If no inconsistencies, state "No cross-reference issues found." and continue.
+
+### Step A5: Build Change Sets
+
+For each skill file, compare extracted document content against the current file content from Step A2. Build two buckets.
+
+**Additive changes:** entirely new content not in the skill file in any form. Examples: a certification not in `01-candidate-profile.md`, a new endorsement skill, a referee not yet listed, a new behavioral quote from a reference letter, a new award.
+
+**Conflicting changes:** content that touches something already in a skill file but disagrees. Examples: a different date range for an existing job, a different job title for the same role, a different graduation date than what is recorded.
+
+**Inference rules** (apply when populating from inferred sources):
+
+- **`02-behavioral-profile.md`:** Source is LinkedIn About + recommendation letters. Extract recurring themes, adjectives, phrases about how the candidate works. Add only to "Strongest Behavioral Traits", "How [Candidate] Works Best", or "Management Style Preferences" sections. Do not overwrite existing scored assessments. Always label inferred additions: *[Inferred from LinkedIn About / Reference letter - review before relying on this]*
+- **`03-writing-style.md`:** Source is `cover_letter.tex` files. Extract recurring patterns. Add as observations under "## Patterns Observed in Past Applications". Do not modify existing rules. Only add if 2+ cover letters show a genuine pattern.
+- **`04-job-evaluation.md`:** Source is `job_posting.md` + `outcome.md` pairs. If an application reached interview or offer: note role type and sector as a confirmed strong-fit signal. If 2+ applications repeat a no-response or rejection pattern: note it. Add findings under "## Calibration from Past Applications". Do not modify the existing scoring framework.
+- **`05-cv-templates.md`:** Source is `cv_draft.tex` files. Extract any profile statement that does not already appear in templates. Label with: *[Used for: <company>_<role>]*
+- **`06-cover-letter-templates.md`:** Source is `cover_letter.tex` files. Extract opening patterns, bullet structures, closing formulations. Add only what is structurally distinct from existing templates.
+- **`07-interview-prep.md`:** Source is CV bullets, LinkedIn descriptions, reference letter quotes. Identify achievements not yet covered by an existing STAR example. Do NOT draft full STAR examples. Add stubs under "## STAR Candidates (Complete Manually)":
+
+```markdown
+### [Achievement title]
+**Source:** [CV / LinkedIn / Reference letter - role/company]
+**What happened:** [one sentence]
+**Why it matters:** [interview question types this could answer]
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+```
+
+### Step A6: Present and Confirm Changes
+
+Present the full change set before writing anything.
+
+**Additive changes** (single grouped list, organized by target file):
+
+```
+## Proposed Additive Changes
+
+### 01-candidate-profile.md
+- [ ] New certification: [title], [issuer], [date] - extracted from LinkedIn
+- [ ] New reference: [name, title, company]
+  Quote: "[relevant quote]"
+
+### 02-behavioral-profile.md
+- [ ] New behavioral observation [labeled as inference]: "[phrase]"
+
+[and so on per file]
+```
+
+Then ask:
+
+> **Apply all additive changes?** These add new content without touching anything already in the files.
+> Reply **yes** to apply all, or list the numbers you want to skip.
+
+Wait for the response. Apply only the confirmed items.
+
+**Conflicting changes** (one at a time):
+
+```
+## Conflict 1 of [N]: Job title - [COMPANY]
+
+**Current in 01-candidate-profile.md:**
+[TITLE_A] - [COMPANY] ([START]-[END])
+
+**Proposed (from LinkedIn export):**
+[TITLE_B] - [COMPANY] ([START]-[END])
+
+Options:
+  [keep] Keep the existing text
+  [replace] Replace with the version from the document
+  [manual] I'll edit this myself - skip for now
+```
+
+Wait for the user's choice on each conflict. If no conflicts, state "No conflicting changes found." and skip this section.
+
+### Step A7: Write Confirmed Changes and Fill Gaps
+
+Apply the confirmed changes with the targeted file-editing tools. Make targeted edits only. Do not rewrite entire files. State which changes were applied per file. If a file has no confirmed changes, state "No changes made to [filename]."
+
+Documents cover skills, experience, education, references, and behavioral signal. They do not cover everything `/apply` and `/scrape` need. After the writes, ask follow-up questions for gaps:
+
+- Career goals and target role types
+- What excites the user in their next role
+- Deal-breakers and must-haves
+- Salary expectations / baseline (optional)
+- Commute or location constraints (if not visible from CV)
+- Job search configuration (use the questions from Path C Section 9 below)
+
+Then proceed to Step 3 to populate the non-skill files (`AGENTS.md`, `cv/main_example.tex`, `.agents/skills/job-scraper/search-queries.md`). Step 3 will detect that the seven skill files are already populated and skip those substeps.
+
+---
+
+## Path B: Single CV Import
+
+If the user provides a single CV/resume:
+
+1. Read the document thoroughly.
+2. Extract all structured information: name, contact, education, experience, skills, publications, awards.
+3. Present a summary of what was extracted.
+4. Ask follow-up questions for gaps (behavioral profile, career goals, deal-breakers, salary expectations, references).
+5. Proceed to Step 3 (file generation).
+
+---
+
+## Path C: Interview Mode
+
+Walk through each section conversationally. Ask questions naturally, not as a form. Let the user answer in their own words and you'll structure the data.
+
+### Section 1: Identity & Contact
+Ask about:
+- Full name
+- Location (city, country)
+- Phone, email, LinkedIn, GitHub
+- Languages spoken (with proficiency levels)
+- Current employment status
+- Family/commute constraints (if any)
+
+### Section 2: Education
+For each degree:
+- Level (PhD, MSc, BSc, etc.), field, institution, years
+- Thesis topic (if applicable)
+- Key coursework or topics
+
+Also ask about certifications (online courses, professional certs).
+
+### Section 3: Professional Experience
+For each role (most recent first):
+- Job title, company, dates, location
+- Key responsibilities (3-5 bullets)
+- Key achievements or projects
+- Technologies/tools used
+
+Also ask about independent projects, freelance work, or side projects.
+
+### Section 4: Technical Skills
+- Programming languages + proficiency level
+- ML/AI frameworks and tools
+- Domain expertise
+- Software tools and platforms
+- Any other technical skills
+
+### Section 5: Publications & Awards (optional)
+- Peer-reviewed papers, conference presentations
+- Hackathons, competitions, awards
+- Skip if not applicable
+
+### Section 6: Behavioral Profile (optional)
+If they have a formal assessment (PI, DISC, Myers-Briggs, StrengthsFinder):
+- Ask them to describe or share the results
+
+If not, ask behavioral questions:
+- "What work environments do you thrive in?"
+- "What drains your energy at work?"
+- "How do you prefer to work in teams?"
+- "How do you make decisions, quickly or deliberately?"
+- "What's your communication style?"
+- Synthesize answers into a behavioral profile
+
+### Section 7: Career Goals & Preferences
+- Target roles and industries
+- What excites you in work
+- Deal-breakers and must-haves
+- Salary expectations/baseline (optional)
+- What environments to avoid
+- Commute/location constraints
+
+### Section 8: References (optional)
+For each reference:
+- Name, title, company, email, phone
+- Relationship to the user
+
+### Section 9: Job Search Configuration
+This section generates the search queries that power `/scrape`. Use the information from Sections 1, 4, and 7 to build targeted queries.
+
+Ask about:
+- **Role titles to search for:** "What job titles should I search for? For example: Data Scientist, ML Engineer, Geophysicist." Collect 3-8 specific titles.
+- **Key skills as search terms:** "Which of your skills are most likely to appear in job postings?" Pick 3-5 that are distinctive and searchable.
+- **Target companies (optional):** "Are there specific companies you'd like to monitor for openings?"
+- **Geographic scope:** "Which cities or regions should I search in? How far are you willing to commute?" Use this to define the location filter tiers (ideal, acceptable, borderline, too far).
+- **Job portals:** "The framework includes tools for Danish job portals (Jobindex, Jobbank, Jobdanmark, Jobnet). Are these the right ones for you, or do you use other sites?" Note: if the user is outside Denmark, acknowledge that the built-in CLI tools are Denmark-specific and suggest they can add their own portal integrations or rely on LinkedIn/Google site-searches.
+
+**Important:** Also suggest role types the user may not have considered, based on their skill profile. For example:
+- If they have strong Python + domain expertise: "Have you considered roles like 'Technical Consultant' or 'Solutions Engineer' in your domain?"
+- If they have ML + a specific industry: "Companies in adjacent industries also hire for these skills. Should I include searches for [adjacent sector]?"
+- If they have project management experience alongside technical skills: "Would you also want to search for 'Technical Project Manager' or 'Team Lead' roles?"
+
+This proactive suggestion step helps users discover career paths they might not have considered.
+
+---
+
+## Step 3: Generate Profile Files
+
+Once data collection is complete, generate or finish populating the following files. **For Path A**, the seven skill files are already populated by Step A7; check each before writing and skip if its content is no longer placeholder text.
+
+**Implementation rule:** Write and verify one target file at a time. Do not prepare one large multi-file patch for all setup outputs at once. After each file edit, re-read or search that file to confirm the expected personalized values are present before moving to the next target. If any write is blocked, stop and report the blocked file and exact error instead of silently continuing.
+
+### 1. Update `AGENTS.md`
+Replace all `[PLACEHOLDER]` tokens with the user's actual information. Keep the structure, workflow, and verification checklist intact.
+
+### 2. Populate `01-candidate-profile.md` *(Path B and C; skip if Path A populated it)*
+Write the full candidate profile with structured sections: Identity, Education, Professional Experience, Independent Projects, Technical Skills, Publications, Awards, References.
+
+### 3. Populate `02-behavioral-profile.md` *(Path B and C; skip if Path A populated it)*
+Write the behavioral profile based on assessment results or synthesized answers.
+
+### 4. Update `04-job-evaluation.md` *(Path B and C; skip if Path A populated it)*
+Replace skill match areas with the user's actual skills:
+- Strong match areas: [their primary skills]
+- Moderate match areas: [their secondary skills]
+- Weak match areas: [skills they lack]
+
+Update career goals and motivation filters with their actual preferences.
+
+### 5. Update `05-cv-templates.md` *(Path B and C; skip if Path A populated it)*
+Add role-specific profile statement templates based on their background.
+
+### 6. Update `07-interview-prep.md` *(Path B and C; skip if Path A populated it)*
+Create STAR examples from their actual experience (at least 3-4 examples). Path A leaves STAR stubs under "## STAR Candidates (Complete Manually)" rather than full examples; if any stubs are present, mention them in Step 4 so the user knows to flesh them out.
+
+### 7. Update `cv/main_example.tex`
+Replace placeholder personal data with their actual name, contact info, and add their education and most recent experience entries.
+
+### 8. Generate `.agents/skills/job-scraper/search-queries.md`
+Replace all placeholder tokens in the search queries file with the user's actual information from Section 9 (or the equivalent follow-up questions in Path A's Step A7):
+- Replace `[YOUR_PRIMARY_ROLE_TYPE]`, `[YOUR_PRIMARY_JOB_TITLE]`, etc. with actual role titles
+- Replace `[YOUR_KEY_SKILL]`, `[YOUR_DOMAIN_KEYWORD_1]`, etc. with actual skills and domain terms
+- Replace `[YOUR_CITY]`, `[YOUR_COUNTRY]`, `[YOUR_REGION]` with actual location
+- Fill in the location filter tiers (ideal, acceptable, borderline, too far) based on commute constraints
+- Organize queries into priority categories matching the user's career direction:
+  - Priority 1: Their strongest/most desired role direction
+  - Priority 2: Their domain expertise
+  - Priority 3: Adjacent roles they could pivot into
+  - Priority 4: Broader roles (wider net)
+
+---
+
+## Step 4: Confirm & Next Steps
+
+Present a summary:
+
+> **Setup complete!** Here's what was generated:
+>
+> - `AGENTS.md` - Your full candidate profile
+> - `.agents/skills/job-application-assistant/01-candidate-profile.md` - Structured profile
+> - `.agents/skills/job-application-assistant/02-behavioral-profile.md` - Behavioral assessment
+> - `.agents/skills/job-application-assistant/04-job-evaluation.md` - Personalized evaluation framework
+> - `.agents/skills/job-application-assistant/05-cv-templates.md` - CV templates with your profile statements
+> - `.agents/skills/job-application-assistant/07-interview-prep.md` - STAR examples from your experience
+> - `cv/main_example.tex` - Your LaTeX CV template
+> - `.agents/skills/job-scraper/search-queries.md` - Job search queries for `/scrape`
+>
+> **Try it out:**
+> - Run `/scrape` to search for matching jobs right now
+> - Run `/apply` with a job posting URL to see the full application workflow
+> - Run `/setup --section search` later to update your search queries as your priorities evolve
+
+If Path A left any STAR stubs in `07-interview-prep.md`, also note:
+
+> Path A flagged [N] STAR candidate stubs in `07-interview-prep.md` that need your situation/task/action/result details before you use them in interviews.
+
+---
+
+## Design Principles
+
+- Three onboarding paths converge on the same skill files. Step 0 picks the right path based on what's in `documents/`. Steps 3 and 4 are shared.
+- Path A is read-before-write and idempotent. Re-running it as documents are added does not duplicate or overwrite existing content; conflicts are surfaced for explicit resolution.
+- Path A labels inferred behavioral or style additions so the user can review them critically before relying on them.
+- Each section in Path C is a natural conversation, not a form. The user can skip optional sections.
+- Synthesize answers into structured formats (the user does not need to know markdown or LaTeX).
+- Can be re-run with `--section <name>` to update specific sections (e.g., `/setup --section search` to reconfigure job search queries without re-doing the full profile).
+- Section 9 (search) in Path C, and the equivalent follow-up questions in Path A, proactively suggest role types the user may not have considered.
+- At the end, suggest running `/scrape` and `/apply` with a test job posting.

--- a/.agents/skills/upskill/SKILL.md
+++ b/.agents/skills/upskill/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: upskill
+description: >
+  Compares tracked job postings against the candidate profile to identify skill gaps and generate
+  a prioritized learning plan with study resources. Triggers on: /upskill, upskill, skill gaps,
+  what should I learn, learning plan
+---
+
+# Upskill
+
+---
+
+## Overview
+
+`/upskill` analyses jobs you have tracked and your current profile to identify skill gaps, then produces a heatmap of those gaps and a learning plan with concrete, web-searched study resources and a recommended study order.
+
+## Invocation
+
+- **`/upskill`** — aggregate mode: analyses all jobs in `job_search_tracker.csv`
+- **`/upskill <URL>`** — targeted mode: analyses a single job posting fetched from the URL
+
+---
+
+## Step 1: Detect Mode
+
+Check whether the user provided a URL argument:
+
+- If the invocation was `/upskill` with no argument → **aggregate mode**
+- If the invocation was `/upskill <URL>` → **targeted mode**, store the URL for Step 2
+
+In targeted mode, derive a slug from the job title and company for the report filename (e.g. `guardsix-senior-ai-engineer`). You will fetch the posting in Step 2.
+
+## Step 2: Load Data
+
+### Aggregate mode
+1. Read `job_search_tracker.csv`. Extract all rows. The columns are:
+   `date, company, sector, role, role_type, channel, status, contact_person, fit_rating, notes, cv_file, cover_letter_file, source`
+2. For each row, note the `role`, `company`, and `fit_rating`. The `fit_rating` column is a 0–100 score where 100 = perfect fit. You will use it to weight gaps — a lower fit rating means the role exposed more gaps.
+3. Read `.agents/skills/job-application-assistant/01-candidate-profile.md` to get the candidate's current skills and experience.
+4. Check `upskill/` for the most recent aggregate report file (`report-YYYY-MM-DD.md`) — if one exists, note its date and load it for the diff in Step 8.
+
+### Targeted mode
+1. Use available web fetch tools to retrieve the job posting from the URL.
+2. Extract: job title, company, required skills, preferred skills, responsibilities, and any domain context.
+3. Read `.agents/skills/job-application-assistant/01-candidate-profile.md` for the candidate's current skills.
+4. No tracker data is used in targeted mode.
+
+## Step 3: Pass 1 — Hard Skill Diff
+
+Extract required and preferred technical skills from each job source:
+
+### Aggregate mode
+For each job row in the tracker, you do not have the full posting — use the `role`, `sector`, and `notes` columns to infer likely required skills. If the row has a `source` URL, you may optionally fetch it for more detail with available web tools, but skip if the URL is missing or dead.
+
+Build a **skill frequency map**: for each extracted skill, count how many jobs mention it. Then apply a **fit weight**: for each job, multiply the skill count contribution by `(100 - fit_rating) / 100` — lower fit jobs contribute more to the gap score.
+
+Final score for each skill: `sum of (fit_weight × occurrence)` across all jobs.
+
+### Targeted mode
+Extract the explicit required and preferred skills from the fetched posting. Each skill gets equal weight (no fit weighting needed since there is only one job). List required skills before preferred skills, then sort alphabetically within each group.
+
+### Diff against profile
+Remove any skill from the list that is already present in the candidate profile (`01-candidate-profile.md`). Be generous — if the profile mentions a skill in any form (e.g. "Python" covers "Python scripting"), remove it.
+
+What remains is the **hard skill gap list**. In aggregate mode, rank by score descending. In targeted mode, list required skill gaps before preferred skill gaps, then sort alphabetically within each group.
+
+## Step 4: Pass 2 — LLM Synthesis
+
+Now reason holistically about gaps that the hard skill diff would miss. Consider:
+
+- **Domain knowledge gaps**: Does the candidate lack familiarity with the industry, domain, or problem space the jobs operate in? (e.g. cybersecurity, climate tech, quantitative finance)
+- **Soft skill gaps**: Do the job descriptions emphasise ways of working, communication styles, or leadership expectations that the profile does not address?
+- **Tooling and process gaps**: Frameworks, cloud services, methodologies (e.g. MLOps practices, CI/CD, agile at scale) that appear across jobs but are absent from the profile
+- **Credential or certification gaps**: If multiple postings list a certification as preferred, flag it
+
+Tag each synthesised gap as one of: `[domain]`, `[soft]`, `[tooling]`, or `[credential]`.
+
+Do not duplicate gaps already captured in Pass 1. Only add what was missed.
+
+In targeted mode, treat all synthesised gaps as arising from a single posting. Credential gaps can still be flagged if the single posting lists them as preferred or required.
+
+## Step 5: Build Gap Heatmap
+
+Combine Pass 1 and Pass 2 results into a single prioritised table. Assign priority as follows:
+
+- **Critical**: Hard skills with high frequency/weight scores, or domain gaps that appear across most tracked jobs
+- **High**: Hard skills with moderate scores, or soft/tooling gaps that appear consistently
+- **Medium**: Lower-frequency hard skills, or synthesised gaps that appeared in fewer roles
+- **Low**: One-off mentions or minor nice-to-haves
+
+Format:
+
+| Priority | Skill / Area | Type | Gap Source |
+|----------|-------------|------|------------|
+| Critical | Kubernetes | Hard | 4/5 jobs, score 3.2 |
+| High | Security domain knowledge | Domain | LLM synthesis |
+| High | CI/CD pipelines | Tooling | LLM synthesis |
+| Medium | AWS (advanced) | Hard | 2/5 jobs, score 1.1 |
+| Low | ... | ... | ... |
+
+Print this table to the terminal as an intermediate output before continuing to the learning plan.
+
+In targeted mode, assign priority based on the job's own language: required skills → Critical or High, preferred skills → Medium, inferred gaps from LLM synthesis → Medium or Low.
+
+## Step 6: Build Learning Plan
+
+For every **Critical** and **High** gap (and **Medium** gaps if fewer than 5 total gaps exist), produce a learning entry.
+
+### For each gap:
+
+1. **Run a web search** to find current, highly-rated study resources. Use queries like:
+   - `"best Kubernetes course 2025 site:reddit.com OR coursera.org OR fast.ai OR missing.csail.mit.edu"`
+   - `"learn [skill] for [domain] 2025 recommendations"`
+   Include the current year in the query to avoid stale results.
+
+2. **Pick 2-3 resources** from the search results. Prefer:
+   - Courses with hands-on labs over lecture-only content
+   - Official documentation for tooling gaps
+   - Books for domain knowledge gaps
+   - For each resource: name, URL, and one-line reason why it fits
+
+3. **Write a study direction** tailored to the candidate's existing background. For example: if the candidate knows Docker, say "Skip the containers basics module — go straight to the orchestration and networking sections." Be specific about what to skip and where to start.
+
+4. **Estimate time to working proficiency** (e.g. "~20h", "~40h for a solid foundation"). Be realistic — err toward more rather than less.
+
+### Group by theme
+
+Group entries under theme headings rather than listing alphabetically. Example themes: Cloud & Infrastructure, MLOps, Domain Knowledge, Security, Soft Skills & Ways of Working, Certifications.
+
+Example entry format:
+
+```
+### Cloud & Infrastructure
+
+**Kubernetes** `[Hard]` — ~20h
+- [Kubernetes for Absolute Beginners – KodeKloud](https://kodekloud.com) — hands-on labs, widely recommended on r/kubernetes for practical learners
+- [Official Kubernetes Docs: Concepts](https://kubernetes.io/docs/concepts/) — use as reference once you have the basics
+- [The Kubernetes Book – Nigel Poulton](https://leanpub.com/the-kubernetes-book) — concise, updated annually
+
+Study direction: You already know Docker and containerisation — skip Chapter 1 on containers. Start at Pod scheduling and work through Services and Deployments. Focus on manifests and `kubectl` fluency before touching Helm.
+```
+
+## Step 7: Suggest Study Order
+
+After the learning plan, add a **Suggested Study Order** section. Number the topics in the recommended sequence. Apply these rules:
+
+1. **Dependencies first**: If learning topic B requires topic A (e.g. "AWS networking" requires "AWS fundamentals"), place A before B and note the dependency.
+2. **Critical before High before Medium**: Within a dependency tier, prioritise by gap priority.
+3. **Quick wins early**: If a Medium gap is very fast (~5h) and boosts confidence, it can be placed early.
+4. **Domain knowledge last**: Domain/soft gaps usually benefit from being studied alongside practical projects rather than up front.
+
+Format:
+
+```
+## Suggested Study Order
+
+| # | Topic | Type | Est. Time | Note |
+|---|-------|------|-----------|------|
+| 1 | Kubernetes | Hard | ~20h | Required before AWS EKS in step 3 |
+| 2 | CI/CD pipelines | Tooling | ~10h | |
+| 3 | AWS (advanced) | Hard | ~25h | Builds on step 1 |
+| 4 | Security domain knowledge | Domain | ~15h | Study alongside a real project |
+
+**Total estimated time: ~70h**
+```
+
+## Step 8: Write and Save Report
+
+### Compose the report
+
+Assemble the full report in this order:
+
+```markdown
+# Upskill Report — YYYY-MM-DD
+**Mode:** Aggregate (N jobs analysed) | Targeted: <Job Title> @ <Company>
+
+---
+
+## Since Last Report
+<!-- Aggregate mode only. Omit section entirely in targeted mode or if no previous report exists. -->
+**Gaps closed** (skills added to profile since <previous date>):
+- ...
+
+**New gaps** (from jobs tracked since <previous date>):
+- ...
+
+---
+
+## Gap Heatmap
+
+| Priority | Skill / Area | Type | Gap Source |
+|----------|-------------|------|------------|
+...
+
+---
+
+## Learning Plan
+
+### <Theme>
+
+**<Skill>** `[Type]` — ~Xh
+- [Resource 1](url) — reason
+- [Resource 2](url) — reason
+
+Study direction: ...
+
+---
+
+## Suggested Study Order
+
+| # | Topic | Type | Est. Time | Note |
+...
+
+**Total estimated time: ~Xh**
+```
+
+### Save the report
+
+- **Aggregate:** `upskill/report-YYYY-MM-DD.md`
+- **Targeted:** `upskill/report-YYYY-MM-DD-<company-slug>-<role-slug>.md`
+  - Slugify: lowercase, spaces → hyphens, strip special characters
+  - Example: `upskill/report-2026-04-20-guardsix-senior-ai-engineer.md`
+
+Write the file to disk.
+
+### Diff section (aggregate mode only)
+
+If a previous aggregate report was loaded in Step 2:
+- **Gaps closed**: Any skill in the previous report's heatmap that is now present in the candidate profile
+- **New gaps**: Any skill in the current heatmap that was not in the previous report
+
+If no previous report exists, omit the "Since Last Report" section entirely.
+
+### Confirm to user
+
+After saving, print:
+> "Report saved to `upskill/<filename>.md`. Review it anytime to track your learning progress."
+
+## Important Rules
+
+1. **Never fabricate resources.** Only cite resources found via actual web search results. Do not invent course names, URLs, or authors.
+2. **Search with the current year.** Include the year in every web search query for resources so results stay fresh.
+3. **Targeted mode ignores the tracker.** In targeted mode, analyse only the fetched posting. Do not load or reference `job_search_tracker.csv`.
+4. **Be generous with profile matching.** If a skill appears in the candidate profile in any form, do not flag it as a gap. Avoid false positives.
+5. **Print the heatmap before the learning plan.** Always show the intermediate heatmap table in the terminal before proceeding to resource search, so the user can see what you are working from.
+6. **Omit Low-priority gaps from the learning plan.** List them in the heatmap for completeness, but do not generate study resources for them unless the user asks.
+7. **Always save the report.** Do not skip the Write step even if the user seems satisfied with the terminal output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# Job Application Assistant for [YOUR_NAME]
+
+<!-- SETUP: This file is populated by running /setup -->
+<!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
+
+## Role
+This repo is a job application workspace. Codex acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
+2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
+3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
+4. **Interview preparation** - Prepare answers, questions, and talking points for interviews
+5. **Career strategy** - Advise on positioning and personal branding
+
+## Candidate Profile
+
+<!-- This section is auto-populated by /setup. You can also fill it in manually. -->
+
+### Identity
+- **Name:** [YOUR_NAME]
+- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
+- **Languages:** [YOUR_LANGUAGES]
+- **Status:** [YOUR_EMPLOYMENT_STATUS]
+- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+
+### Education
+<!-- List your degrees, most recent first -->
+- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
+  - Thesis: "[THESIS_TITLE]"
+  - Topics: [KEY_TOPICS]
+
+### Professional Experience
+<!-- List your roles, most recent first -->
+- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
+  - [KEY_RESPONSIBILITY_1]
+  - [KEY_RESPONSIBILITY_2]
+  - [KEY_ACHIEVEMENT]
+
+### Technical Skills
+- **Primary:** [YOUR_PRIMARY_SKILLS]
+- **Secondary:** [YOUR_SECONDARY_SKILLS]
+- **Domain:** [YOUR_DOMAIN_EXPERTISE]
+- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+
+### Certifications
+<!-- List relevant certifications with dates -->
+- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+
+### Publications
+<!-- List peer-reviewed publications, if any -->
+- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+
+### Awards
+<!-- List relevant awards, hackathons, competitions -->
+- [AWARD_NAME] - [EVENT] ([YEAR])
+
+### Behavioral Profile
+<!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
+- **[TRAIT_1]** - [DESCRIPTION]
+- **[TRAIT_2]** - [DESCRIPTION]
+- **Strengths:** [YOUR_STRENGTHS]
+- **Growth areas:** [YOUR_GROWTH_AREAS]
+- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+
+### What Excites You
+<!-- What motivates you professionally -->
+- [PASSION_1]
+- [PASSION_2]
+
+### Target Sectors
+<!-- Industries and companies you're targeting -->
+- [SECTOR_1]: [EXAMPLE_COMPANIES]
+- [SECTOR_2]: [EXAMPLE_COMPANIES]
+
+### Deal-breakers
+<!-- Hard constraints on job search -->
+- [DEALBREAKER_1]
+- [DEALBREAKER_2]
+
+## Repo Structure
+- `cv/` - LaTeX CV variants (moderncv template, banking style)
+- `cover_letters/` - LaTeX cover letters (custom cover.cls template)
+- `.agents/skills/` - Codex skill definitions and job search CLI tools
+
+## Workflow for New Job Applications
+1. User provides a job posting (URL or text)
+2. **Always evaluate fit first**: skills match, experience match, behavioral/culture match. Present this assessment to the user before proceeding.
+3. If good fit: create targeted CV (`cv/main_<company>.tex`) and cover letter (`cover_letters/cover_<company>_<role>.tex`)
+4. **Verify both documents** (see Verification Checklist below)
+5. Prepare interview talking points based on the role requirements and your strengths
+
+**Important:** When mentioning agentic coding or AI tooling in CVs/cover letters, explicitly reference **Codex** by name.
+
+## Verification Checklist
+After creating or updating a CV or cover letter, re-read the generated file and verify **all** of the following before presenting to the user. Report the results as a pass/fail checklist.
+
+### Factual accuracy
+- [ ] All claims match actual profile (AGENTS.md / candidate profile) - no fabricated skills, experience, or achievements
+- [ ] Job titles, dates, company names, and locations are correct
+- [ ] Contact details are correct
+- [ ] All company-specific claims (partnerships, products, technology, expansions) have been independently verified with available web/search tools - do not trust reviewer research without verification
+
+### Targeting
+- [ ] Profile statement / opening paragraph is tailored to the specific role (not generic)
+- [ ] Skills and experience bullets are reframed to match the job requirements
+- [ ] Key job requirements are addressed (with gaps acknowledged where relevant)
+- [ ] Nice-to-have requirements are highlighted where there is a match
+
+### Consistency
+- [ ] CV follows the standard 2-page moderncv/banking format
+- [ ] Cover letter uses cover.cls template and established structure
+- [ ] Tone is consistent across CV and cover letter
+- [ ] No contradictions between CV and cover letter content
+
+### Quality
+- [ ] No LaTeX syntax errors (balanced braces, correct commands)
+- [ ] No spelling or grammar errors
+- [ ] Agentic coding / AI tooling references mention **Codex** by name
+- [ ] Cover letter is addressed to the correct person (or "Dear Hiring Manager" if unknown)
+- [ ] Cover letter fits approximately one page
+
+### Compiled PDF verification (MANDATORY - never skip)
+Both documents MUST be compiled and visually inspected with available PDF/file-reading tools. "Looks fine in the .tex" is not acceptable - LaTeX page-break decisions are unpredictable. Iterate until these all pass:
+- [ ] CV compiled with **lualatex** (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors). Cover letter compiled with **xelatex** (cover.cls requires fontspec).
+- [ ] **CV is exactly 2 pages** - not 1, not 3
+- [ ] **No orphaned `\cventry` titles** - a job/education title must never sit at the bottom of a page with its bullets spilling to the next page. Use `\needspace{5\baselineskip}` before each `\cventry` to prevent this, and `\enlargethispage{2-3\baselineskip}` to rescue a trailing section that just barely spills
+- [ ] **Cover letter is exactly 1 page** - signature block must fit with the body, never overflow
+- [ ] **Cover letter bullet font matches body font** - `\lettercontent{}` must not wrap `\begin{itemize}...\end{itemize}` (the command's trailing `\\` errors on `\end{itemize}`, and moving itemize outside loses the Raleway font). Standard pattern: close `\lettercontent{}`, then wrap the list in `{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont \begin{itemize}...\end{itemize}\par}`
+
+### ATS & keyword verification (CV)
+ATS parsers read the PDF's embedded text layer, not the rendered page. Extract it with `pdftotext -layout` and verify what a parser sees. `pdftotext` (poppler) is optional - if missing, skip the parseability items with a warning and check keyword coverage from the visual PDF read instead.
+- [ ] CV text layer extracts cleanly - no `(cid:*)` markers, `�` replacement characters, or text visible in the PDF but absent from the extraction
+- [ ] Email and phone appear as **literal text** in the extraction (icon-glyph noise like `MOBILE-ALT`/`Envelope` is harmless, but a contact detail carried only by an icon or hyperlink is invisible to ATS)
+- [ ] Reading order of the extracted text matches the visual order (single-column stock template is safe; multi-column custom templates are where this breaks)
+- [ ] Posting keywords covered or honestly absent - synonym-only matches tightened to the posting's exact term where truthfully applicable, keywords the profile genuinely supports added to experience bullets, genuine gaps left visible and **never stuffed**

--- a/CODEX_SETUP.md
+++ b/CODEX_SETUP.md
@@ -1,0 +1,152 @@
+# Codex Setup Guide
+
+This guide explains how to run the AI Job Search framework with Codex. The existing Claude Code setup remains supported; Codex support is additive.
+
+## 1. Prerequisites
+
+Install:
+
+- Codex
+- Python 3.10+ for `salary_lookup.py`
+- Bun for the job portal CLI tools
+- A LaTeX distribution with `lualatex` and `xelatex`
+- Optional: `pdftotext` from Poppler for ATS text-layer checks
+
+Codex reads repository instructions from `AGENTS.md` and repository skills from `.agents/skills/`.
+
+## 2. Install Job Search CLI Dependencies
+
+Run these from the repository root.
+
+PowerShell:
+
+```powershell
+$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search")
+foreach ($tool in $tools) {
+  Set-Location ".agents/skills/$tool/cli"
+  bun install
+  Set-Location "..\..\..\.."
+}
+```
+
+Bash, zsh, or Git Bash:
+
+```bash
+for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search; do
+  cd .agents/skills/$tool/cli && bun install && cd ../../../..
+done
+```
+
+For `linkedin-search`, `bun install` is optional for runtime use because the CLI has zero runtime dependencies. It is still useful for typechecking and tests.
+
+## 3. Start Codex in the Repository
+
+Open Codex from the repository root:
+
+```bash
+codex
+```
+
+Codex should load:
+
+- `AGENTS.md` for repository rules and the candidate profile
+- `.agents/skills/*/SKILL.md` for reusable workflows
+
+If Codex does not pick up new skills immediately, restart the Codex session.
+
+## 4. Run the Setup Workflow
+
+Ask Codex:
+
+```text
+Run setup for this job search workspace.
+```
+
+or:
+
+```text
+/setup
+```
+
+Codex will use `.agents/skills/setup/SKILL.md`. The setup workflow offers the same three paths as the Claude Code workflow:
+
+- Documents folder
+- Single CV import
+- Interview mode
+
+The Codex setup populates:
+
+- `AGENTS.md`
+- `.agents/skills/job-application-assistant/01-candidate-profile.md`
+- `.agents/skills/job-application-assistant/02-behavioral-profile.md`
+- `.agents/skills/job-application-assistant/04-job-evaluation.md`
+- `.agents/skills/job-application-assistant/05-cv-templates.md`
+- `.agents/skills/job-application-assistant/07-interview-prep.md`
+- `cv/main_example.tex`
+- `.agents/skills/job-scraper/search-queries.md`
+
+## 5. Search, Rank, and Apply
+
+Ask Codex to search for jobs:
+
+```text
+Find new jobs.
+```
+
+or:
+
+```text
+/scrape
+```
+
+Ask Codex to rank scraped jobs:
+
+```text
+Rank the scraped jobs.
+```
+
+or:
+
+```text
+/rank
+```
+
+Ask Codex to apply to a posting:
+
+```text
+Apply to this job: https://example.com/job-posting
+```
+
+or paste the full posting text and ask Codex to run the application workflow.
+
+The Codex `/apply` skill evaluates fit first, asks before drafting, creates tailored LaTeX files, compiles and inspects the PDFs, and performs the ATS text-layer check when `pdftotext` is available.
+
+## 6. Other Codex Workflows
+
+The following repository skills mirror the Claude command workflows:
+
+| Workflow | Codex skill |
+|---|---|
+| Setup profile | `.agents/skills/setup/SKILL.md` |
+| Apply to a job | `.agents/skills/apply/SKILL.md` |
+| Scrape jobs | `.agents/skills/job-scraper/SKILL.md` |
+| Rank scraped jobs | `.agents/skills/rank/SKILL.md` |
+| Record outcomes | `.agents/skills/outcome/SKILL.md` |
+| Expand competencies | `.agents/skills/expand/SKILL.md` |
+| Register templates | `.agents/skills/add-template/SKILL.md` |
+| Add job portals | `.agents/skills/add-portal/SKILL.md` |
+| Reset profile/documents | `.agents/skills/reset/SKILL.md` |
+| Upskill plan | `.agents/skills/upskill/SKILL.md` |
+
+You can invoke skills explicitly by name or naturally by describing the task.
+
+## 7. Notes for Claude Code Users
+
+Claude Code remains supported through:
+
+- `CLAUDE.md`
+- `.claude/commands/`
+- `.claude/skills/`
+- `.claude/settings.json`
+
+The two setups are intentionally parallel. Use the Codex paths when working in Codex, and use the Claude paths when working in Claude Code.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # AI Job Search
 
-An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
+An AI-powered job application framework built for agentic coding assistants, with support for [Claude Code](https://claude.com/claude-code) and Codex. Fork it, fill in your profile, and let your coding agent evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
-> Note: This is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic. Anthropic and Claude Code are referenced only to describe the toolchain this workflow uses.
+> Note: This is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic or OpenAI. Anthropic, Claude Code, OpenAI, and Codex are referenced only to describe supported toolchains.
 
 <p align="center">
   <a href="https://ko-fi.com/madslorentzen">
@@ -16,7 +16,7 @@ An AI-powered job application framework built on [Claude Code](https://claude.co
 
 ## What this is
 
-A structured workflow that turns Claude Code into a full-stack job application assistant. The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
+A structured workflow that turns an agentic coding assistant into a full-stack job application assistant. The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
 
 ```
 /setup          /scrape              /apply <url>
@@ -38,7 +38,7 @@ The framework encodes career guidance best practices, including structured evalu
 
 ## Prerequisites
 
-- [Claude Code](https://claude.com/claude-code) (CLI)
+- [Claude Code](https://claude.com/claude-code) (CLI) or Codex
 - Python 3.10+
 - [Bun](https://bun.sh) (for Danish job search CLI tools)
 - LaTeX distribution with `lualatex` and `xelatex`: [TeX Live](https://tug.org/texlive/) or [MiKTeX](https://miktex.org/). The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors); the cover letter compiles with `xelatex` because `cover.cls` requires `fontspec`.
@@ -67,13 +67,25 @@ For `linkedin-search` the install is optional: it has zero runtime dependencies 
 
 ### 3. Set up your profile
 
+With Claude Code:
+
 ```bash
 claude
 # Then inside Claude Code:
 /setup
 ```
 
+With Codex:
+
+```bash
+codex
+# Then ask Codex:
+Run setup for this job search workspace.
+```
+
 `/setup` offers three paths: read your `documents/` folder if you have one populated (CV PDF, LinkedIn export, diplomas, reference letters, past applications), import a single CV pasted in chat, or walk through an interview. It auto-detects what you have and asks. Documents-folder mode is idempotent and safe to re-run as you add more material; see `documents/README.md` for the layout.
+
+For detailed Codex instructions, see [`CODEX_SETUP.md`](CODEX_SETUP.md).
 
 ### 4. Search for jobs
 
@@ -115,6 +127,7 @@ This runs the full workflow: evaluate fit, draft CV + cover letter, review with 
 ```
 ai-job-search/
 ├── CLAUDE.md                          # Main candidate profile + workflow rules
+├── AGENTS.md                          # Codex candidate profile + workflow rules
 ├── .claude/
 │   ├── commands/
 │   │   ├── apply.md                   # /apply workflow (drafter-reviewer)
@@ -138,7 +151,7 @@ ai-job-search/
 │   │   ├── job-scraper/               # Job search orchestration
 │   │   └── upskill/                   # /upskill skill gap analysis and learning plan
 │   └── settings.json                  # Claude Code permissions (shared, scoped)
-├── .agents/skills/                    # Job portal CLI tools
+├── .agents/skills/                    # Codex skills and job portal CLI tools
 │   ├── jobbank-search/                # Akademikernes Jobbank (Denmark)
 │   ├── jobdanmark-search/             # Jobdanmark.dk (Denmark)
 │   ├── jobindex-search/               # Jobindex.dk (Denmark)
@@ -177,7 +190,7 @@ The `/apply` command runs a **drafter-reviewer workflow** with mandatory PDF com
 3. **Draft** a tailored CV and cover letter in LaTeX
 4. **Spawn a reviewer agent** that researches the company and critiques the drafts
 5. **Revise** based on the reviewer's feedback
-6. **Compile and inspect** both PDFs: lualatex for the CV, xelatex for the cover letter. Claude reads the rendered pages and iterates on the LaTeX until the CV is exactly 2 pages with no orphaned entry titles, and the cover letter is exactly 1 page with the signature visible and fonts consistent.
+6. **Compile and inspect** both PDFs: lualatex for the CV, xelatex for the cover letter. The agent reads the rendered pages and iterates on the LaTeX until the CV is exactly 2 pages with no orphaned entry titles, and the cover letter is exactly 1 page with the signature visible and fonts consistent.
 7. **ATS-check the CV**: extract the PDF's text layer (`pdftotext`, optional dependency) and verify it the way an ATS parser sees it — contact details present as literal text, no garbled glyphs, sane reading order — then score the posting's keyword coverage against the extraction. Keywords the profile genuinely supports get added; genuine gaps stay visible, never stuffed.
 8. **Present** the final output with a verification checklist
 
@@ -188,7 +201,7 @@ All claims in the CV and cover letter are verified against your actual profile. 
 - **PDF verification loop.** Most LaTeX-resume templates produce "looks fine in the .tex" output that breaks in the PDF: job titles orphan to the next page, cover letters spill onto page 2, bullet fonts silently fall back to the body font. The `/apply` command compiles and visually inspects every PDF and applies targeted fixes (`\needspace`, `\enlargethispage`, font-matching wrappers for list items) until the layout is clean. This runs automatically on every application.
 - **ATS verification on the PDF text layer.** An ATS reads the PDF's embedded text, not the rendered page — and LaTeX can silently produce PDFs whose text extracts as garbage (icon glyphs where the email should be, interleaved lines from multi-column layouts). `/apply` extracts the compiled CV's text layer with `pdftotext` and verifies contact details, reading order, and the posting's keyword coverage against what a parser actually sees. Honesty rule enforced: a keyword the profile doesn't support is acknowledged as a gap, never stuffed in.
 - **Relevance-weighted CV cutting.** When a CV overflows 2 pages, the workflow does not cut mechanically from the "oldest" section. It scores each candidate line by (a) relevance to the target posting, (b) uniqueness in the document, and (c) whether the cover letter depends on it, and cuts the lowest-total-score line first. An older-role bullet that hits posting keywords survives ahead of a recent-role bullet that does not.
-- **Drafter-reviewer separation.** The drafter writes; a second Claude agent, spawned with a fresh context, researches the company and critiques the drafts. The drafter then revises. This catches missed keywords, weak framing, and generic language that a single pass often leaves in.
+- **Drafter-reviewer separation.** The drafter writes; a separate reviewer pass researches the company and critiques the drafts. The drafter then revises. This catches missed keywords, weak framing, and generic language that a single pass often leaves in.
 - **Token-efficient reviewer dispatch.** The reviewer agent receives drafts inline rather than re-reading them, and the verification checklist runs once at the end of the workflow rather than being duplicated by both agents. Note: the new compile-and-inspect step in Step 5 spends some of those savings on PDF rendering and layout iteration — the workflow trades some end-to-end token cost for a real reduction in broken PDFs reaching the user.
 
 ## Customization
@@ -199,7 +212,7 @@ If you prefer editing files directly instead of using `/setup`:
 
 | File | What to change |
 |------|---------------|
-| `CLAUDE.md` | Your full profile (name, education, experience, skills, goals) |
+| `CLAUDE.md` / `AGENTS.md` | Your full profile (name, education, experience, skills, goals) |
 | `01-candidate-profile.md` | Structured version of your CV data |
 | `02-behavioral-profile.md` | Your behavioral assessment or self-assessment |
 | `04-job-evaluation.md` | Skill match areas, career goals, motivation filters |
@@ -285,7 +298,7 @@ To get the most from this, invest time during `/setup` in describing not just yo
 ## Acknowledgements
 
 - [Mikkel Krogholm](https://github.com/mikkelkrogsholm) ([skills repo](https://github.com/mikkelkrogsholm/skills)) for the job search CLI skills
-- Built with [Claude Code](https://claude.com/claude-code) by [Anthropic](https://anthropic.com)
+- Built for agentic coding assistants, with Claude Code and Codex setup paths
 
 ## License
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,6 +4,15 @@ Step-by-step instructions for getting the AI Job Search framework running.
 
 ## 1. Prerequisites
 
+### Agent runtime
+
+This framework supports two agent runtimes:
+
+- **Claude Code** through `CLAUDE.md`, `.claude/commands/`, and `.claude/skills/`
+- **Codex** through `AGENTS.md` and `.agents/skills/`
+
+Use the setup path for the runtime you plan to work in.
+
 ### Claude Code
 
 Install Claude Code (Anthropic's CLI for Claude):
@@ -13,6 +22,10 @@ npm install -g @anthropic-ai/claude-code
 ```
 
 You'll need an Anthropic API key or a Claude Pro/Team subscription. See the [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) for details.
+
+### Codex
+
+Install and authenticate Codex using the instructions for your environment. See [`CODEX_SETUP.md`](CODEX_SETUP.md) for the Codex-specific workflow.
 
 ### Python
 
@@ -98,6 +111,24 @@ If you're outside Denmark, you can generate an equivalent search skill for your 
 
 ## 4. Run the setup interview
 
+### Codex
+
+Start Codex in the repository:
+
+```bash
+codex
+```
+
+Then ask Codex:
+
+```text
+Run setup for this job search workspace.
+```
+
+Codex reads `AGENTS.md` and uses `.agents/skills/setup/SKILL.md`.
+
+### Claude Code
+
 Start Claude Code in the repository:
 
 ```bash
@@ -122,7 +153,7 @@ All three paths produce the same result: fully populated profile files.
 
 | File | Content |
 |------|---------|
-| `CLAUDE.md` | Your full candidate profile |
+| `CLAUDE.md` / `AGENTS.md` | Your full candidate profile and workflow rules |
 | `01-candidate-profile.md` | Structured education, experience, skills |
 | `02-behavioral-profile.md` | Behavioral assessment |
 | `04-job-evaluation.md` | Personalized skill match areas and career goals |
@@ -170,11 +201,11 @@ Or paste the job description directly:
 /apply [paste job posting text here]
 ```
 
-Claude will:
+The agent will:
 1. Evaluate the fit against your profile
 2. Ask if you want to proceed
 3. Draft a tailored CV and cover letter
-4. Have a reviewer agent critique the drafts
+4. Run a reviewer pass on the drafts
 5. Revise and present the final output
 
 ## 7. Compile your documents

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # Documents Folder
 
-This folder holds your actual career documents. The `/setup` command reads everything here and uses it to populate the candidate skill files under `.claude/skills/job-application-assistant/`. It is safe to re-run `/setup` as you add new documents — it merges intelligently and will never overwrite existing content without asking you first.
+This folder holds your actual career documents. The `/setup` workflow reads everything here and uses it to populate the candidate skill files. Claude Code uses `.claude/skills/job-application-assistant/`; Codex uses `.agents/skills/job-application-assistant/`. It is safe to re-run `/setup` as you add new documents — it merges intelligently and will never overwrite existing content without asking you first.
 
 ---
 
@@ -154,7 +154,7 @@ Any signal about what they valued or didn't?
 
 | Format | Readable by `/setup` | Notes |
 |--------|--------------------------|-------|
-| `.pdf` | Yes | Parsed directly with the Read tool |
+| `.pdf` | Yes | Parsed directly with the agent's available PDF/file-reading tools |
 | `.tex` | Yes | LaTeX source — structure and content both readable |
 | `.md` | Yes | Plain text |
 | `.txt` | Yes | Plain text |

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Custom Templates
 
-This folder holds user-registered LaTeX templates, managed by the `/add-template` command. The framework works out of the box with its stock templates (moderncv for CVs, `cover.cls` for cover letters) — this folder only gets content when you register your own.
+This folder holds user-registered LaTeX templates, managed by the `/add-template` workflow. The framework works out of the box with its stock templates (moderncv for CVs, `cover.cls` for cover letters) — this folder only gets content when you register your own.
 
 ## Layout
 
@@ -20,7 +20,7 @@ templates/
 ## How it works
 
 - `/add-template` interviews you for the template's instructions (compile engine, fonts, style rules, page limit), stores the files here, and runs a mandatory test compile before registering anything.
-- Activating a template adds a managed block to `05-cv-templates.md` or `06-cover-letter-templates.md`, which is what `/apply` reads when drafting — no other wiring needed.
+- Activating a template adds a managed block to `05-cv-templates.md` or `06-cover-letter-templates.md`, which is what `/apply` reads when drafting — no other wiring needed. Claude Code reads these under `.claude/skills/job-application-assistant/`; Codex reads them under `.agents/skills/job-application-assistant/`.
 - `/add-template --list` shows registered templates; `/add-template --use <name>` switches; `/add-template --use default` reverts to the stock templates.
 
 Templates are stored with `[PLACEHOLDER]` tokens instead of personal data, so they are safe to commit and share.


### PR DESCRIPTION
## Summary

- Add Codex-native `AGENTS.md` guidance and `CODEX_SETUP.md` onboarding documentation.
- Add `.agents/skills/` equivalents for the existing job-search workflows, including setup, apply, rank, outcome, expand, reset, template, portal, assistant, scraper, and upskill skills.
- Update README/setup/template/document docs to describe both Claude Code and Codex usage.
- Fix existing `.agents` portal search commands to run from `.agents/skills/...` paths.

## Validation

- Ran `codex exec` smoke checks in a temporary copy of the repo for setup discovery and Path C setup output generation.
- Verified setup output stayed scoped to setup-owned files in the temp repo.
- Ran stale path/tool audits for `.Codex`, `.claude/skills`, and `bun run skills/` references in Codex-facing files.
- Ran skill frontmatter audit across `.agents/skills/*/SKILL.md`.
- Ran `git diff --check` successfully.

## Notes

`bun` and `lualatex` were not available in the local PATH, so scraper CLI execution and LaTeX PDF compilation could not be validated locally.