### PR TITLE
docs: prefer python3 in setup examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Reviews here are empirical. Bug reports are reproduced on master before the fix 
 
 - State the failing case and how to reproduce it.
 - Put CLI tests in `.agents/skills/<name>/cli/tests/` (bun test, network-free where possible); Python tool tests in `tests/`.
-- Run what CI runs: `python tools/lint_skills.py`, `bun run typecheck` in touched CLIs, and the relevant test suites.
+- Run what CI runs: `python3 tools/lint_skills.py` (or `python tools/lint_skills.py` if that is your Python 3 executable), `bun run typecheck` in touched CLIs, and the relevant test suites.
 
 ## Building for your own market? Do this instead
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -19,10 +19,10 @@ You'll need an Anthropic API key or a Claude Pro/Team subscription. See the [Cla
 Python 3.10+ is required for the salary lookup tool. Check with:
 
 ```bash
-python --version
+python3 --version
 ```
 
-On Windows, `py --version` is often the most reliable check if `python` is not on your PATH.
+On Windows, `py --version` is often the most reliable check. If your system exposes Python as `python` instead of `python3`, use `python` in the commands below.
 
 ### Bun (for job search tools)
 
@@ -196,7 +196,7 @@ If you have salary data (from a union, salary survey, Glassdoor, or personal res
 2. **Option B:** Convert from Excel:
    ```bash
    pip install openpyxl
-   python tools/convert_salary_excel.py path/to/salary-data.xlsx --source "My Salary Data 2025"
+   python3 tools/convert_salary_excel.py path/to/salary-data.xlsx --source "My Salary Data 2025"
    ```
 
 This creates `salary_data.json` which the `/apply` workflow uses for salary benchmarking. If you skip this step, salary lookup is simply omitted.
@@ -257,7 +257,7 @@ Make sure Bun is installed and you ran `bun install` in each CLI directory. The 
 The cover letter template expects fonts in `cover_letters/OpenFonts/fonts/`. Make sure this directory exists and contains the Lato and Raleway font files.
 
 ### Stale `.claude/settings.local.json` from an older clone
-Shared Claude Code permissions now live in `.claude/settings.json` (scoped to `bun run` and `python salary_lookup.py`). Earlier versions of this repo committed a broader `.claude/settings.local.json` that pre-approved `Bash(curl:*)`, `Bash(python:*)` and `Bash(bun:*)`. If you cloned before that change, git leaves the old file behind in your working copy, and its permissions still apply on top of `settings.json`. Delete it (or trim it to your own personal overrides):
+Shared Claude Code permissions now live in `.claude/settings.json` (scoped to `bun run`, `python salary_lookup.py`, and `python3 salary_lookup.py`). Earlier versions of this repo committed a broader `.claude/settings.local.json` that pre-approved `Bash(curl:*)`, `Bash(python:*)` and `Bash(bun:*)`. If you cloned before that change, git leaves the old file behind in your working copy, and its permissions still apply on top of `settings.json`. Delete it (or trim it to your own personal overrides):
 
 ```bash
 rm .claude/settings.local.json

--- a/tools/README_SALARY_TOOL.md
+++ b/tools/README_SALARY_TOOL.md
@@ -69,11 +69,13 @@ If you have salary data in an Excel file:
 
 ```bash
 pip install openpyxl
-python tools/convert_salary_excel.py path/to/salary-data.xlsx \
+python3 tools/convert_salary_excel.py path/to/salary-data.xlsx \
   --source "My Salary Data 2025" \
   --baseline 100 \
   --baseline-desc "Index 100 = median salary"
 ```
+
+On Windows, use `py` if that is how Python is exposed on your PATH. If your system uses `python` instead of `python3`, substitute that in the examples.
 
 The converter auto-detects the Excel layout:
 - Looks for a "Company"/"Firma" column and an optional "City"/"By" column
@@ -107,10 +109,10 @@ Start with an empty template and add companies as you research them:
 ## Usage
 
 ```bash
-python salary_lookup.py "Novo Nordisk"
-python salary_lookup.py "Ørsted" --city "Fredericia"
-python salary_lookup.py "COWI" --json
-python salary_lookup.py --list-all
+python3 salary_lookup.py "Novo Nordisk"
+python3 salary_lookup.py "Ørsted" --city "Fredericia"
+python3 salary_lookup.py "COWI" --json
+python3 salary_lookup.py --list-all
 ```
 
 ## Important notes


### PR DESCRIPTION
## Summary
- Update setup and salary-tool docs to use `python3` for macOS/Linux examples.
- Document the `python`/`py` fallback for environments where Python 3 is exposed under those commands.
- Align the stale-settings troubleshooting note with the existing `python3 salary_lookup.py` permission.

## Why
On systems that do not provide a `python` executable, the current setup and salary-tool commands fail before users reach the documented workflow. The repo already permits both `python salary_lookup.py` and `python3 salary_lookup.py`, so this keeps the docs aligned with the shipped settings.

## Verification
- `python3 tools/lint_skills.py`
- `git diff --check`
- `python3 salary_lookup.py --list-all` exits with the expected missing-`salary_data.json` guidance, confirming the documented executable path reaches the tool.