### PR TITLE
ci: add supply-chain guards — permission allowlist, gitignore rules, manifest checks, pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,32 @@ jobs:
 
   dependency-review:
     name: Dependency review (upstream PRs only)
-    # Requires the repo's Dependency graph (enabled by default on public
-    # repos, but NOT on forks) - so this runs only on PRs to the upstream
-    # repo, same pattern as the other upstream-only jobs.
+    # Requires the repo's Dependency graph, which forks never inherit and
+    # which may be disabled upstream - so: upstream PRs only, and the
+    # graph is probed first. If it is unavailable, the job warns and
+    # passes instead of hard-failing (the same graceful-skip pattern the
+    # workflow uses for optional tools). Enabling Dependency graph under
+    # Settings -> Advanced Security activates the real check.
     if: github.event_name == 'pull_request' && github.repository == 'MadsLorentzen/ai-job-search'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+      - name: Probe Dependency graph availability
+        id: graph
+        run: |
+          code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/dependency-graph/sbom")
+          if [ "$code" = "200" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Dependency graph is not enabled on this repository (HTTP $code). Dependency review was skipped - enable Dependency graph under Settings -> Advanced Security to activate this check."
+          fi
+      - name: Dependency review
+        if: steps.graph.outputs.enabled == 'true'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@
 # real portals (network-flaky, and the linkedin-search skill is personal-use
 # only per its own ToS warning - CI-automated requests would violate that).
 # CLIs get typechecked instead; live testing stays a local, on-demand step.
+#
+# Security posture: this template ships pre-approved Claude Code permissions
+# and CLI code that every fork user executes, so the security-guards job
+# fails PRs that widen settings.json permissions, weaken the personal-data
+# gitignore rules, or add package lifecycle scripts; dependency-review flags
+# newly introduced vulnerable/malicious dependencies. Honest limit: a PR can
+# edit this workflow itself, so these guards catch accidents and casual
+# attempts, not a determined author - branch protection with required checks
+# and human review of workflow/settings diffs remain the real backstop.
+# Actions are pinned to commit SHAs; the token is read-only.
 
 name: CI
 
@@ -19,24 +29,47 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint skills, commands, settings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install pyyaml
       - run: python tools/lint_skills.py
+
+  security-guards:
+    name: Security guards (permissions, gitignore, manifests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - run: python tools/security_guards.py
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
 
   latex-smoke:
     name: Compile example CV and cover letter
     runs-on: ubuntu-latest
     container: texlive/texlive:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Compile CV example (lualatex)
         run: |
           cd cv
@@ -78,8 +111,8 @@ jobs:
           - jobnet-search
           - linkedin-search
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
         working-directory: .agents/skills/${{ matrix.tool }}/cli
       - run: bun run typecheck
@@ -90,7 +123,7 @@ jobs:
     if: github.repository == 'MadsLorentzen/ai-job-search'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Tracked template files must keep their placeholder tokens
         run: |
           fail=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,11 @@ jobs:
       - run: python tools/security_guards.py
 
   dependency-review:
-    name: Dependency review
-    if: github.event_name == 'pull_request'
+    name: Dependency review (upstream PRs only)
+    # Requires the repo's Dependency graph (enabled by default on public
+    # repos, but NOT on forks) - so this runs only on PRs to the upstream
+    # repo, same pattern as the other upstream-only jobs.
+    if: github.event_name == 'pull_request' && github.repository == 'MadsLorentzen/ai-job-search'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ ai-job-search/
 ├── tools/
 │   ├── convert_salary_excel.py        # Convert salary Excel to JSON
 │   ├── lint_skills.py                 # CI lint for skills, commands, settings.json
+│   ├── security_guards.py             # CI guards: permission allowlist, gitignore rules, manifests
 │   └── README_SALARY_TOOL.md          # Salary tool setup instructions
 ├── job_scraper/                       # Scraper state (seen jobs, results)
 ├── upskill/                           # /upskill report output (markdown reports per run)

--- a/tools/security_guards.py
+++ b/tools/security_guards.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Supply-chain guards for the template's riskiest surfaces.
+
+Run from anywhere: python tools/security_guards.py
+
+This repo ships pre-approved Claude Code permissions and CLI code that every
+fork user executes. These guards make the dangerous changes LOUD, not
+impossible: a PR that intentionally needs one of them must update the
+allowlists in this file in the same diff, so the change is explicit and
+reviewable rather than buried.
+
+Checks:
+1. .claude/settings.json — every permissions.allow entry must be in the exact
+   allowlist below. Catches permission widening (e.g. Bash(*), Bash(curl:*)),
+   which would auto-approve commands on every fork.
+2. .gitignore — the personal-data ignore rules must all still be present.
+   Catches weakening that would make future users silently commit their
+   tracker, profile exports, or application archives.
+3. .agents/**/package.json — no npm/bun lifecycle scripts (preinstall,
+   install, postinstall, prepare, prepack) and no trustedDependencies.
+   Catches code execution smuggled into `bun install`.
+
+Stdlib only. Exit 0 on success, 1 with a failure list otherwise.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+errors: list[str] = []
+
+# The exact permission entries the template ships. A PR that adds or changes
+# an entry must add it here too - that is the point: the diff shows both.
+ALLOWED_PERMISSIONS = {
+    "Skill(job-application-assistant)",
+    "Bash(bun run:*)",
+    "Bash(python salary_lookup.py:*)",
+    "Bash(python3 salary_lookup.py:*)",
+    "Bash(pdftotext:*)",
+}
+
+# Personal-data ignore rules that must never disappear from .gitignore.
+REQUIRED_IGNORE_RULES = [
+    "salary_data.json",
+    "job_scraper/seen_jobs.json",
+    "cv/main_*.tex",
+    "!cv/main_example.tex",
+    "cover_letters/cover_*.tex",
+    "documents/cv/**",
+    "documents/linkedin/**",
+    "documents/diplomas/**",
+    "documents/references/**",
+    "documents/applications/**",
+    "job_search_tracker.csv",
+]
+
+FORBIDDEN_SCRIPTS = {"preinstall", "install", "postinstall", "prepare", "prepack"}
+
+
+def check_permissions() -> None:
+    path = ROOT / ".claude" / "settings.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f".claude/settings.json: unreadable or invalid JSON: {exc}")
+        return
+    allow = data.get("permissions", {}).get("allow", [])
+    for entry in allow:
+        if entry not in ALLOWED_PERMISSIONS:
+            errors.append(
+                f".claude/settings.json: permission not in the reviewed allowlist: {entry!r}. "
+                "Pre-approved permissions run without prompting on every fork. If this entry is "
+                "intentional, add it to ALLOWED_PERMISSIONS in tools/security_guards.py in the "
+                "same PR so the widening is explicit and reviewable."
+            )
+    for entry in ALLOWED_PERMISSIONS - set(allow):
+        # Not an error: settings may legitimately drop an entry. But an
+        # allowlist entry that no longer exists should be pruned.
+        print(f"note: allowlisted permission not present in settings.json: {entry!r}")
+
+
+def check_gitignore() -> None:
+    path = ROOT / ".gitignore"
+    try:
+        rules = {line.strip() for line in path.read_text(encoding="utf-8").splitlines()}
+    except OSError as exc:
+        errors.append(f".gitignore: unreadable: {exc}")
+        return
+    for rule in REQUIRED_IGNORE_RULES:
+        if rule not in rules:
+            errors.append(
+                f".gitignore: required personal-data rule missing: {rule!r}. "
+                "These rules keep fork users from committing personal data. If the rule moved "
+                "or was renamed intentionally, update REQUIRED_IGNORE_RULES in "
+                "tools/security_guards.py in the same PR."
+            )
+
+
+def check_package_manifests() -> None:
+    manifests = [
+        p for p in ROOT.glob(".agents/**/package.json") if "node_modules" not in p.parts
+    ]
+    if not manifests:
+        errors.append(".agents: no package.json files found - glob roots are wrong or the tree moved")
+    for manifest in manifests:
+        relpath = manifest.relative_to(ROOT)
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{relpath}: unreadable or invalid JSON: {exc}")
+            continue
+        bad = FORBIDDEN_SCRIPTS & set(data.get("scripts", {}))
+        if bad:
+            errors.append(
+                f"{relpath}: lifecycle script(s) {sorted(bad)} are forbidden - they execute "
+                "arbitrary code during `bun install` on every fork user's machine."
+            )
+        if "trustedDependencies" in data:
+            errors.append(
+                f"{relpath}: trustedDependencies is forbidden - it re-enables dependency "
+                "lifecycle scripts that bun blocks by default."
+            )
+
+
+def main() -> int:
+    check_permissions()
+    check_gitignore()
+    check_package_manifests()
+    if errors:
+        print(f"security_guards: {len(errors)} failure(s)")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+    print("security_guards: OK (permissions allowlist, gitignore rules, package manifests)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Security hardening for CI (#59 follow-up), built around this template's unusual threat model: **the product ships pre-approved execution**. Every fork user applies `.claude/settings.json` permissions automatically, and `Bash(bun run:*)` pre-approves running the portal CLIs — so a plausible-looking PR could ship risk to every forker: widen a permission to `Bash(*)`, weaken the personal-data gitignore rules, or smuggle code execution into `bun install` via a lifecycle script. Nothing checked for these mechanically.

## New jobs

**`security-guards`** — runs `tools/security_guards.py` (stdlib only, also runnable locally). The design principle: make dangerous changes **loud, not impossible** — a PR that legitimately needs one of these must update the allowlist in the same diff, so the widening is explicit and reviewable rather than buried:

1. **Permission allowlist** — every `permissions.allow` entry in `settings.json` must be in an exact in-repo allowlist (currently the five entries the template ships). Catches `Bash(*)`-style widening; the failure message tells the contributor exactly what to do if the change is intentional. In the spirit of #27's tightening, now enforced.
2. **Gitignore guard** — the personal-data rules (tracker, `documents/**`, `cv/main_*`, salary data, seen jobs) must all still be present. The mirror image of the placeholder-integrity job: that one catches personal data committed upstream, this one catches rule-weakening that would make *fork users* commit theirs.
3. **Manifest guard** — no npm/bun lifecycle scripts (`preinstall`/`install`/`postinstall`/`prepare`/`prepack`) and no `trustedDependencies` in `.agents/**/package.json` — either would execute arbitrary code during `bun install` on users' machines.

**`dependency-review`** — `actions/dependency-review-action`, `fail-on-severity: high`, flags newly introduced vulnerable/malicious dependencies. Scoped to **upstream PRs only** (forks never inherit Dependency graph — verified: the action hard-fails there), and — since this PR's own first run revealed the graph is currently disabled on this repo too — the job now **probes the graph first and degrades gracefully**: HTTP 200 on the SBOM endpoint runs the real review; otherwise it emits a `::warning::` naming the setting to flip (Settings → Advanced Security → Dependency graph) and passes. Same graceful-skip pattern the workflow uses for optional tools. The check self-activates the moment you enable the graph — no workflow change needed, and enabling it is recommended.

## Workflow hardening

- Explicit top-level `permissions: contents: read` — least-privilege token instead of the repo default.
- All actions **pinned to commit SHAs** (resolved live from the same major tags already in use — checkout v4, setup-python v5, setup-bun v2 — with the tag recorded in a comment). Standard supply-chain hygiene against tag-moving attacks.

## The honest limit (recorded in the workflow header)

A PR can edit this workflow itself, so these guards catch **accidents and casual attempts, not a determined author**. The real backstop is maintainer-side and worth two clicks if not already on: branch protection requiring these checks, and secret-scanning push protection. Human review of any diff touching `.github/workflows/` or `settings.json` remains irreplaceable — the guards just make sure such diffs can't pass quietly.

## Verification

- **Positive:** full fork run green — all existing jobs plus `security-guards` passed: https://github.com/ayobamiseun/ai-job-search/actions/runs/28960818212
- **Negative (the part that matters for a guard):** locally injected each violation and confirmed the guard fails with the intended message — `Bash(*)` added to `settings.json` → *"permission not in the reviewed allowlist"*; `job_search_tracker.csv` rule deleted from `.gitignore` → *"required personal-data rule missing"*; `postinstall` added to a CLI `package.json` → *"lifecycle script(s) … forbidden"*. Clean pass restored after each revert.
- **dependency-review, exercised in all three states:** hard-failed on the fork without Dependency graph (hence the upstream-only scope); passed with the real review after enabling the graph on the fork (proving the action config is sound); and this PR's own first upstream run revealed the graph is disabled here too — which the probe now handles by warning-and-passing, as the current green run on this PR shows.

## Files

- `.github/workflows/ci.yml` — two new jobs, `permissions` block, SHA-pinned actions, security-posture header comment
- `tools/security_guards.py` — the guard script (new, stdlib only)
- `README.md` — file-tree entry
