### PR TITLE
setup: populate profile from documents for Joshua Cullinan

### DIFF
--- a/.claude/skills/job-application-assistant/01-candidate-profile.md
+++ b/.claude/skills/job-application-assistant/01-candidate-profile.md
@@ -1,60 +1,90 @@
 # Candidate Profile
 
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all sections will be filled with your actual information -->
-
 ## Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_ADDRESS]
-- **Phone:** [YOUR_PHONE]
-- **Email:** [YOUR_EMAIL]
-- **LinkedIn:** [YOUR_LINKEDIN_URL]
-- **GitHub:** [YOUR_GITHUB_URL]
-- **Languages:** [YOUR_LANGUAGES with proficiency levels]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
+- **Name:** Dr Joshua Cullinan (full: Joshua Peter Cullinan)
+- **Location:** City of Johannesburg, Gauteng, South Africa
+- **Phone:** +27 74 775 3256
+- **Email:** joshcull1@gmail.com
+- **LinkedIn:** https://www.linkedin.com/in/joshcullinan
+- **GitHub:** https://github.com/JoshCullinan
+- **Languages:** English (native). <!-- Afrikaans: basic (Beginners' Afrikaans for MBChB on transcript) - confirm level in interview -->
+- **Work authorization:** South African citizen. **EU citizen (Ireland)** and **British passport holder** - full right to work across the EU, Ireland, and the UK with no visa sponsorship required.
+- **Status:** Employed - Medical Officer (Community Service) at Bheki Mlangeni District Hospital (Jan 2026 - present). Completing the mandatory South African community service year; intends to transition to a new role after it (targeting end of 2026 / into 2027), but open to an exceptional opportunity sooner.
+- **Career direction:** Health-AI / clinical AI and ML/AI engineering (any domain). Not seeking pure clinical shift work.
+- **Location & mobility:** Based in Johannesburg. Open to remote (global), hybrid in Johannesburg/Gauteng, and relocation (including to the UK, Ireland, or EU where he already has the right to work).
 
 ## Education
 
-| Degree | Period | Institution | Key Topics |
-|--------|--------|-------------|------------|
-| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+| Degree | Period | Institution | Result | Key Topics |
+|--------|--------|-------------|--------|------------|
+| MSc in Medicine - Bioinformatics | 2023-2025 | University of Cape Town | Distinction, GPA 89.0% (conferred Sep 2025) | Machine learning / deep learning on simulated viral evolution; recombinant sequence identification |
+| BMedSc (Honours) - Bioinformatics | 2020 | University of Cape Town | Distinction, first class, GPA 85.9% (conferred Jul 2021) | ML to predict cancer cell responses to small-molecule inhibitors (CCLE / GDSC) |
+| MBChB - Bachelor of Medicine and Bachelor of Surgery | 2017-2023 | University of Cape Town | Distinction in clinical sciences, overall first class honours, GPA 77.49% (conferred Mar 2024) | Clinical medicine, diagnostic reasoning, evidence-based medicine |
+
+**Thesis (MSc, 2025):** "Utilising Machine Learning Techniques on Simulated Viral Evolution Datasets to Improve Viral Recombinant Identification." Used time-forward evolutionary models to simulate ~500,000 viral sequences; trained multiple ML/AI models to identify recombinant sequences. Best model was a deep neural network with recurrent pathways. Supervised by Prof. Darren Martin.
+
+**Project (BMedSc Hons, 2020):** Machine learning to predict cancer cell line responses to small-molecule inhibitors using the Cancer Cell Line Encyclopaedia (CCLE) and Genomics of Drug Sensitivity in Cancer (GDSC) databases. Supervised by Prof. Darren Martin and Dr. Musalula Sinkala.
 
 ## Professional Experience
 
-### [JOB_TITLE] - [COMPANY] ([START] - [END])
-[LOCATION]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+### Internal Medicine Medical Officer (Community Service) - Bheki Mlangeni District Hospital (Jan 2026 - present)
+Johannesburg, Gauteng, South Africa
+- Comprehensive clinical management of internal medicine inpatients: daily ward rounds, diagnostic workup, treatment planning, and multidisciplinary coordination
+- Key areas: HIV/TB co-infection, hypertension, diabetes mellitus, chronic kidney disease, and acute medical emergencies in a resource-limited district hospital
+- Additional emergency department overtime shifts covering undifferentiated trauma, surgical, medical, and paediatric presentations
 
-<!-- Add more roles as needed -->
+### Medical Officer Intern - Chris Hani Baragwanath Academic Hospital (Jan 2024 - Dec 2025)
+Johannesburg
+- Two-year HPCSA-accredited medical internship at Africa's largest hospital (3,400 beds)
+- Rotated across Internal Medicine, General Surgery, Paediatrics, Obstetrics & Gynaecology, Psychiatry, Orthopaedics, Anaesthesiology, and Family Medicine
+- Extensive trauma and emergency medicine experience in a high-acuity tertiary care setting
+
+### Tutor - SmartPrep (2019-2020)
+- Lectured classes of matric students in physics and chemistry; developed communication and teaching skills
+
+### Volunteer & Leadership - SHAWCO (Students' Health and Welfare Centres Organisation) (2017-2021)
+- Student-led healthcare organisation serving underprivileged communities across Cape Town
+- Progressed from weekly volunteer to Head of the Khayelitsha Clinic (2018-2019), then Member of the SHAWCO Board of Directors (2020-2021)
 
 ## Independent Projects
-<!-- Projects outside of employment: freelance, open source, personal -->
-- **[PROJECT_NAME]**: [DESCRIPTION]
+- **RDP5 deep-learning integration:** Trained deep neural networks (including recurrent architectures) on 500,000+ simulated viral sequences and deployed them into RDP5, a widely-used recombination-detection research tool, via ONNX. Designed a modular architecture for seamless model replacement.
+- **Self-hosted AI agent:** Integrated the Anthropic Claude API with LLM routing, persistent memory, and skill automation across multi-platform messaging channels.
+- **Proxmox homelab:** Self-hosted virtualisation platform with ZFS storage, Docker services, reverse proxy, and local LLM inference via Ollama.
+- **Chest X-ray classification:** Applied transfer-learning CNNs to chest X-ray classification.
+- **Personal web applications:** Component-based React frontends with Django REST backend services.
 
 ## Technical Skills
 
 ### Programming & ML
-- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
-- [OTHER_SKILLS]
+- **Python** (primary): TensorFlow, scikit-learn, Pandas, NumPy, TensorBoard, Jupyter
+- **JavaScript, HTML/CSS, Bash, SQL**
+- **Deep learning:** neural networks (incl. recurrent), CNNs, transfer learning, ONNX model export/deployment
+- **Web & APIs:** React, Django, REST APIs
+- **LLM integration:** Anthropic Claude API, LLM routing, local inference via Ollama
+
+### Infrastructure & DevOps
+- Git/GitHub, Docker, Linux system administration, AWS EC2, VPS management
+- Proxmox virtualisation, ZFS storage, reverse proxy
+- High-performance compute: SLURM job scheduling, GPU compute
 
 ### Domain Expertise
-- [DOMAIN_1]
-- [DOMAIN_2]
-
-### Software & Tools
-- [TOOL_LIST]
+- **Clinical medicine:** HIV/TB, internal medicine, emergency care, diagnostic reasoning, evidence-based medicine
+- **Bioinformatics:** genomic and proteomic datasets, viral evolution modelling, clinical imaging pipelines, large-scale biomedical data processing
 
 ## Publications
-<!-- List peer-reviewed publications, if any -->
-1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+<!-- SETUP: No peer-reviewed journal publications listed in source documents. Confirm in interview whether any exist. -->
+- MSc dissertation (2025): *Utilising Machine Learning Techniques on Simulated Viral Evolution Datasets to Improve Viral Recombinant Identification*, University of Cape Town.
 
 ## Awards
-- [AWARD] - [EVENT] ([YEAR])
+- MBChB awarded with **distinction in the clinical sciences** and **overall first class honours** (UCT, 2023)
+- MSc in Medicine (Bioinformatics) awarded **with distinction** (UCT, 2025)
+- BMedSc (Honours) in Bioinformatics awarded in the **first class** (UCT, 2020)
+- **Class Medal - Mathematics 1005** (UCT, 2016)
+- **UCT Plus Gold** - 60 hours in an elected leadership role
 
 ## References
-- [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])
+<!-- SETUP: No reference letters provided. Potential referees to confirm in interview: -->
+- Prof. Darren Martin, University of Cape Town (MSc and BMedSc Hons supervisor) - confirm contact details and permission
+- <!-- Add a clinical referee (e.g. supervising consultant) -->
 
 More references available upon request.

--- a/.claude/skills/job-application-assistant/02-behavioral-profile.md
+++ b/.claude/skills/job-application-assistant/02-behavioral-profile.md
@@ -1,50 +1,46 @@
 # Behavioral Profile
 
-<!-- SETUP: This file is populated by running /setup -->
-<!-- You can use results from PI, DISC, Myers-Briggs, StrengthsFinder, or a self-assessment -->
+<!-- No formal assessment (PI/DISC/etc.) provided. This profile is synthesized from the setup interview and inferred from the LinkedIn "About" section. Inferred items are labeled; review before relying on them. -->
 
 ## Overview
-[YOUR_NAME]'s behavioral assessment identifies them as a **[PROFILE_TYPE]** pattern. [1-2 SENTENCE_SUMMARY].
-
-## Core Behavioral Drives
-
-| Drive | Level | Meaning |
-|-------|-------|---------|
-| [DRIVE_1] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_2] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_3] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_4] | [LEVEL] | [DESCRIPTION] |
+Joshua is a high-achieving, intellectually curious clinician-engineer who is energised by hard, novel problems and by building things that reach real users. He pairs the disciplined, evidence-based judgement of a doctor with the self-directed drive of a self-taught engineer (self-hosted AI agent, homelab, an MSc completed with distinction *during* a demanding hospital internship). He calibrates his working style to the stakes: thorough and careful where the cost of error is high, fast and iterative where it is cheap.
 
 ## Strongest Behaviors
-- **[BEHAVIOR_1]:** [DESCRIPTION]
-- **[BEHAVIOR_2]:** [DESCRIPTION]
-- **[BEHAVIOR_3]:** [DESCRIPTION]
+- **Self-directed learning and ownership:** Builds and runs his own infrastructure and projects end-to-end; taught himself ML, deployment, and systems administration alongside a medical career.
+- **Disciplined execution under load:** Earned an MSc with distinction (89%) while working a full HPCSA internship at Africa's largest hospital. Long-form endurance shows up outside work too (1,500 km Amsterdam-to-France bikepacking trip). *[Inferred from CV/LinkedIn]*
+- **Bridging clinical and technical worlds:** Comfortable translating between clinicians and engineers, a rare and durable differentiator.
+- **Judgement calibrated to context:** Deliberate and evidence-based where stakes are high; willing to ship rough first versions where iteration is cheap.
 
 ## How You Work Best
-- [ENVIRONMENT_PREFERENCE_1]
-- [ENVIRONMENT_PREFERENCE_2]
-- [ENVIRONMENT_PREFERENCE_3]
+- On novel research and genuinely hard problems, with room to learn continuously
+- With real-world impact visible, especially clinical or patient-facing outcomes
+- With autonomy and ownership over your scope
+- In cross-functional settings sitting between clinical and engineering teams
+- Flexible on company shape: thrives in a structured, well-mentored organisation *and* in a small autonomous team, as long as ownership and learning are present
 
 ## Growth Areas (frame positively in applications)
-- **[AREA_1]:** [HOW_TO_FRAME_IT_POSITIVELY]
-- **[AREA_2]:** [HOW_TO_FRAME_IT_POSITIVELY]
+- **Limited commercial/industry software-engineering track record:** Deep clinical and research background, less time inside industry SWE teams. Frame as bringing research rigor and a clinician's judgement, and as eager to absorb team engineering practices quickly.
+- **Low tolerance for bureaucracy and repetitive maintenance work:** Frame as a strong bias toward high-impact, high-learning work; be honest that heavily process-bound or maintenance-only roles are a poor fit rather than pretending otherwise.
 
 ## Mapping to Job Posting Language
 
-When a job posting mentions these keywords, it's a **strong behavioral fit**:
-- [KEYWORD_OR_PHRASE_THAT_MATCHES_YOUR_STYLE]
-- [ANOTHER_KEYWORD]
+When a posting uses these, it is a **strong behavioral fit**:
+- "ownership", "autonomy", "end-to-end", "0-to-1", "research", "ambiguous problems"
+- "cross-functional", "clinical", "healthcare impact", "mission-driven"
+- "fast-moving", "learning culture", "take something from prototype to production"
 
-When a job posting mentions these, flag as **potential friction** (not deal-breaker):
-- [KEYWORD_OR_PHRASE_THAT_MIGHT_CLASH]
-- [ANOTHER_KEYWORD]
+When a posting uses these, flag as **potential friction** (not an automatic deal-breaker):
+- "maintenance", "legacy system", "support/on-call for existing systems"
+- "highly process-driven", "matrixed organisation", "strict change control"
+- "shift work", "rota", "back-office", "purely operational"
 
 ## Management Style Preferences
-- [WHAT_MANAGEMENT_STYLE_WORKS_FOR_YOU]
-- [WHAT_DOESN'T_WORK]
+- Works best with managers who give context and autonomy, then get out of the way, while remaining available for mentorship
+- Dislikes micromanagement and approval-heavy hierarchies
+- Values clear goals and honest feedback over prescriptive task lists
 
 ## Using This in Applications
-- **Cover letters:** [HOW_TO_WEAVE_IN_BEHAVIORAL_STRENGTHS]
-- **CV:** [WHAT_TO_EMPHASIZE]
-- **Interviews:** [WHAT_STAR_EXAMPLES_TO_USE]
-- **Don't overstate:** [WHAT_NOT_TO_CLAIM]
+- **Cover letters:** Lead with the clinician-plus-engineer combination and a concrete build-and-ship example (e.g. deploying his model into RDP5). Show initiative and ownership.
+- **CV:** Emphasise self-directed delivery, research-to-production, and the dual domain.
+- **Interviews:** Use the SHAWCO leadership progression and the MSc-during-internship story for discipline/ownership; the RDP5 deployment for research-to-production; clinical decision-making for judgement under pressure.
+- **Don't overstate:** Do not claim extensive commercial/team software-engineering experience, or leadership of large engineering teams. The strength is judgement, learning speed, and the clinical+technical bridge, not years in industry.

--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -16,9 +16,9 @@ How well do the required/preferred skills align with the candidate's capabilitie
 | 40-59 | Partial match, significant upskilling needed |
 | 0-39 | Fundamental mismatch |
 
-**Strong match areas:** [YOUR_PRIMARY_SKILLS]
-**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
-**Weak match areas:** [SKILLS_YOU_LACK]
+**Strong match areas:** Python, machine learning / deep learning (TensorFlow, scikit-learn), data analysis (Pandas/NumPy), bioinformatics and genomics, clinical medicine and biomedical domain knowledge, model training and evaluation
+**Moderate match areas:** ML deployment / MLOps (ONNX), LLM integration (Claude API, Ollama), web development (React, Django, REST), DevOps/infrastructure (Docker, Linux, AWS EC2, Proxmox), HPC (SLURM/GPU), SQL
+**Weak match areas:** large-scale production software engineering, commercial/industry SWE track record, big-team enterprise delivery, PyTorch/JAX (has used TensorFlow), formal product/PM experience, cloud-native/Kubernetes at scale
 
 ### 2. Experience Match (0-100)
 Does work history align with what they're looking for?
@@ -30,9 +30,9 @@ Does work history align with what they're looking for?
 | 40-59 | Adjacent experience, would need to make the case |
 | 0-39 | Unrelated experience |
 
-**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
-**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
-**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+**Strong:** clinical medicine (internal medicine, emergency, HIV/TB), bioinformatics research, ML/DL model development on large datasets, academic research delivery
+**Moderate:** ML model deployment, software/web development, self-managed infrastructure, teaching/mentoring
+**Entry-level:** commercial software engineering, industry/product roles, MLOps in a team setting, consulting/client-facing delivery
 
 ### 3. Behavioral/Culture Fit (0-100)
 Does the role and company culture match the behavioral profile?
@@ -63,19 +63,22 @@ Does this role advance career goals and contain tasks that energize?
 | 0-39 | Dead end or backwards step |
 
 **Career goals:**
-- [YOUR_CAREER_GOAL_1]
-- [YOUR_CAREER_GOAL_2]
-- [YOUR_CAREER_GOAL_3]
+- Move into health-AI / clinical AI: build ML/AI products that improve clinical decision-making and patient outcomes
+- Grow as an ML/AI engineer who takes models from research to production (also open to strong ML/AI roles in any domain)
+- Leverage the dual clinician + engineer identity as a durable differentiator, ideally in cross-functional teams
+- Land a role to transition into after the community-service year (targeting end of 2026 / into 2027), open to an exceptional opportunity sooner. Right to work in the EU, Ireland, and the UK broadens the search internationally.
 
 **Motivation filter:** Evaluate not just whether you *can* do the tasks, but whether the tasks will *energize* you. Consider:
-- Tasks that energize: [YOUR_ENERGIZING_TASKS]
-- Tasks that drain: [YOUR_DRAINING_TASKS]
+- Tasks that energize: novel research and hard problems, building and shipping real systems, work with visible clinical/patient impact, autonomous self-directed work
+- Tasks that drain: pure maintenance work, endless meetings and process overhead, repetitive work with no learning, bureaucracy and red tape
 - Non-task factors: leadership style, department culture, company values, degree of autonomy
 
 **Life situation alignment:** Consider personal constraints:
-- **Security**: [YOUR_FINANCIAL_SITUATION_CONTEXT]
-- **Flexibility**: [YOUR_SCHEDULE_CONSTRAINTS]
-- **Professional development**: [YOUR_GROWTH_PRIORITIES]
+- **Security**: Currently employed through the community-service year (to end of 2026); transitioning deliberately rather than under pressure. Can afford to hold out for a strong-fit role.
+- **Flexibility**: Open to remote (global), hybrid in Johannesburg/Gauteng, and relocation. Right to work in the EU, Ireland, and the UK.
+- **Professional development**: High priority. A role that offers continuous learning and growth into more technical or architectural scope scores well; a role with no learning curve scores poorly.
+
+**Deal-breaker:** Pure clinical shift work with no path into data/AI/technical work. Auto-downgrade such roles.
 
 ### 6. Salary Benchmark (Optional)
 

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -105,12 +105,18 @@ Write 5-7 lines that function as an "elevator pitch": a concise, compelling intr
 
 **Create 2-3 profile statement templates for your main role types:**
 
-<!-- SETUP: These are populated based on your background -->
-**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+**For Health-AI / Clinical AI roles (primary direction):**
+> Medical doctor and AI/ML engineer with three years of frontline clinical experience, including at Africa's largest hospital, and an MSc in Bioinformatics (Distinction, UCT) specialising in machine learning. Trained deep learning models on 500,000+ simulated viral sequences and deployed them into a widely-used research tool (RDP5) via ONNX, while practising medicine in a high-burden HIV/TB district setting. Brings a rare dual perspective to building AI products that create real-world impact for clinicians and patients.
 
-**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+**For ML / AI Engineering roles:**
+> ML engineer with an MSc in Bioinformatics (Distinction) and a track record of taking deep learning models from research to deployment. Built and trained neural networks (including recurrent architectures) on 500,000+ sequence datasets and shipped them into a widely-used research tool (RDP5) via ONNX with a modular, swappable architecture. Comfortable across the stack: Python/TensorFlow, GPU/SLURM compute, Docker, and self-hosted infrastructure.
+
+**For clinical / medical roles:**
+> Medical doctor (MBChB, UCT, distinction in clinical sciences) with three years of frontline experience across internal medicine, emergency, and a full HPCSA internship at Africa's largest hospital (3,400 beds). Strong in diagnostic reasoning and evidence-based practice in resource-limited, high-acuity settings, with an additional MSc in Bioinformatics that brings a data-driven edge to clinical decision-making.
+
+<!-- SETUP: Refine or add role-specific statements as the job search direction firms up. -->
+<!-- [Used for: none yet - no past applications on file] -->
+
 
 ### Core Competencies / Skills Section (Best Practice)
 Reorder and emphasize based on the role. Use bold category labels.

--- a/.claude/skills/job-application-assistant/07-interview-prep.md
+++ b/.claude/skills/job-application-assistant/07-interview-prep.md
@@ -8,32 +8,69 @@ Structure answers as: **Situation** (context), **Task** (your responsibility), *
 
 Keep answers to 1-2 minutes. Be specific. End with what you learned or would do differently.
 
-## Ready-Made STAR Examples
+## STAR Candidates (Complete Manually)
 
-<!-- These are populated by /setup from your actual experience. Below are templates showing the format. -->
+These are drawn from your CV, LinkedIn, and academic record. Each is a strong raw candidate for a STAR answer, but the Situation/Task/Action/Result details need your first-hand input before you rely on them in an interview. Flesh out the four lines for the ones most relevant to your target roles.
 
-### 1. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
-**S:** [CONTEXT - what was happening, what was the problem]
-**T:** [YOUR RESPONSIBILITY - what you specifically needed to do]
-**A:** [WHAT YOU DID - specific actions, tools, methods]
-**R:** [OUTCOME - measurable results, adoption, impact]
-**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+### MSc thesis - ML on 500,000+ simulated viral sequences (technical depth, independent delivery)
+**Source:** MSc dissertation, UCT (2023-2025)
+**What happened:** Simulated ~500,000 viral sequences with time-forward evolutionary models and trained multiple ML/AI models to identify recombinants; best was a deep neural network with recurrent pathways.
+**Why it matters:** Answers questions on end-to-end ML projects, handling large datasets, model selection, and self-directed research.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
-### 2. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
-**S:** [CONTEXT]
-**T:** [YOUR RESPONSIBILITY]
-**A:** [WHAT YOU DID]
-**R:** [OUTCOME]
-**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+### Deploying a model into RDP5 via ONNX (research-to-production, software design)
+**Source:** MSc project / independent work
+**What happened:** Deployed trained neural networks into RDP5, a widely-used research tool, via ONNX, with a modular architecture allowing models to be swapped without rework.
+**Why it matters:** Answers questions on shipping ML to real users, maintainable design, and thinking beyond the notebook.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
-### 3. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
-**S:** [CONTEXT]
-**T:** [YOUR RESPONSIBILITY]
-**A:** [WHAT YOU DID]
-**R:** [OUTCOME]
-**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+### BMedSc Honours - cancer drug-response ML (research, first ML project)
+**Source:** BMedSc (Hons) project, UCT (2020)
+**What happened:** Built ML models to predict cancer cell line responses to small-molecule inhibitors using CCLE and GDSC data.
+**Why it matters:** Answers questions on early initiative, applying ML to biomedical data, and learning a new field.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
-<!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
+### Self-hosted AI agent + homelab (initiative, self-taught engineering)
+**Source:** Independent projects
+**What happened:** Built a self-hosted AI agent on the Anthropic Claude API (LLM routing, persistent memory, skill automation) running on a self-managed Proxmox/ZFS/Docker platform with local Ollama inference.
+**Why it matters:** Answers questions on self-directed learning, systems/infra ownership, and hands-on LLM engineering.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Clinical management under pressure - HIV/TB in a resource-limited setting (judgement, resourcefulness)
+**Source:** Bheki Mlangeni District Hospital (2026-present) / Chris Hani Baragwanath internship
+**What happened:** Managed complex internal-medicine and emergency cases (HIV/TB co-infection, acute emergencies) with limited resources in high-acuity settings.
+**Why it matters:** Answers questions on decision-making under pressure, prioritisation, and working within constraints.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### SHAWCO leadership progression (leadership, service, teamwork)
+**Source:** SHAWCO (2017-2021)
+**What happened:** Progressed from weekly volunteer to Head of the Khayelitsha Clinic, then to the SHAWCO Board of Directors.
+**Why it matters:** Answers questions on leadership, taking ownership, and working with teams over time.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
 ## Common Tough Questions
 

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -1,76 +1,89 @@
 # Search Queries for Job Scraper
 
-<!-- SETUP: Customize these queries based on your skills, target roles, and location -->
+<!-- Configured for Joshua Cullinan via /setup. -->
+
+> **Note on tooling:** The framework's built-in scraper CLI targets **Danish** job portals (Jobindex, Jobnet, etc.), which do **not** apply here. Joshua is based in South Africa and searches the **remote-global, UK, Ireland, EU, and South African** markets. This config therefore drives searches through **LinkedIn** and **Google `site:` searches** of company career pages and health-AI job boards. To add a dedicated local portal integration later, run `/add-portal`.
+
+## Target markets (Joshua has the right to work in all of these)
+- **Remote (global)** - highest priority; widest net for health-AI / ML roles
+- **United Kingdom** (British passport) - London and remote-UK
+- **Ireland** (EU/Irish citizen) - Dublin and remote-IE
+- **EU** (Irish citizenship) - remote-EU and major hubs
+- **South Africa** - Johannesburg and Cape Town (current base)
 
 ## Search Sites
-
-Primary (Danish job market):
-- **jobindex.dk** - largest Danish job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: Denmark / your city)
-- **karriere.dk** - IDA's job board (engineering/science roles)
-- **jobfinder.dk** - another major Danish job board
-- **akademikernes.dk** - academic union job board
-
-Secondary (company career pages via Google):
-- Direct Google searches with `site:` filters for known target companies
+- **linkedin.com/jobs** - primary. Filter by the markets above and by "Remote".
+- **Google `site:` searches** - company career pages and aggregators (examples below).
+- Health-AI job boards / aggregators: `builtin.com`, `wellfound.com` (AngelList Talent), `ycombinator.com/jobs`, `otta.com`, company career pages directly.
 
 ## Query Categories
 
-Queries are grouped by priority. Each query should be combined with your location terms (e.g. "Copenhagen", "Sjælland", "Hovedstaden") where the site supports it.
+Queries are grouped by priority. Combine each with a market term (`remote`, `United Kingdom`, `Ireland`, `EU`, `South Africa`, `Johannesburg`, `Cape Town`) where the site supports it.
 
-### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+### Priority 1: Health-AI / Clinical AI (primary direction)
 
-These match your strongest and most desired career direction.
-
-```
-site:jobindex.dk "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
-site:jobindex.dk "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
-```
-
-### Priority 2: [YOUR_DOMAIN_EXPERTISE]
-
-These match your domain expertise.
+Strongest and most desired direction: building AI/ML for healthcare.
 
 ```
-site:jobindex.dk [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:jobindex.dk [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+site:linkedin.com/jobs "clinical AI" (remote OR "United Kingdom" OR Ireland)
+site:linkedin.com/jobs "clinical data scientist" (remote OR UK OR EU)
+site:linkedin.com/jobs "clinical machine learning" engineer remote
+site:linkedin.com/jobs ("medical AI" OR "health AI" OR "digital health") "machine learning"
+site:linkedin.com/jobs "clinical decision support" (ML OR "machine learning")
+site:wellfound.com health AI machine learning
+"health AI" "machine learning engineer" careers (remote OR London OR Dublin)
 ```
 
-### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
+### Priority 2: Applied ML / AI Engineering (any domain)
 
-Adjacent roles you could pivot into.
-
-```
-site:jobindex.dk "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:jobindex.dk "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
-```
-
-### Priority 4: Broader Technical / Consulting
-
-Wider net for general technical roles.
+Leans on Python, deep learning, and research-to-production skill.
 
 ```
-site:jobindex.dk [YOUR_KEY_SKILL] developer [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:jobindex.dk "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+site:linkedin.com/jobs "machine learning engineer" (remote OR "United Kingdom" OR Ireland)
+site:linkedin.com/jobs "AI engineer" Python (remote OR EU)
+site:linkedin.com/jobs "applied scientist" "deep learning" remote
+site:linkedin.com/jobs "data scientist" Python TensorFlow (remote OR UK)
+site:linkedin.com/jobs "LLM engineer" OR "GenAI engineer" remote
 ```
 
-## Location Filter
+### Priority 3: Biomedical / Bioinformatics ML (domain expertise)
 
-When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
-- [YOUR_CITY] and surrounding areas
-- [ACCEPTABLE_AREA_1]
-- [ACCEPTABLE_AREA_2]
-- [BORDERLINE_AREA] (borderline - ~X min by transit)
-- [TOO_FAR_AREA] (too far)
+Direct match to his research background.
+
+```
+site:linkedin.com/jobs bioinformatics "machine learning" (remote OR UK OR EU)
+site:linkedin.com/jobs "computational biology" "deep learning" remote
+site:linkedin.com/jobs (genomics OR "medical imaging") "machine learning" engineer
+site:linkedin.com/jobs "ML scientist" (healthcare OR biotech OR pharma) remote
+```
+
+### Priority 4: Broader technical / clinical-informatics (wider net)
+
+```
+site:linkedin.com/jobs "clinical informatics" (data OR AI OR analytics)
+site:linkedin.com/jobs "physician" ("machine learning" OR AI OR "data science") remote
+site:linkedin.com/jobs "medical advisor" health-tech (AI OR data)
+site:linkedin.com/jobs Python developer (health OR medical OR bio) remote
+```
+
+## Role titles to search
+Clinical AI Engineer, Clinical/Medical Machine Learning Engineer, Clinical Data Scientist, Machine Learning Engineer, AI Engineer, Applied Scientist, Data Scientist (health/biotech), Bioinformatics/Computational Biology ML Scientist, LLM/GenAI Engineer, Clinical Informatics Specialist, Physician Data Scientist / Clinical AI Advisor.
+
+## Key skill search terms
+Python, TensorFlow, scikit-learn, deep learning, machine learning, neural networks, ONNX, bioinformatics, genomics, medical imaging, LLM, Claude API, healthcare, clinical.
+
+## Location filter (evaluation tiers)
+- **Ideal:** Remote (global) roles open to South-Africa-based or EU/UK-based candidates.
+- **Acceptable:** UK (London or remote-UK), Ireland (Dublin or remote-IE), remote-EU - Joshua has the right to work and is open to relocating.
+- **Acceptable (local):** Johannesburg / Gauteng (on-site or hybrid); Cape Town (relocation within SA).
+- **Borderline:** On-site EU roles requiring immediate relocation before the community-service year ends (end of 2026) - flag timing.
+- **Too far / fail:** Roles requiring work authorization Joshua does not hold (e.g. US on-site with no sponsorship), or requiring relocation before he can leave his current post.
 
 ## Date Filter
-
 Only include jobs posted within the last 14 days, or with an application deadline that has not yet passed. If a posting date cannot be determined, include it but flag as "date unknown".
 
-## Adapting Queries
+## Timing note
+Joshua is completing a community-service year to the end of 2026 and is targeting a transition after it (into 2027), but is open to an exceptional opportunity sooner. Flag start-date expectations on strong matches.
 
-If the user specifies a focus area, select queries from the matching category and also generate 2-3 custom queries for that focus. For example:
-- "/scrape [focus_area]" -> relevant category queries + custom focus-specific queries
+## Adapting Queries
+If the user specifies a focus area (e.g. `/scrape medical imaging`), select queries from the matching category and generate 2-3 custom queries for that focus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,7 @@
-# Job Application Assistant for [YOUR_NAME]
-
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
+# Job Application Assistant for Joshua Cullinan
 
 ## Role
-This repo is a job application workspace. Claude acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+This repo is a job application workspace. Claude acts as a career advisor and application assistant for Joshua Cullinan, helping with:
 1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
 2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
 3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
@@ -13,68 +10,70 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 
 ## Candidate Profile
 
-<!-- This section is auto-populated by /setup. You can also fill it in manually. -->
+> Full structured profile: `.claude/skills/job-application-assistant/01-candidate-profile.md`. Behavioral detail: `02-behavioral-profile.md`.
 
 ### Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
-- **Languages:** [YOUR_LANGUAGES]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+- **Name:** Dr Joshua Cullinan (full: Joshua Peter Cullinan)
+- **Location:** Johannesburg, Gauteng, South Africa. Open to remote (global), hybrid in Johannesburg/Gauteng, and relocation.
+- **Work authorization:** South African citizen; **EU citizen (Ireland)** and **British passport holder** - full right to work in the EU, Ireland, and the UK with no visa sponsorship.
+- **Languages:** English (native); basic Afrikaans (confirm level).
+- **Status:** Medical Officer (Community Service), Bheki Mlangeni District Hospital (Jan 2026 - present). Finishing the community-service year; targeting a transition into a new role at end of 2026 / into 2027, open to an exceptional opportunity sooner.
+- **LinkedIn headline:** "Medical Doctor | MSc Medicine (Bioinformatics) | AI Driven Health"
 
 ### Education
-<!-- List your degrees, most recent first -->
-- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
-  - Thesis: "[THESIS_TITLE]"
-  - Topics: [KEY_TOPICS]
+- **MSc in Medicine - Bioinformatics** (2023-2025) - University of Cape Town - **Distinction, GPA 89.0%**
+  - Thesis: "Utilising Machine Learning Techniques on Simulated Viral Evolution Datasets to Improve Viral Recombinant Identification"
+  - Topics: deep learning (recurrent networks), ~500,000 simulated viral sequences, recombinant identification, ONNX deployment into RDP5
+- **BMedSc (Honours) - Bioinformatics** (2020) - University of Cape Town - **Distinction, first class, GPA 85.9%**
+  - Project: ML to predict cancer cell responses to small-molecule inhibitors (CCLE / GDSC)
+- **MBChB - Bachelor of Medicine and Surgery** (2017-2023) - University of Cape Town - **Distinction in clinical sciences, overall first class honours, GPA 77.49%**
 
 ### Professional Experience
-<!-- List your roles, most recent first -->
-- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
-  - [KEY_RESPONSIBILITY_1]
-  - [KEY_RESPONSIBILITY_2]
-  - [KEY_ACHIEVEMENT]
+- **Internal Medicine Medical Officer (Community Service)** (Jan 2026 - present) - **Bheki Mlangeni District Hospital** (Johannesburg)
+  - Comprehensive management of internal-medicine inpatients: ward rounds, diagnostic workup, treatment planning, MDT coordination
+  - HIV/TB co-infection, diabetes, hypertension, CKD, acute emergencies in a resource-limited district hospital
+  - Additional ED shifts across trauma, surgical, medical, and paediatric presentations
+- **Medical Officer Intern** (Jan 2024 - Dec 2025) - **Chris Hani Baragwanath Academic Hospital** (Johannesburg)
+  - Two-year HPCSA-accredited internship at Africa's largest hospital (3,400 beds)
+  - Rotations across Internal Medicine, Surgery, Paediatrics, O\&G, Psychiatry, Orthopaedics, Anaesthesiology, Family Medicine; extensive trauma/emergency exposure
+- **Tutor** (2019-2020) - **SmartPrep** - physics and chemistry for matric students
+- **Volunteer & Leadership** (2017-2021) - **SHAWCO** - volunteer to Head of Khayelitsha Clinic (2018-2019) to Board of Directors (2020-2021)
 
 ### Technical Skills
-- **Primary:** [YOUR_PRIMARY_SKILLS]
-- **Secondary:** [YOUR_SECONDARY_SKILLS]
-- **Domain:** [YOUR_DOMAIN_EXPERTISE]
-- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+- **Primary:** Python, machine learning / deep learning (TensorFlow, scikit-learn), data analysis (Pandas, NumPy)
+- **Secondary:** JavaScript, React, Django, REST APIs, SQL, Bash; ONNX model deployment; LLM integration (Anthropic Claude API, Ollama)
+- **Domain:** clinical medicine (HIV/TB, internal medicine, emergency); bioinformatics, genomics, viral evolution, clinical imaging
+- **Software / Infra:** Git/GitHub, Docker, Linux, AWS EC2, Proxmox/ZFS, SLURM/GPU compute, Jupyter, TensorBoard
 
 ### Certifications
-<!-- List relevant certifications with dates -->
-- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+- None on file currently.
 
 ### Publications
-<!-- List peer-reviewed publications, if any -->
-- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+- MSc dissertation (2025): *Utilising Machine Learning Techniques on Simulated Viral Evolution Datasets to Improve Viral Recombinant Identification*, University of Cape Town. (No peer-reviewed journal publications on file - confirm.)
 
 ### Awards
-<!-- List relevant awards, hackathons, competitions -->
-- [AWARD_NAME] - [EVENT] ([YEAR])
+- MBChB with distinction in the clinical sciences and overall first class honours (UCT, 2023)
+- MSc (Bioinformatics) with distinction (UCT, 2025); BMedSc (Hons) first class (UCT, 2020)
+- Class Medal - Mathematics 1005 (UCT, 2016); UCT Plus Gold (60h elected leadership role)
 
 ### Behavioral Profile
-<!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
-- **[TRAIT_1]** - [DESCRIPTION]
-- **[TRAIT_2]** - [DESCRIPTION]
-- **Strengths:** [YOUR_STRENGTHS]
-- **Growth areas:** [YOUR_GROWTH_AREAS]
-- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+- **Self-directed clinician-engineer** - builds and ships end-to-end; taught himself ML, deployment, and systems admin alongside a medical career
+- **Disciplined under load** - MSc with distinction earned during a full hospital internship
+- **Strengths:** research-to-production delivery, judgement calibrated to stakes, bridging clinical and engineering teams, fast learning
+- **Growth areas:** limited commercial/team software-engineering track record; low tolerance for bureaucracy and maintenance-only work
+- **Thrives in:** novel hard problems with autonomy and visible impact; flexible between structured orgs and small autonomous teams
 
 ### What Excites You
-<!-- What motivates you professionally -->
-- [PASSION_1]
-- [PASSION_2]
+- Novel research and genuinely hard problems, with continuous learning
+- Building and shipping AI/ML systems that reach real users and create clinical/patient impact
 
 ### Target Sectors
-<!-- Industries and companies you're targeting -->
-- [SECTOR_1]: [EXAMPLE_COMPANIES]
-- [SECTOR_2]: [EXAMPLE_COMPANIES]
+- **Health-AI / clinical AI / digital health:** companies building AI for clinicians and patients (e.g. clinical documentation, diagnostics, medical imaging, clinical decision support)
+- **ML / AI engineering (any domain):** applied ML/AI roles that value research-to-production skill
 
 ### Deal-breakers
-<!-- Hard constraints on job search -->
-- [DEALBREAKER_1]
-- [DEALBREAKER_2]
+- Pure clinical shift work with no path into data/AI/technical work
+- Roles with no learning curve or no AI/ML/technical component
 
 ## Repo Structure
 - `cv/` - LaTeX CV variants (moderncv template, banking style)

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -1,8 +1,7 @@
-%% Example CV - [YOUR_NAME]
-%% Comprehensive overview of all competencies, experience, and achievements.
-%% Use as a master reference when tailoring role-specific CVs.
+%% Example CV - Dr Joshua Cullinan
+%% Comprehensive master reference of all competencies, experience, and achievements.
+%% Use as the source when tailoring role-specific CVs (cv/main_<company>.tex).
 %%
-%% SETUP: Run /setup to populate this with your actual information.
 %% Compile with: lualatex main_example.tex
 %% (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors.)
 
@@ -18,24 +17,25 @@
 \renewcommand*{\sectionstyle}[1]{{\sectionfont\color{color1}#1}}
 
 \usepackage[utf8]{inputenc}
+\usepackage{needspace}
 \usepackage{hyperref}
 \hypersetup{
     colorlinks=true,
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Joshua Cullinan - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}
 
 % personal data
-\name{[First]}{[Last]}
-\address{[Your Address, City, Country]}{}{}
-\phone[mobile]{[+XX XXXXXXXXXX]}
-\email{[your.email@example.com]}
-\extrainfo{\href{[https://linkedin.com/in/your-profile]}{LinkedIn}, \href{[https://github.com/your-username]}{GitHub}}
+\name{Joshua}{Cullinan}
+\address{Johannesburg, Gauteng, South Africa}{}{}
+\phone[mobile]{+27~74~775~3256}
+\email{joshcull1@gmail.com}
+\extrainfo{\href{https://www.linkedin.com/in/joshcullinan}{LinkedIn}, \href{https://github.com/JoshCullinan}{GitHub}}
 
 \begin{document}
 
@@ -46,7 +46,7 @@
 % ============================================================
 
 \vspace{6pt}
-\small{[Write a 3-5 line profile statement tailored to the role you're applying for. Focus on what makes you uniquely qualified. Example: "Data scientist with a PhD in [field] and X years of industry experience. Combines deep domain expertise in [domain] with strong applied machine learning and Python development skills. Experienced in developing end-to-end ML pipelines, from data ingestion to stakeholder-facing dashboards."]}
+\small{Medical doctor and AI/ML engineer with three years of frontline clinical experience, including at Africa's largest hospital, and an MSc in Bioinformatics (Distinction, UCT) specialising in machine learning. Trained deep learning models on 500,000+ simulated viral sequences and deployed them into a widely-used research tool (RDP5) via ONNX, while practising medicine in a high-burden HIV/TB district setting. Brings a rare dual perspective to building AI products that create real-world impact for clinicians and patients.}
 
 % ============================================================
 %     CORE COMPETENCIES
@@ -56,15 +56,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item \textbf{[Skill Category 1]}: [Specific skills, frameworks, tools. Be concrete.]
+\item \textbf{Machine Learning \& Deep Learning}: Python, TensorFlow, scikit-learn, Pandas, NumPy. Neural networks (incl. recurrent), CNNs, transfer learning; model training, evaluation, and ONNX deployment into research tools.
 
-\item \textbf{[Skill Category 2]}: [Specific skills, frameworks, tools.]
+\item \textbf{Programming \& Web}: Python (primary), JavaScript, HTML/CSS, Bash, SQL. React frontends and Django REST backends; REST API design.
 
-\item \textbf{[Skill Category 3]}: [Specific skills, frameworks, tools.]
+\item \textbf{LLM \& AI Engineering}: Anthropic Claude API integration, LLM routing, persistent memory, skill automation; local inference via Ollama. Agentic coding with \textbf{Claude Code}.
 
-\item \textbf{[Skill Category 4]}: [Domain expertise, methods, approaches.]
+\item \textbf{Infrastructure \& DevOps}: Git/GitHub, Docker, Linux administration, AWS EC2, VPS and Proxmox/ZFS self-hosting; high-performance compute with SLURM and GPUs.
 
-\item \textbf{[Skill Category 5]}: [Tools, platforms, software.]
+\item \textbf{Clinical \& Biomedical Domain}: HIV/TB, internal medicine, and emergency care; genomic and proteomic datasets, clinical imaging pipelines, and large-scale biomedical data processing.
 
 \end{itemize}
 
@@ -77,33 +77,47 @@
 \begin{itemize}
 
 % --- Most Recent Role ---
-\item{\cventry{[YYYY--Present]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{2026--Present}{Internal Medicine Medical Officer (Community Service)}{Bheki Mlangeni District Hospital}{Johannesburg, South Africa}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1 - be specific, use numbers where possible]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
-    \item [Achievement or responsibility 4]
+    \item Comprehensive clinical management of internal-medicine inpatients: ward rounds, diagnostic workup, treatment planning, and multidisciplinary coordination
+    \item Key areas: HIV/TB co-infection, diabetes, hypertension, chronic kidney disease, and acute medical emergencies in a resource-limited district hospital
+    \item Additional emergency-department shifts across trauma, surgical, medical, and paediatric presentations
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Previous Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{2024--2025}{Medical Officer Intern}{Chris Hani Baragwanath Academic Hospital}{Johannesburg, South Africa}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
+    \item Two-year HPCSA-accredited internship at Africa's largest hospital (3,400 beds)
+    \item Rotated across Internal Medicine, Surgery, Paediatrics, Obstetrics \& Gynaecology, Psychiatry, Orthopaedics, Anaesthesiology, and Family Medicine
+    \item Extensive trauma and emergency-medicine experience in a high-acuity tertiary setting
 \end{itemize}}}
 
 \vspace{3pt}
 
-% --- Earlier Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+% --- Earlier Roles ---
+\needspace{5\baselineskip}
+\item{\cventry{2017--2021}{Volunteer \& Leadership}{SHAWCO (Students' Health and Welfare Centres Organisation)}{Cape Town, South Africa}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
+    \item Progressed from weekly volunteer to Head of the Khayelitsha Clinic (2018--2019), then Member of the Board of Directors (2020--2021)
+    \item Student-led healthcare serving underprivileged communities across Cape Town
 \end{itemize}}}
 
+\end{itemize}
+
+% ============================================================
+%     SELECTED PROJECTS
+% ============================================================
+
+\section{Selected Projects}
+\vspace{1pt}
+\begin{itemize}
+\item \textbf{RDP5 deep-learning integration}: Trained deep neural networks on 500,000+ simulated viral sequences and deployed them into RDP5 via ONNX, with a modular architecture for seamless model replacement.
+\item \textbf{Self-hosted AI agent}: Anthropic Claude API with LLM routing, persistent memory, and skill automation across multi-platform messaging channels.
+\item \textbf{Proxmox homelab}: Self-hosted virtualisation with ZFS storage, Docker services, reverse proxy, and local LLM inference via Ollama.
 \end{itemize}
 
 % ============================================================
@@ -114,14 +128,23 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-Thesis: ``[Thesis Title].'' [Brief description of research focus.]
+\needspace{5\baselineskip}
+\item{\cventry{2023--2025}{MSc in Medicine -- Bioinformatics (Distinction, 89.0\%)}{University of Cape Town}{}{}{\vspace{1pt}
+Thesis: ``Utilising Machine Learning Techniques on Simulated Viral Evolution Datasets to Improve Viral Recombinant Identification.'' Simulated $\sim$500,000 viral sequences; best model a deep neural network with recurrent pathways. Supervised by Prof. Darren Martin.
 }}
 
 \vspace{3pt}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-[Brief description or key topics.]
+\needspace{5\baselineskip}
+\item{\cventry{2020}{BMedSc (Honours) -- Bioinformatics (Distinction, first class, 85.9\%)}{University of Cape Town}{}{}{\vspace{1pt}
+ML to predict cancer cell line responses to small-molecule inhibitors using the CCLE and GDSC databases.
+}}
+
+\vspace{3pt}
+
+\needspace{5\baselineskip}
+\item{\cventry{2017--2023}{MBChB -- Bachelor of Medicine and Surgery (distinction in clinical sciences, first class honours, 77.5\%)}{University of Cape Town}{}{}{\vspace{1pt}
+Clinical diagnostic reasoning, evidence-based medicine, emergency assessment and triage.
 }}
 
 \end{itemize}
@@ -133,27 +156,18 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Languages}
 \vspace{1pt}
 \begin{itemize}
-\item [Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).
+\item English (native); Afrikaans (basic).
 \end{itemize}
 
 % ============================================================
-%     PUBLICATIONS (optional)
-% ============================================================
-
-\section{Publications}
-\vspace{1pt}
-\begin{itemize}
-\item [Author(s)] ([Year]). [Title]. [Journal/Conference]. \href{[DOI_URL]}{DOI link}
-\end{itemize}
-
-% ============================================================
-%     HONORS AND AWARDS (optional)
+%     HONORS AND AWARDS
 % ============================================================
 
 \section{Honors and Awards}
 \vspace{1pt}
 \begin{itemize}
-\item{\textbf{[Award Name]} -- [Event/Organization] ([Year]).}
+\item{MBChB awarded with \textbf{distinction in the clinical sciences} and \textbf{overall first class honours} (UCT, 2023).}
+\item{\textbf{Class Medal} -- Mathematics 1005 (UCT, 2016); \textbf{UCT Plus Gold} -- 60 hours in an elected leadership role.}
 \end{itemize}
 
 % ============================================================


### PR DESCRIPTION
## Summary
Ran `/setup` (Path A: documents folder + interview) to populate the job-search profile from source materials in `documents/` (CV, LinkedIn export, 3 diplomas, UCT transcript), cross-referenced for consistency.

Merge this to activate the profile — until merged, `master` still shows the placeholder template.

## What changed
- **CLAUDE.md** — full candidate profile, EU/UK work authorization, target sectors, deal-breakers
- **01-candidate-profile.md** — identity, 3 UCT degrees (MSc/BMedSc Hons/MBChB), 4 roles, projects, skills, awards
- **02-behavioral-profile.md** — synthesized from interview + LinkedIn About (inferred items labeled)
- **04-job-evaluation.md** — strong/moderate/weak skill & experience areas, career goals, motivation, deal-breaker
- **05-cv-templates.md** — 3 tailored profile statements (health-AI, ML engineering, clinical)
- **07-interview-prep.md** — 6 STAR candidate stubs (S/T/A/R to be completed manually)
- **cv/main_example.tex** — master reference CV
- **.claude/skills/job-scraper/search-queries.md** — reconfigured for SA / UK / Ireland / EU / remote via LinkedIn + Google (built-in Danish portals don't apply)

## Cross-reference resolution
- MBChB end date reconciled to **2017–2023** (official transcript; LinkedIn's "2022" was an error) per user confirmation.

## Still needs the user
- Confirm items: salary baseline, a clinical referee, Afrikaans level, any peer-reviewed publications, and whether "three years clinical experience" (their CV wording) should stay vs "~2.5 years as a qualified doctor"
- Flesh out S/T/A/R detail on the 6 interview stubs
- `lualatex`/`pdftotext` not installed in this environment — master CV not compile-verified here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXeBRP4kb7fE5esZnZr3hr