### PR TITLE
fix: rename job-scraper skill to 'scrape' so /scrape resolves natively

### DIFF
--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: job-scraper
+name: scrape
 description: >
   Scrapes Danish job sites for new positions matching your profile. Deduplicates across runs.
   Triggers on: job scrape, find jobs, search jobs, new jobs, job search, scrape jobs, /scrape


### PR DESCRIPTION
Fixes #68: docs everywhere say `/scrape`, but the skill was named `job-scraper`, so `/scrape` only worked via fuzzy description-trigger matching, not as a real command. One-line rename of the frontmatter `name:` field makes it resolve natively - same mechanism that already makes `/upskill` work. Folder path and all file references unchanged; `lint_skills: OK`.

No wrapper command, per the #52 precedent against duplicate entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)