### PR TITLE
Fix workflow wiring and salary tool edge cases

### DIFF
--- a/.agents/skills/jobbank-search/SKILL.md
+++ b/.agents/skills/jobbank-search/SKILL.md
@@ -89,7 +89,7 @@ bun run .agents/skills/jobbank-search/cli/src/cli.ts search \
   --location 2 --location 8
 ```
 
-**Filter codes are documented in the README** at `skills/jobbank-search/cli/README.md`.
+**Filter codes are documented in the README** at `.agents/skills/jobbank-search/cli/README.md`.
 
 ---
 
@@ -176,4 +176,4 @@ All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and 
 - RSS feed returns max 100 results per query. For higher counts, `meta.total` shows the true total.
 - The `detail` command fetches a full job page and extracts the JSON-LD structured data block.
 - `location` values are region codes (e.g. `2` = Storkøbenhavn), not city names.
-- All filter codes are documented in `skills/jobbank-search/cli/README.md`.
+- All filter codes are documented in `.agents/skills/jobbank-search/cli/README.md`.

--- a/.agents/skills/jobbank-search/cli/README.md
+++ b/.agents/skills/jobbank-search/cli/README.md
@@ -14,7 +14,7 @@ CLI for [Akademikernes Jobbank](https://jobbank.dk) — Denmark's job portal for
 ## Installation
 
 ```bash
-cd skills/jobbank-search/cli
+cd .agents/skills/jobbank-search/cli
 bun install
 ```
 

--- a/.agents/skills/jobbank-search/cli/src/cli.ts
+++ b/.agents/skills/jobbank-search/cli/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import { createCLI } from "@bunli/core"
 import { search } from "./commands/search.js"
 import { detail } from "./commands/detail.js"

--- a/.agents/skills/jobdanmark-search/cli/README.md
+++ b/.agents/skills/jobdanmark-search/cli/README.md
@@ -11,7 +11,7 @@ CLI for the [Jobdanmark.dk](https://www.jobdanmark.dk) public job search API.
 ## Installation
 
 ```bash
-cd skills/jobdanmark-search/cli
+cd .agents/skills/jobdanmark-search/cli
 bun install
 ```
 

--- a/.agents/skills/jobdanmark-search/cli/src/cli.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import { createCLI } from "@bunli/core"
 import { search } from "./commands/search.js"
 import { detail } from "./commands/detail.js"

--- a/.agents/skills/jobindex-search/cli/README.md
+++ b/.agents/skills/jobindex-search/cli/README.md
@@ -11,7 +11,7 @@ CLI for searching jobs on [Jobindex.dk](https://www.jobindex.dk).
 ## Installation
 
 ```bash
-cd skills/jobindex-search/cli
+cd .agents/skills/jobindex-search/cli
 bun install
 ```
 

--- a/.agents/skills/jobindex-search/cli/src/cli.ts
+++ b/.agents/skills/jobindex-search/cli/src/cli.ts
@@ -1,10 +1,11 @@
+#!/usr/bin/env bun
 import { createCLI } from "@bunli/core"
 import { search } from "./commands/search.js"
 import { detail } from "./commands/detail.js"
 
 const cli = await createCLI({
   name: "jobindex-cli",
-  version: "0.1.0",
+  version: "1.0.0",
   description: "CLI for searching jobs on Jobindex.dk",
 })
 

--- a/.agents/skills/jobnet-search/cli/README.md
+++ b/.agents/skills/jobnet-search/cli/README.md
@@ -11,7 +11,7 @@ CLI for the [Jobnet.dk](https://jobnet.dk) Danish government job portal API.
 ## Installation
 
 ```bash
-cd skills/jobnet-search/cli
+cd .agents/skills/jobnet-search/cli
 bun install
 ```
 

--- a/.agents/skills/jobnet-search/cli/src/cli.ts
+++ b/.agents/skills/jobnet-search/cli/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import { createCLI } from "@bunli/core"
 import { search } from "./commands/search.js"
 import { detail } from "./commands/detail.js"
@@ -6,7 +7,7 @@ import { suggestions } from "./commands/suggestions.js"
 
 const cli = await createCLI({
   name: "jobnet-cli",
-  version: "0.1.0",
+  version: "1.0.0",
   description: "CLI for the Jobnet.dk Danish government job portal API",
 })
 

--- a/.agents/skills/linkedin-search/cli/src/commands/search.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/search.ts
@@ -55,7 +55,7 @@ export async function runSearch(opts: SearchOpts): Promise<number> {
   try {
     const html = await htmlFetch(buildUrl(opts))
     let cards = parseJobCards(html)
-    if (opts.limit && opts.limit > 0) cards = cards.slice(0, opts.limit)
+    if (opts.limit !== undefined && opts.limit >= 0) cards = cards.slice(0, opts.limit)
 
     if (opts.format === "table") {
       process.stdout.write(renderTable(cards) + "\n")

--- a/.agents/skills/linkedin-search/cli/tests/search.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/search.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { runSearch } from "../src/commands/search";
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write;
+
+function searchCard(id: string, title: string): string {
+  return `<li>
+    <div data-entity-urn="urn:li:jobPosting:${id}">
+      <a class="base-card__full-link" href="https://www.linkedin.com/jobs/view/${id}"></a>
+      <h3 class="base-search-card__title">${title}</h3>
+    </div>
+  </li>`;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+});
+
+describe("runSearch", () => {
+  test("--limit 0 emits zero results", async () => {
+    globalThis.fetch = (async () => new Response(searchCard("123456", "Engineer"))) as typeof fetch;
+
+    let stdout = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runSearch({
+      location: "Copenhagen, Denmark",
+      jobage: 9999,
+      page: 1,
+      limit: 0,
+      format: "json",
+    });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).results).toHaveLength(0);
+  });
+});

--- a/.claude/commands/add-portal.md
+++ b/.claude/commands/add-portal.md
@@ -31,7 +31,7 @@ Ask the user (skip anything already answered by `$ARGUMENTS`):
 
 ## Step 2: Investigate the Portal
 
-Do reconnaissance before writing any code. Use WebFetch (or `curl` via Bash) on the portal:
+Do reconnaissance before writing any code. Use WebFetch on the portal. Use `curl` only if the user's local Claude permissions already allow it.
 
 1. **Find the search URL pattern.** Load the portal's search page, run a search in the URL bar mentally or via fetch, and identify: the search endpoint, the query parameter, and any parameters for location, posting age, and pagination. Prefer a JSON API if one backs the site (check for `/api/` XHR endpoints in the page source); otherwise plan to parse the HTML results page.
 2. **Fetch one search-results response** for the test query and identify the per-result fields: **id, title, company, location, posting date, and URL**. For HTML, note the class names / attributes that anchor each field. For JSON, note the field paths.
@@ -78,16 +78,16 @@ These conventions are what make portal skills interchangeable for `/scrape` and 
 - **JSON output shape:** `{ "meta": { "count": ..., "page": ... }, "results": [...] }` where each result has at least `id`, `title`, `company`, `location`, `date`, `url` (missing values are `null`, never omitted).
 - **Errors:** written to **stderr** as `{ "error": "...", "code": "..." }`, exit code `1`. Never write errors to stdout.
 - **Fetching:** browser User-Agent, exponential backoff with jitter on 429/5xx (max ~6 retries), `""`/`null` on 404 rather than a crash.
-- **HTML parsing:** split the response into per-result chunks and parse each independently, so one malformed card cannot break the rest (see `parseJobCards` in `linkedin-search/cli/src/helpers.ts`).
+- **HTML parsing:** split the response into per-result chunks and parse each independently, so one malformed card cannot break the rest (see `parseJobCards` in `.agents/skills/linkedin-search/cli/src/helpers.ts`).
 - **Dependencies:** default to **zero runtime dependencies** (plain `bun` + `fetch` + regex parsing) like `linkedin-search` - `bun install` should only pull dev types. Only add a parsing library if the portal's markup genuinely defeats chunked regex parsing, and say so in the README.
 
 ### File specifics
 
-- **`SKILL.md` frontmatter:** `name`, `version: 1.0.0`, a `description` written for skill triggering - it must name the portal, the market, and include trigger phrases in English **and** the market's language; `context: fork`; `allowed-tools: Bash(bun run skills/<name>/cli/src/cli.ts *)`.
+- **`SKILL.md` frontmatter:** `name`, `version: 1.0.0`, a `description` written for skill triggering - it must name the portal, the market, and include trigger phrases in English **and** the market's language; `context: fork`; `allowed-tools: Bash(bun run .agents/skills/<name>/cli/src/cli.ts *)`.
 - **`SKILL.md` body:** what the skill searches, the personal-use warning if Step 2 found terms restrictions, command reference with flags, 4-6 usage examples using the user's market (real cities, realistic roles), output-format table, and a Notes section recording portal quirks found in Step 2.
 - **`url-reference.md`:** the endpoints, parameters table, and response-structure notes from Step 2 - this is the file a future maintainer needs when the portal changes its markup.
 - **`package.json`:** name `<portal>-cli`, `"type": "module"`, scripts `start`, `test` (`bun test --timeout 30000`), and `typecheck` (`tsc --noEmit`); dev-only dependencies in the zero-dependency default.
-- **`tests/`:** copy `runCLI`/`parseJSON` from `jobindex-search/cli/tests/helpers.ts`, then add a small live smoke-test file: `search` with the test query returns exit code 0 and ≥1 result with non-null `id`/`title`/`url`; a bogus flag or missing required arg exits 1 with a JSON error on stderr.
+- **`tests/`:** copy `runCLI`/`parseJSON` from `.agents/skills/jobindex-search/cli/tests/helpers.ts`, then add a small live smoke-test file: `search` with the test query returns exit code 0 and ≥1 result with non-null `id`/`title`/`url`; a bogus flag or missing required arg exits 1 with a JSON error on stderr.
 
 ---
 

--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -182,8 +182,8 @@ After all edits are applied, the two files on disk are the final drafts.
 ### 5a. Compile
 
 ```bash
-cd cv && lualatex -interaction=nonstopmode main_<company>.tex
-cd ../cover_letters && xelatex -interaction=nonstopmode cover_<company>_<role>.tex
+(cd cv && lualatex -interaction=nonstopmode -halt-on-error main_<company>.tex)
+(cd cover_letters && xelatex -interaction=nonstopmode -halt-on-error cover_<company>_<role>.tex)
 ```
 
 - CV uses **lualatex** — pdflatex fails on modern MiKTeX with fontawesome5 font-expansion errors. lualatex handles the same sources cleanly.
@@ -277,8 +277,10 @@ Summarize 3-5 key decisions made to tailor the application:
 ### Files Created
 List the files written:
 - `cv/main_<company>.tex`
+- `cv/main_<company>.pdf`
 - `cover_letters/cover_<company>_<role>.tex`
+- `cover_letters/cover_<company>_<role>.pdf`
 
-Tell the user: "Both files are ready for your review. Open them to check the final output before compiling."
+Tell the user: "Both PDFs have been compiled and verified. Open them to review before submitting."
 
 Also mention: once they have actually submitted the application, `/outcome <company>` logs it in the tracker and starts the per-application record that `/setup` later uses to calibrate the fit framework.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -46,6 +46,7 @@ Ask the user what happened, then classify:
 - `rejected` - explicit rejection at any stage
 - `no_response` - no reply; if the user is unsure whether to call it, note how long it has been since the last contact and let them decide - do not impose a cutoff
 - `interview_only` - reached interviews but the process stalled or was abandoned without an explicit rejection
+- `withdrawn` - candidate withdrew from the process
 
 Also collect, without interrogating - one or two open questions are enough:
 - Dates for the stages reached
@@ -65,7 +66,7 @@ Create or update `documents/applications/<company>_<role>/`. All content here is
 ```markdown
 # Outcome: <Company> — <Role>
 
-**Status:** in_progress | hired | offer_declined | rejected | no_response | interview_only
+**Status:** in_progress | hired | offer_declined | rejected | no_response | interview_only | withdrawn
 
 **Date resolved:** YYYY-MM-DD   <- only when resolved; omit while in_progress
 

--- a/.claude/commands/scrape.md
+++ b/.claude/commands/scrape.md
@@ -1,0 +1,10 @@
+# /scrape - Search Job Portals
+
+Run the workflow in `.claude/skills/job-scraper/SKILL.md`.
+
+Treat `$ARGUMENTS` as optional:
+- no argument: run the default top-priority query categories
+- `broad`: run all query categories
+- anything else: treat as the focus area to prioritize
+
+Follow the skill's deduplication, tracker, and output rules.

--- a/.claude/commands/upskill.md
+++ b/.claude/commands/upskill.md
@@ -1,0 +1,9 @@
+# /upskill - Skill Gap Analysis
+
+Run the workflow in `.claude/skills/upskill/SKILL.md`.
+
+Treat `$ARGUMENTS` as optional:
+- no argument: aggregate mode across tracked jobs
+- URL argument: targeted mode for that single posting
+
+Follow the skill's reporting and saved-report rules.

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -33,7 +33,7 @@ Optional arguments:
 ### Step 0: Load State
 
 1. Read `job_scraper/seen_jobs.json` (create if missing - start with `{"seen": {}}`)
-2. Read `job_search_tracker.csv` to extract already-applied companies+roles
+2. Read `job_search_tracker.csv` to extract already-applied companies+roles. If it does not exist, treat the tracker as empty.
 3. Read `search-queries.md` (this directory) for the search strategy
 
 ### Step 1: Search

--- a/.claude/skills/upskill/SKILL.md
+++ b/.claude/skills/upskill/SKILL.md
@@ -36,9 +36,10 @@ In targeted mode, derive a slug from the job title and company for the report fi
 ### Aggregate mode
 1. Read `job_search_tracker.csv`. Extract all rows. The columns are:
    `date, company, sector, role, role_type, channel, status, contact_person, fit_rating, notes, cv_file, cover_letter_file, source`
-2. For each row, note the `role`, `company`, and `fit_rating`. The `fit_rating` column is a 0–100 score where 100 = perfect fit. You will use it to weight gaps — a lower fit rating means the role exposed more gaps.
-3. Read `.claude/skills/job-application-assistant/01-candidate-profile.md` to get the candidate's current skills and experience.
-4. Check `upskill/` for the most recent aggregate report file (`report-YYYY-MM-DD.md`) — if one exists, note its date and load it for the diff in Step 8.
+2. If `job_search_tracker.csv` is missing or has no tracked jobs, stop and tell the user to run `/outcome` first or use `/upskill <URL>` for targeted mode.
+3. For each row, note the `role`, `company`, and `fit_rating`. The `fit_rating` column is a 0–100 score where 100 = perfect fit. You will use it to weight gaps — a lower fit rating means the role exposed more gaps.
+4. Read `.claude/skills/job-application-assistant/01-candidate-profile.md` to get the candidate's current skills and experience.
+5. Check `upskill/` for the most recent aggregate report file (`report-YYYY-MM-DD.md`) — if one exists, note its date and load it for the diff in Step 8.
 
 ### Targeted mode
 1. Use WebFetch to retrieve the job posting from the URL.
@@ -110,8 +111,8 @@ For every **Critical** and **High** gap (and **Medium** gaps if fewer than 5 tot
 ### For each gap:
 
 1. **Run a WebSearch** to find current, highly-rated study resources. Use queries like:
-   - `"best Kubernetes course 2025 site:reddit.com OR coursera.org OR fast.ai OR missing.csail.mit.edu"`
-   - `"learn [skill] for [domain] 2025 recommendations"`
+   - `"best Kubernetes course <current year> site:reddit.com OR coursera.org OR fast.ai OR missing.csail.mit.edu"`
+   - `"learn [skill] for [domain] <current year> recommendations"`
    Include the current year in the query to avoid stale results.
 
 2. **Pick 2-3 resources** from the search results. Prefer:

--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ If you prefer editing files directly instead of using `/setup`:
 | File | What to change |
 |------|---------------|
 | `CLAUDE.md` | Your full profile (name, education, experience, skills, goals) |
-| `01-candidate-profile.md` | Structured version of your CV data |
-| `02-behavioral-profile.md` | Your behavioral assessment or self-assessment |
-| `04-job-evaluation.md` | Skill match areas, career goals, motivation filters |
-| `05-cv-templates.md` | Profile statement templates for different role types |
-| `07-interview-prep.md` | Your STAR examples from actual experience |
-| `search-queries.md` | Job search queries for your skills and location |
+| `.claude/skills/job-application-assistant/01-candidate-profile.md` | Structured version of your CV data |
+| `.claude/skills/job-application-assistant/02-behavioral-profile.md` | Your behavioral assessment or self-assessment |
+| `.claude/skills/job-application-assistant/04-job-evaluation.md` | Skill match areas, career goals, motivation filters |
+| `.claude/skills/job-application-assistant/05-cv-templates.md` | Profile statement templates for different role types |
+| `.claude/skills/job-application-assistant/07-interview-prep.md` | Your STAR examples from actual experience |
+| `.claude/skills/job-scraper/search-queries.md` | Job search queries for your skills and location |
 
 ### Updating your search queries
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -168,13 +168,13 @@ All three paths produce the same result: fully populated profile files.
 | File | Content |
 |------|---------|
 | `CLAUDE.md` | Your full candidate profile |
-| `01-candidate-profile.md` | Structured education, experience, skills |
-| `02-behavioral-profile.md` | Behavioral assessment |
-| `04-job-evaluation.md` | Personalized skill match areas and career goals |
-| `05-cv-templates.md` | Profile statement templates for your background |
-| `07-interview-prep.md` | STAR examples from your experience |
+| `.claude/skills/job-application-assistant/01-candidate-profile.md` | Structured education, experience, skills |
+| `.claude/skills/job-application-assistant/02-behavioral-profile.md` | Behavioral assessment |
+| `.claude/skills/job-application-assistant/04-job-evaluation.md` | Personalized skill match areas and career goals |
+| `.claude/skills/job-application-assistant/05-cv-templates.md` | Profile statement templates for your background |
+| `.claude/skills/job-application-assistant/07-interview-prep.md` | STAR examples from your experience |
 | `cv/main_example.tex` | Your LaTeX CV with actual details |
-| `search-queries.md` | Job search queries for `/scrape` |
+| `.claude/skills/job-scraper/search-queries.md` | Job search queries for `/scrape` |
 
 ### Re-running setup
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -88,8 +88,8 @@ Reference letters from former managers, supervisors, or collaborators.
 
 **What `/setup` extracts:**
 - Referee name, title, and organization
-- Specific quotes and assessments (added to the references section of `01-candidate-profile.md`)
-- Competency language used by referees (adds behavioral signal to `02-behavioral-profile.md`)
+- Specific quotes and assessments (added to the references section of `.claude/skills/job-application-assistant/01-candidate-profile.md`)
+- Competency language used by referees (adds behavioral signal to `.claude/skills/job-application-assistant/02-behavioral-profile.md`)
 
 **Naming:** Use the referee's name, e.g. `reference_ole_frandsen.pdf`.
 
@@ -124,7 +124,7 @@ applications/
 ```markdown
 # Outcome: <Company> — <Role>
 
-**Status:** in_progress | hired | offer_declined | rejected | no_response | interview_only
+**Status:** in_progress | hired | offer_declined | rejected | no_response | interview_only | withdrawn
 
 **Date resolved:** YYYY-MM-DD
 

--- a/salary_lookup.py
+++ b/salary_lookup.py
@@ -204,12 +204,15 @@ def format_entry(entry, metadata):
             count = data.get("count")
             index = data.get("index")
             if count is not None or index is not None:
-                count_str = str(count) if count else "-"
-                if index is not None:
+                count_str = str(count) if count is not None else "-"
+                if isinstance(index, (int, float)):
                     diff = index - baseline
                     sign = "+" if diff >= 0 else ""
                     index_str = f"{index:.1f}"
                     diff_str = f"{sign}{diff:.1f}%"
+                elif index is not None:
+                    index_str = str(index)
+                    diff_str = ""
                 else:
                     index_str = "N/A*"
                     diff_str = ""

--- a/templates/README.md
+++ b/templates/README.md
@@ -20,7 +20,7 @@ templates/
 ## How it works
 
 - `/add-template` interviews you for the template's instructions (compile engine, fonts, style rules, page limit), stores the files here, and runs a mandatory test compile before registering anything.
-- Activating a template adds a managed block to `05-cv-templates.md` or `06-cover-letter-templates.md`, which is what `/apply` reads when drafting — no other wiring needed.
+- Activating a template adds a managed block to `.claude/skills/job-application-assistant/05-cv-templates.md` or `.claude/skills/job-application-assistant/06-cover-letter-templates.md`, which is what `/apply` reads when drafting — no other wiring needed.
 - `/add-template --list` shows registered templates; `/add-template --use <name>` switches; `/add-template --use default` reverts to the stock templates.
 
 Templates are stored with `[PLACEHOLDER]` tokens instead of personal data, so they are safe to commit and share.

--- a/tests/test_convert_salary_excel.py
+++ b/tests/test_convert_salary_excel.py
@@ -37,6 +37,10 @@ class DetectColumnTypeTests(unittest.TestCase):
             with self.subTest(header=header):
                 self.assertEqual(detect_column_type(header), "count")
 
+    def test_count_inside_word_does_not_make_count_header(self):
+        self.assertEqual(detect_column_type("Accounting Index"), "index")
+        self.assertEqual(detect_column_type("Country Index"), "index")
+
     def test_parse_sheet_preserves_category_name_with_letter_n(self):
         ws = FakeWorksheet([
             ("Company", "Engineering Count", "Engineering Index"),
@@ -46,6 +50,16 @@ class DetectColumnTypeTests(unittest.TestCase):
         companies = parse_sheet(ws)
 
         self.assertEqual(companies[0]["categories"]["engineering"], {"count": 12, "index": 105.5})
+
+    def test_parse_sheet_groups_accounting_count_index_pair(self):
+        ws = FakeWorksheet([
+            ("Company", "Accounting Count", "Accounting Index"),
+            ("Example Corp", 12, 105.5),
+        ])
+
+        companies = parse_sheet(ws)
+
+        self.assertEqual(companies[0]["categories"]["accounting"], {"count": 12, "index": 105.5})
 
 
 if __name__ == "__main__":

--- a/tests/test_salary_lookup.py
+++ b/tests/test_salary_lookup.py
@@ -1,0 +1,41 @@
+import unittest
+
+from salary_lookup import format_entry
+
+
+class FormatEntryTests(unittest.TestCase):
+    def test_zero_count_is_displayed_as_zero(self):
+        entry = {
+            "company": "Example Corp",
+            "city": "",
+            "categories": {
+                "public_data": {
+                    "count": 0,
+                    "index": 100.0,
+                },
+            },
+        }
+
+        rendered = format_entry(entry, {"index_baseline": 100, "index_label": "Index"})
+
+        self.assertRegex(rendered, r"Public Data\s+0\s+100\.0")
+
+    def test_text_index_does_not_crash(self):
+        entry = {
+            "company": "Example Corp",
+            "city": "",
+            "categories": {
+                "sample": {
+                    "count": 3,
+                    "index": "private",
+                },
+            },
+        }
+
+        rendered = format_entry(entry, {"index_baseline": 100, "index_label": "Index"})
+
+        self.assertIn("private", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/convert_salary_excel.py
+++ b/tools/convert_salary_excel.py
@@ -49,23 +49,14 @@ def header_matches(header, patterns):
     h = header.lower().strip()
     tokens = set(re.findall(r"[a-zæøåöäü0-9]+", h))
 
-    for p in patterns:
-        if len(p) == 1:
-            if p in tokens:
-                return True
-        elif p in h:
-            return True
-    return False
+    return any(p in tokens for p in patterns)
 
 
 def strip_type_patterns(header, patterns):
     """Remove count/index words from a header to derive a category name."""
     name = header.lower()
     for p in patterns:
-        if len(p) == 1:
-            name = re.sub(rf"\b{re.escape(p)}\b", "", name)
-        else:
-            name = name.replace(p, "")
+        name = re.sub(rf"(?<![a-zæøåöäü0-9]){re.escape(p)}(?![a-zæøåöäü0-9])", "", name)
     return name.strip(" _-")
 
 


### PR DESCRIPTION
﻿## Summary
- add missing `/scrape` and `/upskill` command wrappers
- fix salary Excel header matching and salary lookup formatting edge cases
- fix LinkedIn `--limit 0`, align CLI entrypoints, and clean up stale workflow docs paths

## Tests
- `python -m unittest discover -v`
- `python tools/lint_skills.py`
- `bun test tests\search.test.ts tests\parsing.test.ts` in `.agents/skills/linkedin-search/cli`
- `bun test tests\parsing.test.ts` in `.agents/skills/jobindex-search/cli`
- `bun install && bun run typecheck` in each portal CLI directory
