### PR TITLE
chore: untrack tracker CSV, scope scraper Bash permission, fix portal SKILL.md paths

### DIFF
--- a/.agents/skills/jobbank-search/SKILL.md
+++ b/.agents/skills/jobbank-search/SKILL.md
@@ -19,7 +19,7 @@ description: >
   jobbank søgning, find stilling, data scientist job, software developer job,
   projektleder stilling, konsulent job, data analyse job.
 context: fork
-allowed-tools: Bash(bun run skills/jobbank-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobbank-search/cli/src/cli.ts *)
 ---
 
 # Jobbank Search Skill
@@ -43,7 +43,7 @@ Invoke this skill when the user wants to:
 ### Search jobs
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -66,7 +66,7 @@ Key flags:
 ### Full job detail
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts detail <id> [--format json|plain]
+bun run .agents/skills/jobbank-search/cli/src/cli.ts detail <id> [--format json|plain]
 ```
 
 `id` is the numeric job ID from `search` results. Fetches the job page and parses the embedded Schema.org `JobPosting` JSON-LD for structured data.
@@ -84,7 +84,7 @@ bun run skills/jobbank-search/cli/src/cli.ts detail <id> [--format json|plain]
 
 ```bash
 # IT or Finance industry, Copenhagen or Aarhus
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --industry 10331 --industry 10358 \
   --location 2 --location 8
 ```
@@ -98,7 +98,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Find data scientist jobs in Copenhagen
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --key "data scientist" \
   --location 2 \
   --format table
@@ -107,7 +107,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Graduate trainee positions for new graduates
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --type 6 \
   --suitable-for 2 \
   --format table
@@ -116,7 +116,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Remote IT software jobs
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --work-area 31 \
   --remote helt \
   --format table
@@ -125,7 +125,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Ph.d. and postdoc positions in research
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --type 12 \
   --industry 10442 \
   --format table
@@ -134,7 +134,7 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Recent full-time jobs posted since March 1
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --type 3 \
   --since 2026-03-01 \
   --format table
@@ -143,13 +143,13 @@ bun run skills/jobbank-search/cli/src/cli.ts search \
 ### Full details for a specific job
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts detail 1234567 --format plain
+bun run .agents/skills/jobbank-search/cli/src/cli.ts detail 1234567 --format plain
 ```
 
 ### IT jobs in Aarhus or Copenhagen
 
 ```bash
-bun run skills/jobbank-search/cli/src/cli.ts search \
+bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --key developer \
   --location 2 --location 8 \
   --work-area 31 \

--- a/.agents/skills/jobdanmark-search/SKILL.md
+++ b/.agents/skills/jobdanmark-search/SKILL.md
@@ -17,7 +17,7 @@ description: >
   work in denmark, employment denmark, job denmark, jobs near me denmark,
   apprentice denmark, internship denmark, part-time denmark, full-time denmark.
 context: fork
-allowed-tools: Bash(bun run skills/jobdanmark-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobdanmark-search/cli/src/cli.ts *)
 ---
 
 # Jobdanmark Search Skill
@@ -42,7 +42,7 @@ Invoke this skill when the user wants to:
 ### Search job listings
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -62,7 +62,7 @@ Key flags:
 ### Full job detail
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts detail <slug> [--format json|plain]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts detail <slug> [--format json|plain]
 ```
 
 `slug` is the URL path segment returned as `slug` in `search` results (e.g. `it-chef-soeges-til-rah`).
@@ -71,7 +71,7 @@ Returns full structured job data from the job page's JSON-LD, including title, o
 ### List categories with live counts
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts categories [--format json|table|plain]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts categories [--format json|table|plain]
 ```
 
 Returns all 10 job categories with current live job counts. Useful for giving the user an overview of the job market.
@@ -79,7 +79,7 @@ Returns all 10 job categories with current live job counts. Useful for giving th
 ### Autocomplete job titles and categories
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "<text>" [--limit <n>]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "<text>" [--limit <n>]
 ```
 
 Use this to resolve search terms into precise job title IDs (`--jobtitle-id`) or category IDs (`--category`) for `search`. The `value` field in results is the ID to pass to `search`.
@@ -87,7 +87,7 @@ Use this to resolve search terms into precise job title IDs (`--jobtitle-id`) or
 ### Suggest locations
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts locations --query "<text>" [--limit <n>]
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts locations --query "<text>" [--limit <n>]
 ```
 
 Returns matching municipalities, zip codes, and regions. Use `value` from results as `--municipality` or `--zip` in `search`.
@@ -116,13 +116,13 @@ Returns matching municipalities, zip codes, and regions. Use `value` from result
 **Resolve locations first.** Use `locations` to find the correct municipality name or zip code before passing them to `search`:
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts locations --query "Aarhus" --format plain
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts locations --query "Aarhus" --format plain
 ```
 
 **Resolve job titles for precision.** Use `autocomplete` to get the exact job title ID when the user wants a specific role:
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "sygeplejerske" --format plain
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "sygeplejerske" --format plain
 ```
 
 **Natural workflow: `search` → `detail`.**
@@ -142,7 +142,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts autocomplete --query "sygeplejer
 ### IT jobs in Copenhagen
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --category 227978 \
   --municipality "København" \
   --job-type fuldtid \
@@ -152,7 +152,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### Nursing jobs anywhere in Denmark
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --text "sygeplejerske" \
   --category 227975 \
   --format table
@@ -161,7 +161,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### Student jobs in Aarhus
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --municipality "Aarhus" \
   --job-type studiejob \
   --format table
@@ -170,25 +170,25 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### What job categories are most active right now?
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts categories --format table
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts categories --format table
 ```
 
 ### Full details for a specific job posting
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts detail it-chef-soeges-til-rah --format plain
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts detail it-chef-soeges-til-rah --format plain
 ```
 
 ### Find jobs in zip code 8000
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search --zip 8000 --format table
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search --zip 8000 --format table
 ```
 
 ### What electrician jobs are available?
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --text "elektriker" \
   --category 227973 \
   --job-type "fuldtid,deltid" \
@@ -198,7 +198,7 @@ bun run skills/jobdanmark-search/cli/src/cli.ts search \
 ### Apprentice positions in all of Denmark
 
 ```bash
-bun run skills/jobdanmark-search/cli/src/cli.ts search \
+bun run .agents/skills/jobdanmark-search/cli/src/cli.ts search \
   --job-type elev \
   --page 1 \
   --format table

--- a/.agents/skills/jobindex-search/SKILL.md
+++ b/.agents/skills/jobindex-search/SKILL.md
@@ -17,7 +17,7 @@ description: >
   hiring denmark, job listings denmark, python jobs denmark, grafisk designer job,
   data engineer job, softwareudvikler job, full stack developer job danmark.
 context: fork
-allowed-tools: Bash(bun run skills/jobindex-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobindex-search/cli/src/cli.ts *)
 ---
 
 # Jobindex Search Skill
@@ -40,7 +40,7 @@ Invoke this skill when the user wants to:
 ### Search job listings
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -56,7 +56,7 @@ Key flags:
 ### Fetch full job detail
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts detail <id> [--format json|plain]
+bun run .agents/skills/jobindex-search/cli/src/cli.ts detail <id> [--format json|plain]
 ```
 
 `id` is the job ID from `search` results (e.g. `h1647303`). You may also pass the full Jobindex URL. Returns the full job description, deadline, employment type, hours, and apply link.
@@ -86,7 +86,7 @@ bun run skills/jobindex-search/cli/src/cli.ts detail <id> [--format json|plain]
 ### Find Python jobs posted in the last 7 days
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query python \
   --jobage 7 \
   --sort date \
@@ -96,7 +96,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Data engineer jobs in Copenhagen
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "data engineer københavn" \
   --sort score \
   --format table
@@ -105,7 +105,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Graphic designer jobs — all time, by relevance
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "grafisk designer" \
   --limit 10 \
   --format table
@@ -114,7 +114,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Full-stack developer jobs, page 2
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "full stack developer" \
   --page 2 \
   --format json
@@ -123,7 +123,7 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Jobs posted today across all sectors
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --jobage 1 \
   --sort date \
   --limit 20 \
@@ -133,13 +133,13 @@ bun run skills/jobindex-search/cli/src/cli.ts search \
 ### Get full details for a specific job
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts detail h1647303 --format plain
+bun run .agents/skills/jobindex-search/cli/src/cli.ts detail h1647303 --format plain
 ```
 
 ### Marketing jobs in Aarhus
 
 ```bash
-bun run skills/jobindex-search/cli/src/cli.ts search \
+bun run .agents/skills/jobindex-search/cli/src/cli.ts search \
   --query "marketing aarhus" \
   --jobage 30 \
   --sort date \

--- a/.agents/skills/jobnet-search/SKILL.md
+++ b/.agents/skills/jobnet-search/SKILL.md
@@ -18,7 +18,7 @@ description: >
   social worker job denmark, occupation search denmark, esco occupation, job deadline,
   ansøgningsfrist, søg efter job, full time job denmark, part time job denmark.
 context: fork
-allowed-tools: Bash(bun run skills/jobnet-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/jobnet-search/cli/src/cli.ts *)
 ---
 
 # Jobnet-Search Skill
@@ -45,7 +45,7 @@ Invoke this skill when the user wants to:
 ### Search for job ads
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search [flags]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search [flags]
 ```
 
 Key flags:
@@ -65,7 +65,7 @@ Key flags:
 ### Full job ad detail
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts detail <jobAdId> [--format json|plain]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts detail <jobAdId> [--format json|plain]
 ```
 
 `jobAdId` is the UUID from `search` results (the `jobAdId` field). Returns the complete job
@@ -74,7 +74,7 @@ description, contact persons, application deadline, employer details, and direct
 ### Search occupation types
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts occupations --search-string <text> [--per-page <n>]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts occupations --search-string <text> [--per-page <n>]
 ```
 
 Use this to discover ESCO occupation identifiers before passing them to `search` with
@@ -83,7 +83,7 @@ Use this to discover ESCO occupation identifiers before passing them to `search`
 ### Typeahead suggestions
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts suggestions --query <text> [--limit <n>]
+bun run .agents/skills/jobnet-search/cli/src/cli.ts suggestions --query <text> [--limit <n>]
 ```
 
 Returns Danish job title autocomplete strings. Useful for exploring valid Danish
@@ -97,8 +97,8 @@ job titles before constructing a `search` query.
 term or ESCO identifier before running a `search`:
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts suggestions --query "syge"
-bun run skills/jobnet-search/cli/src/cli.ts occupations --search-string "sygeplejerske"
+bun run .agents/skills/jobnet-search/cli/src/cli.ts suggestions --query "syge"
+bun run .agents/skills/jobnet-search/cli/src/cli.ts occupations --search-string "sygeplejerske"
 ```
 
 **Natural workflow: `search` → `detail`.**
@@ -128,7 +128,7 @@ CLI outputs. Use `--page` + `--per-page` to iterate through large result sets.
 ### Jobs in Copenhagen area
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --region HovedstadenOgBornholm \
   --per-page 10 \
   --format table
@@ -137,7 +137,7 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### Nurse jobs nationwide
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --search-string "sygeplejerske" \
   --work-hours FullTime \
   --duration Permanent \
@@ -149,7 +149,7 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### IT jobs near Aarhus within 30km
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --search-string "udvikler" \
   --postal-code 8000 \
   --radius 30 \
@@ -160,13 +160,13 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### Full details of a job ad
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts detail 9ef43bce-d82b-4ea1-a098-7ff6520f99be --format plain
+bun run .agents/skills/jobnet-search/cli/src/cli.ts detail 9ef43bce-d82b-4ea1-a098-7ff6520f99be --format plain
 ```
 
 ### Jobs sorted by application deadline (urgent first)
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts search \
+bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
   --search-string "pædagog" \
   --region OevrigeSjaelland \
   --order ApplicationDate \
@@ -176,8 +176,8 @@ bun run skills/jobnet-search/cli/src/cli.ts search \
 ### Discover occupation terms
 
 ```bash
-bun run skills/jobnet-search/cli/src/cli.ts suggestions --query "ingeniør" --limit 5
-bun run skills/jobnet-search/cli/src/cli.ts occupations --search-string "lærer" --per-page 5
+bun run .agents/skills/jobnet-search/cli/src/cli.ts suggestions --query "ingeniør" --limit 5
+bun run .agents/skills/jobnet-search/cli/src/cli.ts occupations --search-string "lærer" --per-page 5
 ```
 
 ---

--- a/.agents/skills/linkedin-search/SKILL.md
+++ b/.agents/skills/linkedin-search/SKILL.md
@@ -11,7 +11,7 @@ description: >
   positions open, remote jobs, "are there any X jobs in <place>", look up this
   job posting.
 context: fork
-allowed-tools: Bash(bun run skills/linkedin-search/cli/src/cli.ts *)
+allowed-tools: Bash(bun run .agents/skills/linkedin-search/cli/src/cli.ts *)
 ---
 
 # LinkedIn Search Skill
@@ -42,7 +42,7 @@ Run it on your own responsibility.
 ### Search job listings
 
 ```bash
-bun run skills/linkedin-search/cli/src/cli.ts search --location "<place>" [flags]
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search --location "<place>" [flags]
 ```
 
 Key flags:
@@ -57,7 +57,7 @@ Key flags:
 ### Fetch full job detail
 
 ```bash
-bun run skills/linkedin-search/cli/src/cli.ts detail <id|url> [--format json|plain]
+bun run .agents/skills/linkedin-search/cli/src/cli.ts detail <id|url> [--format json|plain]
 ```
 
 `id` is the job ID from `search` results (e.g. `4426311357`). You may also pass a full
@@ -68,16 +68,16 @@ seniority, employment type, job function, industries, and apply link.
 
 ```bash
 # Data engineer roles in Bengaluru, last 30 days
-bun run skills/linkedin-search/cli/src/cli.ts search -q "data engineer" -l "Bengaluru, Karnataka, India" --jobage 30 --format table
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "data engineer" -l "Bengaluru, Karnataka, India" --jobage 30 --format table
 
 # Product manager roles in Berlin, remote
-bun run skills/linkedin-search/cli/src/cli.ts search -q "product manager" -l "Berlin, Germany" --remote remote --format table
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "product manager" -l "Berlin, Germany" --remote remote --format table
 
 # Any role, fully remote
-bun run skills/linkedin-search/cli/src/cli.ts search -q "paralegal" -l "Remote" --format table
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "paralegal" -l "Remote" --format table
 
 # Full details for a specific job
-bun run skills/linkedin-search/cli/src/cli.ts detail 4426311357 --format plain
+bun run .agents/skills/linkedin-search/cli/src/cli.ts detail 4426311357 --format plain
 ```
 
 ## Output formats

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -3,7 +3,7 @@ name: job-scraper
 description: >
   Scrapes Danish job sites for new positions matching your profile. Deduplicates across runs.
   Triggers on: job scrape, find jobs, search jobs, new jobs, job search, scrape jobs, /scrape
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, Agent, AskUserQuestion
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(bun --version), Bash(bun run .agents/skills/*/cli/src/cli.ts *), WebFetch, WebSearch, Agent, AskUserQuestion
 ---
 
 # Job Scraper

--- a/job_search_tracker.csv
+++ b/job_search_tracker.csv
@@ -1,1 +1,0 @@
-date,company,sector,role,role_type,channel,status,contact_person,fit_rating,notes,cv_file,cover_letter_file,source

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -55,11 +55,19 @@ def check_skill(path: Path) -> None:
 
     allowed = data.get("allowed-tools", "")
     if isinstance(allowed, str):
-        for match in re.finditer(r"bun run ([^\s*)]+)", allowed):
-            target = match.group(1)
-            candidates = [ROOT / target, ROOT / ".agents" / target]
-            if not any(c.is_file() for c in candidates):
-                errors.append(f"{rel(path)}: allowed-tools references a missing file: {target}")
+        for match in re.finditer(r"bun run ([^\s)]+)", allowed):
+            target = match.group(1).rstrip("*")
+            if not target or target.endswith("/"):
+                continue
+            # Targets may contain globs (e.g. .agents/skills/*/cli/src/cli.ts);
+            # require at least one existing file to match.
+            if "*" in target:
+                if not list(ROOT.glob(target)) and not list((ROOT / ".agents").glob(target)):
+                    errors.append(f"{rel(path)}: allowed-tools glob matches no files: {target}")
+            else:
+                candidates = [ROOT / target, ROOT / ".agents" / target]
+                if not any(c.is_file() for c in candidates):
+                    errors.append(f"{rel(path)}: allowed-tools references a missing file: {target}")
 
 
 def check_command(path: Path) -> None:


### PR DESCRIPTION
Maintenance follow-ups from today's PR round:

1. **Untrack `job_search_tracker.csv`** - it was both tracked and gitignored (the settings.local.json inconsistency class, see #27). Commands create it on demand with the standard header; existing clones keep their local copy.
2. **Scope the job-scraper `Bash` permission** from #52 to `bun --version` plus the portal-CLI invocation pattern - adopting the tighter form from #65.
3. **Fix `bun run skills/...` paths in all five portal SKILL.mds** to `bun run .agents/skills/...` - they didn't resolve from the repo root, and since #52 the scraper reads these docs to build its CLI invocations, so they're load-bearing now. Credit to #66 for spotting it.
4. **Lint update**: `tools/lint_skills.py` now glob-expands `bun run` targets in allowed-tools so scoped wildcard permissions pass (verified locally: `lint_skills: OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)