### PR TITLE
Respect zero LinkedIn result limits

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/commands/search.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/search.ts
@@ -55,7 +55,7 @@ export async function runSearch(opts: SearchOpts): Promise<number> {
   try {
     const html = await htmlFetch(buildUrl(opts))
     let cards = parseJobCards(html)
-    if (opts.limit && opts.limit > 0) cards = cards.slice(0, opts.limit)
+    if (opts.limit !== undefined && opts.limit >= 0) cards = cards.slice(0, opts.limit)
 
     if (opts.format === "table") {
       process.stdout.write(renderTable(cards) + "\n")

--- a/.agents/skills/linkedin-search/cli/tests/search.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/search.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { runSearch } from "../src/commands/search";
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write;
+
+function searchCard(id: string, title: string): string {
+  return `<li>
+    <div data-entity-urn="urn:li:jobPosting:${id}">
+      <a class="base-card__full-link" href="https://www.linkedin.com/jobs/view/${id}"></a>
+      <h3 class="base-search-card__title">${title}</h3>
+    </div>
+  </li>`;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+});
+
+describe("runSearch", () => {
+  test("--limit 0 emits zero results", async () => {
+    globalThis.fetch = (async () => new Response(searchCard("123456", "Engineer"))) as typeof fetch;
+
+    let stdout = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runSearch({
+      location: "Copenhagen, Denmark",
+      jobage: 9999,
+      page: 1,
+      limit: 0,
+      format: "json",
+    });
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
﻿## Summary
- treat `--limit 0` as an explicit zero-result cap instead of falling through to all parsed cards
- add a mocked search regression test so the case does not hit the live LinkedIn endpoint

## Tests
- `bun test tests\search.test.ts tests\parsing.test.ts`
- `bun run typecheck`
