### PR TITLE
fix(cli): guard result cap against negative --limit / --per-page

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/search.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { rssFetch, fetchWithUA, writeError, parseRssDescription, extractJobIdFromUrl, BASE_URL } from "../helpers.js"
+import { rssFetch, fetchWithUA, writeError, parseRssDescription, extractJobIdFromUrl, capResults, BASE_URL } from "../helpers.js"
 
 export const search = defineCommand({
   name: "search",
@@ -152,9 +152,7 @@ export const search = defineCommand({
       })
 
       // Apply limit
-      if (flags.limit !== undefined) {
-        results = results.slice(0, flags.limit)
-      }
+      results = capResults(results, flags.limit)
 
       const output = { meta: { total }, results }
 

--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -152,3 +152,19 @@ export function extractJobIdFromUrl(url: string): string {
   const match = url.match(/\/job\/(\d+)\//)
   return match ? match[1] : ""
 }
+
+/**
+ * Cap a result list to the first `limit` items.
+ *
+ * Only applies when `limit` is a positive, finite number; a negative, zero,
+ * NaN, or `undefined` limit returns the full list unchanged. This mirrors the
+ * linkedin-search CLI's `limit > 0` guard and avoids `Array.prototype.slice`'s
+ * negative-index semantics, where `slice(0, -1)` silently drops the trailing
+ * item instead of capping (e.g. `--limit -1` on 20 results would return 19).
+ */
+export function capResults<T>(items: T[], limit?: number): T[] {
+  if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+    return items.slice(0, limit)
+  }
+  return items
+}

--- a/.agents/skills/jobbank-search/cli/tests/cap-results.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/cap-results.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { capResults } from "../src/helpers";
+
+describe("capResults", () => {
+  const items = [1, 2, 3, 4, 5];
+
+  test("caps to a positive limit", () => {
+    expect(capResults(items, 3)).toEqual([1, 2, 3]);
+  });
+
+  test("returns all items when limit is undefined", () => {
+    expect(capResults(items, undefined)).toEqual(items);
+  });
+
+  test("regression: a negative limit returns all items, not slice(0, -n)", () => {
+    // Array.prototype.slice(0, -1) returns [1,2,3,4] — it counts from the end
+    // and silently drops the trailing item. A negative limit is invalid input,
+    // so capResults must return the full list instead.
+    expect(capResults(items, -1)).toEqual(items);
+    expect(capResults(items, -100)).toEqual(items);
+  });
+
+  test("a zero limit returns all items", () => {
+    expect(capResults(items, 0)).toEqual(items);
+  });
+
+  test("NaN returns all items", () => {
+    expect(capResults(items, NaN)).toEqual(items);
+  });
+
+  test("a limit larger than the list returns all items", () => {
+    expect(capResults(items, 999)).toEqual(items);
+  });
+
+  test("does not mutate the input array", () => {
+    const copy = [...items];
+    capResults(items, 2);
+    expect(items).toEqual(copy);
+  });
+});

--- a/.agents/skills/jobdanmark-search/cli/src/commands/categories.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/categories.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiFetch, writeError } from "../helpers.js"
+import { apiFetch, capResults, writeError } from "../helpers.js"
 
 interface Category {
   id: number
@@ -24,13 +24,11 @@ export const categories = defineCommand({
     if (signal.aborted) return
 
     try {
-      let data = await apiFetch<Category[]>("/api/categorycount/getcounts")
+      const rawData = await apiFetch<Category[]>("/api/categorycount/getcounts")
 
       if (signal.aborted) return
 
-      if (flags.limit !== undefined) {
-        data = data.slice(0, flags.limit)
-      }
+      const data = capResults(rawData, flags.limit)
 
       if (flags.format === "json") {
         console.log(JSON.stringify(data, null, 2))

--- a/.agents/skills/jobdanmark-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/search.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiPost, writeError, BASE_URL } from "../helpers.js"
+import { apiPost, capResults, writeError, BASE_URL } from "../helpers.js"
 
 interface ApiSearchItem {
   title: string
@@ -155,10 +155,7 @@ export const search = defineCommand({
 
       if (signal.aborted) return
 
-      let results = data.items.map(normalizeItem)
-      if (flags.limit !== undefined) {
-        results = results.slice(0, flags.limit)
-      }
+      const results = capResults(data.items.map(normalizeItem), flags.limit)
 
       const meta = {
         currentPage: data.currentPage,

--- a/.agents/skills/jobdanmark-search/cli/src/helpers.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/helpers.ts
@@ -65,3 +65,19 @@ export function writeError(error: string, code: string): void {
 export function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim()
 }
+
+/**
+ * Cap a result list to the first `limit` items.
+ *
+ * Only applies when `limit` is a positive, finite number; a negative, zero,
+ * NaN, or `undefined` limit returns the full list unchanged. This mirrors the
+ * linkedin-search CLI's `limit > 0` guard and avoids `Array.prototype.slice`'s
+ * negative-index semantics, where `slice(0, -1)` silently drops the trailing
+ * item instead of capping (e.g. `--limit -1` on 20 results would return 19).
+ */
+export function capResults<T>(items: T[], limit?: number): T[] {
+  if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+    return items.slice(0, limit)
+  }
+  return items
+}

--- a/.agents/skills/jobdanmark-search/cli/tests/cap-results.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/cap-results.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { capResults } from "../src/helpers";
+
+describe("capResults", () => {
+  const items = [1, 2, 3, 4, 5];
+
+  test("caps to a positive limit", () => {
+    expect(capResults(items, 3)).toEqual([1, 2, 3]);
+  });
+
+  test("returns all items when limit is undefined", () => {
+    expect(capResults(items, undefined)).toEqual(items);
+  });
+
+  test("regression: a negative limit returns all items, not slice(0, -n)", () => {
+    // Array.prototype.slice(0, -1) returns [1,2,3,4] — it counts from the end
+    // and silently drops the trailing item. A negative limit is invalid input,
+    // so capResults must return the full list instead.
+    expect(capResults(items, -1)).toEqual(items);
+    expect(capResults(items, -100)).toEqual(items);
+  });
+
+  test("a zero limit returns all items", () => {
+    expect(capResults(items, 0)).toEqual(items);
+  });
+
+  test("NaN returns all items", () => {
+    expect(capResults(items, NaN)).toEqual(items);
+  });
+
+  test("a limit larger than the list returns all items", () => {
+    expect(capResults(items, 999)).toEqual(items);
+  });
+
+  test("does not mutate the input array", () => {
+    const copy = [...items];
+    capResults(items, 2);
+    expect(items).toEqual(copy);
+  });
+});

--- a/.agents/skills/jobindex-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobindex-search/cli/src/commands/search.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { BASE_URL, htmlFetch, parseSearchPage, writeError, type JobCard } from "../helpers.js"
+import { BASE_URL, capResults, htmlFetch, parseSearchPage, writeError, type JobCard } from "../helpers.js"
 
 export const search = defineCommand({
   name: "search",
@@ -48,11 +48,7 @@ export const search = defineCommand({
 
       const parsed = parseSearchPage(html)
       const total = parsed.total
-      let results = parsed.results
-
-      if (flags.limit !== undefined) {
-        results = results.slice(0, flags.limit)
-      }
+      const results = capResults(parsed.results, flags.limit)
 
       const output = {
         meta: {

--- a/.agents/skills/jobindex-search/cli/src/helpers.ts
+++ b/.agents/skills/jobindex-search/cli/src/helpers.ts
@@ -312,3 +312,19 @@ export function parseHitCount(html: string): number {
   const numStr = match[1].replace(/\./g, "")
   return parseInt(numStr, 10) || 0
 }
+
+/**
+ * Cap a result list to the first `limit` items.
+ *
+ * Only applies when `limit` is a positive, finite number; a negative, zero,
+ * NaN, or `undefined` limit returns the full list unchanged. This mirrors the
+ * linkedin-search CLI's `limit > 0` guard and avoids `Array.prototype.slice`'s
+ * negative-index semantics, where `slice(0, -1)` silently drops the trailing
+ * item instead of capping (e.g. `--limit -1` on 20 results would return 19).
+ */
+export function capResults<T>(items: T[], limit?: number): T[] {
+  if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+    return items.slice(0, limit)
+  }
+  return items
+}

--- a/.agents/skills/jobindex-search/cli/tests/cap-results.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/cap-results.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { capResults } from "../src/helpers";
+
+describe("capResults", () => {
+  const items = [1, 2, 3, 4, 5];
+
+  test("caps to a positive limit", () => {
+    expect(capResults(items, 3)).toEqual([1, 2, 3]);
+  });
+
+  test("returns all items when limit is undefined", () => {
+    expect(capResults(items, undefined)).toEqual(items);
+  });
+
+  test("regression: a negative limit returns all items, not slice(0, -n)", () => {
+    // Array.prototype.slice(0, -1) returns [1,2,3,4] — it counts from the end
+    // and silently drops the trailing item. A negative limit is invalid input,
+    // so capResults must return the full list instead.
+    expect(capResults(items, -1)).toEqual(items);
+    expect(capResults(items, -100)).toEqual(items);
+  });
+
+  test("a zero limit returns all items", () => {
+    expect(capResults(items, 0)).toEqual(items);
+  });
+
+  test("NaN returns all items", () => {
+    expect(capResults(items, NaN)).toEqual(items);
+  });
+
+  test("a limit larger than the list returns all items", () => {
+    expect(capResults(items, 999)).toEqual(items);
+  });
+
+  test("does not mutate the input array", () => {
+    const copy = [...items];
+    capResults(items, 2);
+    expect(items).toEqual(copy);
+  });
+});

--- a/.agents/skills/jobnet-search/cli/src/commands/occupations.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/occupations.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiFetch, writeError } from "../helpers.js"
+import { apiFetch, capResults, writeError } from "../helpers.js"
 
 interface OccupationAlias {
   aliasIdentifier: string
@@ -47,7 +47,7 @@ export const occupations = defineCommand({
       if (signal.aborted) return
 
       // Client-side filter — API does not enforce pageSize reliably
-      const data = rawData.slice(0, flags["per-page"])
+      const data = capResults(rawData, flags["per-page"])
 
       if (flags.format === "json") {
         console.log(JSON.stringify(data, null, 2))

--- a/.agents/skills/jobnet-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/search.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiFetch, writeError } from "../helpers.js"
+import { apiFetch, capResults, writeError } from "../helpers.js"
 
 interface SearchApiResponse {
   jobAds: JobAdRaw[]
@@ -137,9 +137,7 @@ export const search = defineCommand({
         isFavorite: job.isFavorite,
       }))
 
-      if (flags.limit !== undefined) {
-        results = results.slice(0, flags.limit)
-      }
+      results = capResults(results, flags.limit)
 
       const facets = {
         regions: data.searchFacets.regions ?? [],

--- a/.agents/skills/jobnet-search/cli/src/commands/suggestions.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/suggestions.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiFetch, writeError } from "../helpers.js"
+import { apiFetch, capResults, writeError } from "../helpers.js"
 
 export const suggestions = defineCommand({
   name: "suggestions",
@@ -33,10 +33,7 @@ export const suggestions = defineCommand({
 
       if (signal.aborted) return
 
-      let results = data
-      if (flags.limit !== undefined) {
-        results = results.slice(0, flags.limit)
-      }
+      const results = capResults(data, flags.limit)
 
       if (flags.format === "json") {
         console.log(JSON.stringify(results, null, 2))

--- a/.agents/skills/jobnet-search/cli/src/helpers.ts
+++ b/.agents/skills/jobnet-search/cli/src/helpers.ts
@@ -52,3 +52,19 @@ export function stripHtml(html: string): string {
     .replace(/\s+/g, " ")
     .trim()
 }
+
+/**
+ * Cap a result list to the first `limit` items.
+ *
+ * Only applies when `limit` is a positive, finite number; a negative, zero,
+ * NaN, or `undefined` limit returns the full list unchanged. This mirrors the
+ * linkedin-search CLI's `limit > 0` guard and avoids `Array.prototype.slice`'s
+ * negative-index semantics, where `slice(0, -1)` silently drops the trailing
+ * item instead of capping (e.g. `--limit -1` on 20 results would return 19).
+ */
+export function capResults<T>(items: T[], limit?: number): T[] {
+  if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
+    return items.slice(0, limit)
+  }
+  return items
+}

--- a/.agents/skills/jobnet-search/cli/tests/cap-results.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/cap-results.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { capResults } from "../src/helpers";
+
+describe("capResults", () => {
+  const items = [1, 2, 3, 4, 5];
+
+  test("caps to a positive limit", () => {
+    expect(capResults(items, 3)).toEqual([1, 2, 3]);
+  });
+
+  test("returns all items when limit is undefined", () => {
+    expect(capResults(items, undefined)).toEqual(items);
+  });
+
+  test("regression: a negative limit returns all items, not slice(0, -n)", () => {
+    // Array.prototype.slice(0, -1) returns [1,2,3,4] — it counts from the end
+    // and silently drops the trailing item. A negative limit is invalid input,
+    // so capResults must return the full list instead.
+    expect(capResults(items, -1)).toEqual(items);
+    expect(capResults(items, -100)).toEqual(items);
+  });
+
+  test("a zero limit returns all items", () => {
+    expect(capResults(items, 0)).toEqual(items);
+  });
+
+  test("NaN returns all items", () => {
+    expect(capResults(items, NaN)).toEqual(items);
+  });
+
+  test("a limit larger than the list returns all items", () => {
+    expect(capResults(items, 999)).toEqual(items);
+  });
+
+  test("does not mutate the input array", () => {
+    const copy = [...items];
+    capResults(items, 2);
+    expect(items).toEqual(copy);
+  });
+});


### PR DESCRIPTION
## Summary

Five of the six job-portal CLIs cap their result list with
`results.slice(0, flags.limit)`, where `limit` comes from
`z.coerce.number().optional()` with no lower bound. Because
`Array.prototype.slice(0, n)` treats a **negative** `n` as an offset from the
end of the array, a negative limit silently corrupts the output instead of
erroring or being ignored:

- `--limit -1` on a 20-result page returns **19** results (the last one is
  silently dropped), not an error and not "unlimited".
- `--limit -100` on that same page returns **`[]`** (an empty list).

The behaviour is silent and magnitude-dependent, so a user who fat-fingers a
minus sign gets plausible-looking but wrong output. `linkedin-search` already
guards this correctly (`if (opts.limit && opts.limit > 0)`); the other five
CLIs did not.

## Fix

Introduce a small pure helper, `capResults(items, limit)`, that only caps when
`limit` is a **positive, finite** number and otherwise returns the full list —
mirroring the existing `linkedin-search` guard. As a bonus it also makes a
`NaN` limit safe (return everything rather than `slice(0, NaN)` → `[]`).

The helper is added to each affected skill's `helpers.ts` (consistent with the
repo's existing per-skill `helpers.ts` layout — the CLIs don't share a package),
and all six call sites are rewired to use it:

| Skill | Command(s) | Flag |
|---|---|---|
| jobindex-search | `search` | `--limit` |
| jobnet-search | `search`, `occupations`, `suggestions` | `--limit`, `--per-page` |
| jobdanmark-search | `search`, `categories` | `--limit` |
| jobbank-search | `search` | `--limit` |

```ts
/**
 * Cap a result list to the first `limit` items.
 *
 * Only applies when `limit` is a positive, finite number; a negative, zero,
 * NaN, or `undefined` limit returns the full list unchanged. This mirrors the
 * linkedin-search CLI's `limit > 0` guard and avoids `Array.prototype.slice`'s
 * negative-index semantics, where `slice(0, -1)` silently drops the trailing
 * item instead of capping.
 */
export function capResults<T>(items: T[], limit?: number): T[] {
  if (limit !== undefined && Number.isFinite(limit) && limit > 0) {
    return items.slice(0, limit)
  }
  return items
}
```

## Behaviour change

| Input | Before | After |
|---|---|---|
| `--limit 3` (10 results) | 3 results | 3 results (unchanged) |
| `--limit` omitted | all results | all results (unchanged) |
| `--limit -1` (10 results) | **9 results** (tail dropped) | all results |
| `--limit -100` (10 results) | **`[]`** | all results |
| `--limit 0` | `[]` (`slice(0, 0)`) | all results (matches linkedin) |

A negative or zero limit is invalid input, so the chosen semantics are "ignore
it and return everything," identical to how `linkedin-search` already behaves.

## Tests

Adds a pure `capResults` unit test to each affected skill
(`tests/cap-results.test.ts`, `bun:test`, no network) covering the positive
cap, `undefined`, zero, `NaN`, an over-length limit, non-mutation, and a
**regression test** asserting that a negative limit returns the full list
rather than `slice(0, -n)` dropping the tail.

Run per skill:

```bash
cd .agents/skills/<skill>-search/cli && bun test
```

## Scope / notes

- No behaviour change for valid input (positive limit, or no limit).
- No new dependency; the helper is a few lines of standard TS per skill.
- `linkedin-search` is intentionally untouched — it already had the guard.
