### PR TITLE
fix(salary): handle missing/null city & resolve custom baseline percentage bug

### DIFF
--- a/salary_lookup.py
+++ b/salary_lookup.py
@@ -160,7 +160,7 @@ def search_company(data, query, city=None):
     for entry in companies:
         if city:
             city_lower = city.lower()
-            entry_city = entry.get("city", "").lower()
+            entry_city = (entry.get("city") or "").lower()
             if city_lower not in entry_city and anglicize(city_lower) not in anglicize(entry_city):
                 continue
 

--- a/salary_lookup.py
+++ b/salary_lookup.py
@@ -206,10 +206,13 @@ def format_entry(entry, metadata):
             if count is not None or index is not None:
                 count_str = str(count) if count is not None else "-"
                 if isinstance(index, (int, float)):
-                    diff = index - baseline
-                    sign = "+" if diff >= 0 else ""
                     index_str = f"{index:.1f}"
-                    diff_str = f"{sign}{diff:.1f}%"
+                    if baseline == 0:
+                        diff_str = ""
+                    else:
+                        diff_pct = ((index - baseline) / baseline) * 100
+                        sign = "+" if diff_pct >= 0 else ""
+                        diff_str = f"{sign}{diff_pct:.1f}%"
                 elif index is not None:
                     index_str = str(index)
                     diff_str = ""

--- a/tests/test_salary_lookup.py
+++ b/tests/test_salary_lookup.py
@@ -36,6 +36,36 @@ class FormatEntryTests(unittest.TestCase):
 
         self.assertIn("private", rendered)
 
+    def test_format_entry_with_zero_baseline(self):
+        entry = {
+            "company": "Example Corp",
+            "city": "",
+            "categories": {
+                "it": {
+                    "count": None,
+                    "index": 45000.0,
+                },
+            },
+        }
+        rendered = format_entry(entry, {"index_baseline": 0, "index_label": "Salary"})
+        self.assertIn("45000.0", rendered)
+        self.assertNotIn("%", rendered)
+
+    def test_format_entry_with_custom_baseline(self):
+        entry = {
+            "company": "Example Corp",
+            "city": "",
+            "categories": {
+                "it": {
+                    "count": None,
+                    "index": 45000.0,
+                },
+            },
+        }
+        rendered = format_entry(entry, {"index_baseline": 40000, "index_label": "Salary"})
+        self.assertIn("45000.0", rendered)
+        self.assertIn("+12.5%", rendered)
+
 
 class SearchCompanyTests(unittest.TestCase):
     def test_search_company_with_none_city(self):

--- a/tests/test_salary_lookup.py
+++ b/tests/test_salary_lookup.py
@@ -1,6 +1,6 @@
 import unittest
 
-from salary_lookup import format_entry
+from salary_lookup import format_entry, search_company
 
 
 class FormatEntryTests(unittest.TestCase):
@@ -35,6 +35,20 @@ class FormatEntryTests(unittest.TestCase):
         rendered = format_entry(entry, {"index_baseline": 100, "index_label": "Index"})
 
         self.assertIn("private", rendered)
+
+
+class SearchCompanyTests(unittest.TestCase):
+    def test_search_company_with_none_city(self):
+        data = {
+            "companies": [
+                {
+                    "company": "Acme",
+                    "city": None,
+                }
+            ]
+        }
+        results = search_company(data, "Acme", city="Aarhus")
+        self.assertEqual(results, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request contains two bug fixes for the salary lookup tool:

1. **Fix AttributeError on missing/null city:** Safely handles cases where the city key is present but its value is None, preventing crashes on .lower() during search operations.
2. **Fix custom/zero baseline percentage displays:** Calculates the correct relative percentage comparing to the baseline and suppresses percentage offsets when the baseline is 0.

Unit tests have been added to verify both modifications.