### PR TITLE
Move Verification Checklist out of CLAUDE.md into the skill

### DIFF
--- a/.claude/skills/job-application-assistant/08-verification-checklist.md
+++ b/.claude/skills/job-application-assistant/08-verification-checklist.md
@@ -1,0 +1,43 @@
+# Verification Checklist
+
+After creating or updating a CV or cover letter, re-read the generated file and verify **all** of the following before presenting to the user. Report the results as a pass/fail checklist.
+
+## Factual accuracy
+- [ ] All claims match actual profile (CLAUDE.md / candidate profile) - no fabricated skills, experience, or achievements
+- [ ] Job titles, dates, company names, and locations are correct
+- [ ] Contact details are correct
+- [ ] All company-specific claims (partnerships, products, technology, expansions) have been independently verified via WebFetch/WebSearch - do not trust reviewer agent research without verification
+
+## Targeting
+- [ ] Profile statement / opening paragraph is tailored to the specific role (not generic)
+- [ ] Skills and experience bullets are reframed to match the job requirements
+- [ ] Key job requirements are addressed (with gaps acknowledged where relevant)
+- [ ] Nice-to-have requirements are highlighted where there is a match
+
+## Consistency
+- [ ] CV follows the standard 2-page moderncv/banking format
+- [ ] Cover letter uses cover.cls template and established structure
+- [ ] Tone is consistent across CV and cover letter
+- [ ] No contradictions between CV and cover letter content
+
+## Quality
+- [ ] No LaTeX syntax errors (balanced braces, correct commands)
+- [ ] No spelling or grammar errors
+- [ ] Agentic coding / AI tooling references mention **Claude Code** by name
+- [ ] Cover letter is addressed to the correct person (or "Dear Hiring Manager" if unknown)
+- [ ] Cover letter fits approximately one page
+
+## Compiled PDF verification (MANDATORY - never skip)
+Both documents MUST be compiled and visually inspected via the Read tool on the PDF output. "Looks fine in the .tex" is not acceptable - LaTeX page-break decisions are unpredictable. Iterate until these all pass:
+- [ ] CV compiled with **lualatex** (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors). Cover letter compiled with **xelatex** (cover.cls requires fontspec).
+- [ ] **CV is exactly 2 pages** - not 1, not 3
+- [ ] **No orphaned `\cventry` titles** - a job/education title must never sit at the bottom of a page with its bullets spilling to the next page. Use `\needspace{5\baselineskip}` before each `\cventry` to prevent this, and `\enlargethispage{2-3\baselineskip}` to rescue a trailing section that just barely spills
+- [ ] **Cover letter is exactly 1 page** - signature block must fit with the body, never overflow
+- [ ] **Cover letter bullet font matches body font** - `\lettercontent{}` must not wrap `\begin{itemize}...\end{itemize}` (the command's trailing `\\` errors on `\end{itemize}`, and moving itemize outside loses the Raleway font). Standard pattern: close `\lettercontent{}`, then wrap the list in `{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont \begin{itemize}...\end{itemize}\par}`
+
+## ATS & keyword verification (CV)
+ATS parsers read the PDF's embedded text layer, not the rendered page. Extract it with `pdftotext -layout` and verify what a parser sees. `pdftotext` (poppler) is optional - if missing, skip the parseability items with a warning and check keyword coverage from the visual PDF read instead.
+- [ ] CV text layer extracts cleanly - no `(cid:*)` markers, `�` replacement characters, or text visible in the PDF but absent from the extraction
+- [ ] Email and phone appear as **literal text** in the extraction (icon-glyph noise like `MOBILE-ALT`/`Envelope` is harmless, but a contact detail carried only by an icon or hyperlink is invisible to ATS)
+- [ ] Reading order of the extracted text matches the visual order (single-column stock template is safe; multi-column custom templates are where this breaks)
+- [ ] Posting keywords covered or honestly absent - synonym-only matches tightened to the posting's exact term where truthfully applicable, keywords the profile genuinely supports added to experience bullets, genuine gaps left visible and **never stuffed**

--- a/.claude/skills/job-application-assistant/SKILL.md
+++ b/.claude/skills/job-application-assistant/SKILL.md
@@ -36,7 +36,12 @@ When the user provides a job posting (URL or text), follow this workflow:
 - Create `cover_letters/cover_<company>_<role>.tex`
 - Ensure the letter connects specific experience to the role requirements
 
-### Step 4: Interview Preparation
+### Step 4: Verify Documents
+- After creating or updating any CV or cover letter, run the full verification checklist in `08-verification-checklist.md`
+- Compiling both documents and visually inspecting the PDF output is **MANDATORY - never skip it**
+- Report the results to the user as a pass/fail checklist before presenting the documents
+
+### Step 5: Interview Preparation
 - Follow the framework in `07-interview-prep.md`
 - Prepare STAR-format answers for likely questions
 - Identify role-specific talking points
@@ -55,6 +60,7 @@ When the user provides a job posting (URL or text), follow this workflow:
 | `05-cv-templates.md` | LaTeX CV structure and tailoring rules |
 | `06-cover-letter-templates.md` | LaTeX cover letter structure and tailoring rules |
 | `07-interview-prep.md` | STAR examples, tough questions, roleplay guidelines |
+| `08-verification-checklist.md` | CV/cover-letter verification: factual accuracy, targeting, compiled-PDF inspection, ATS/keywords |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,50 +86,13 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 1. User provides a job posting (URL or text)
 2. **Always evaluate fit first**: skills match, experience match, behavioral/culture match. Present this assessment to the user before proceeding.
 3. If good fit: create targeted CV (`cv/main_<company>.tex`) and cover letter (`cover_letters/cover_<company>_<role>.tex`)
-4. **Verify both documents** (see Verification Checklist below)
+4. **Verify both documents** against the full checklist in `.claude/skills/job-application-assistant/08-verification-checklist.md`
 5. Prepare interview talking points based on the role requirements and your strengths
 
 **Important:** When mentioning agentic coding or AI tooling in CVs/cover letters, explicitly reference **Claude Code** by name.
 
 ## Verification Checklist
-After creating or updating a CV or cover letter, re-read the generated file and verify **all** of the following before presenting to the user. Report the results as a pass/fail checklist.
 
-### Factual accuracy
-- [ ] All claims match actual profile (CLAUDE.md / candidate profile) - no fabricated skills, experience, or achievements
-- [ ] Job titles, dates, company names, and locations are correct
-- [ ] Contact details are correct
-- [ ] All company-specific claims (partnerships, products, technology, expansions) have been independently verified via WebFetch/WebSearch - do not trust reviewer agent research without verification
+> Full pass/fail checklist: `.claude/skills/job-application-assistant/08-verification-checklist.md` (loaded by the job-application-assistant skill during CV/cover-letter work).
 
-### Targeting
-- [ ] Profile statement / opening paragraph is tailored to the specific role (not generic)
-- [ ] Skills and experience bullets are reframed to match the job requirements
-- [ ] Key job requirements are addressed (with gaps acknowledged where relevant)
-- [ ] Nice-to-have requirements are highlighted where there is a match
-
-### Consistency
-- [ ] CV follows the standard 2-page moderncv/banking format
-- [ ] Cover letter uses cover.cls template and established structure
-- [ ] Tone is consistent across CV and cover letter
-- [ ] No contradictions between CV and cover letter content
-
-### Quality
-- [ ] No LaTeX syntax errors (balanced braces, correct commands)
-- [ ] No spelling or grammar errors
-- [ ] Agentic coding / AI tooling references mention **Claude Code** by name
-- [ ] Cover letter is addressed to the correct person (or "Dear Hiring Manager" if unknown)
-- [ ] Cover letter fits approximately one page
-
-### Compiled PDF verification (MANDATORY - never skip)
-Both documents MUST be compiled and visually inspected via the Read tool on the PDF output. "Looks fine in the .tex" is not acceptable - LaTeX page-break decisions are unpredictable. Iterate until these all pass:
-- [ ] CV compiled with **lualatex** (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors). Cover letter compiled with **xelatex** (cover.cls requires fontspec).
-- [ ] **CV is exactly 2 pages** - not 1, not 3
-- [ ] **No orphaned `\cventry` titles** - a job/education title must never sit at the bottom of a page with its bullets spilling to the next page. Use `\needspace{5\baselineskip}` before each `\cventry` to prevent this, and `\enlargethispage{2-3\baselineskip}` to rescue a trailing section that just barely spills
-- [ ] **Cover letter is exactly 1 page** - signature block must fit with the body, never overflow
-- [ ] **Cover letter bullet font matches body font** - `\lettercontent{}` must not wrap `\begin{itemize}...\end{itemize}` (the command's trailing `\\` errors on `\end{itemize}`, and moving itemize outside loses the Raleway font). Standard pattern: close `\lettercontent{}`, then wrap the list in `{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont \begin{itemize}...\end{itemize}\par}`
-
-### ATS & keyword verification (CV)
-ATS parsers read the PDF's embedded text layer, not the rendered page. Extract it with `pdftotext -layout` and verify what a parser sees. `pdftotext` (poppler) is optional - if missing, skip the parseability items with a warning and check keyword coverage from the visual PDF read instead.
-- [ ] CV text layer extracts cleanly - no `(cid:*)` markers, `�` replacement characters, or text visible in the PDF but absent from the extraction
-- [ ] Email and phone appear as **literal text** in the extraction (icon-glyph noise like `MOBILE-ALT`/`Envelope` is harmless, but a contact detail carried only by an icon or hyperlink is invisible to ATS)
-- [ ] Reading order of the extracted text matches the visual order (single-column stock template is safe; multi-column custom templates are where this breaks)
-- [ ] Posting keywords covered or honestly absent - synonym-only matches tightened to the posting's exact term where truthfully applicable, keywords the profile genuinely supports added to experience bullets, genuine gaps left visible and **never stuffed**
+After creating or updating a CV or cover letter, verify it before presenting to the user: factual accuracy, targeting, consistency, quality, the **MANDATORY** compiled-PDF inspection (never skip - compile the CV with lualatex and the cover letter with xelatex, then visually read the PDF output), and ATS/keyword coverage. Run the complete checklist from the reference file above and report the results as a pass/fail list.


### PR DESCRIPTION
## What

Moves the detailed CV/cover-letter **Verification Checklist** out of the always-loaded root `CLAUDE.md` and into a new reference file under the `job-application-assistant` skill, where it loads on demand during document work.

## Why

Every line of the root `CLAUDE.md` is in the model's context on **every** session — including job scraping, ranking, and interview prep, where the LaTeX/PDF/ATS verification steps are irrelevant. The checklist is ~42 lines (~1.2k tokens) of task-specific guidance that only matters when a CV or cover letter is being generated. Lazy-loading it via the skill keeps it available exactly when it's needed and trims always-resident context.

## Changes

- **New** `.claude/skills/job-application-assistant/08-verification-checklist.md` — the full pass/fail checklist (factual accuracy, targeting, consistency, quality, the mandatory compiled-PDF inspection, ATS/keywords), verbatim.
- **`SKILL.md`** — adds an explicit **Step 4: Verify Documents** referencing the new file (interview prep becomes Step 5) and a Reference Files table row.
- **`CLAUDE.md`** — replaces the full section with a one-line pointer plus a short resident summary that preserves the **MANDATORY "compile and visually inspect the PDF"** rule, so nothing safety-critical is lost from always-on context.

No checklist content is dropped — only relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)