### PR TITLE
Add Codex command skills

### DIFF
--- a/.agents/codex-workflows/README.md
+++ b/.agents/codex-workflows/README.md
@@ -1,0 +1,21 @@
+# Codex Workflows
+
+This folder documents how Codex maps onto the existing Claude Code workflow without replacing it.
+
+Use the command-named Codex skills in `.agents/skills/`:
+
+| Claude workflow | Codex entrypoint |
+| --- | --- |
+| `/setup` | `$setup` |
+| `/apply <posting>` | `$apply <posting>` |
+| `/rank` | `$rank` |
+| `/interview` | `$interview` |
+| `/outcome` | `$outcome` |
+| `/expand` | `$expand` |
+| `/reset` | `$reset` |
+| `/add-template` | `$add-template` |
+| `/add-portal` | `$add-portal` |
+| `/scrape` | `$scrape` |
+| `/upskill` | `$upskill` |
+
+The `.claude/commands/*.md` and `.claude/skills/*` files remain the behavioral source of truth. `$setup` is the reliable Codex invocation; in Codex surfaces where skills appear in the slash menu, `/setup` may also be selectable.

--- a/.agents/skills/add-portal/SKILL.md
+++ b/.agents/skills/add-portal/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: add-portal
+description: Generate a job portal search skill for a local market. Use when the user says /add-portal, add portal, add job board, or create a portal search skill.
+---
+
+# add-portal
+
+Read `.claude/commands/add-portal.md` first and follow it exactly.
+
+Investigate the portal before scaffolding. Do not generate parsers from guesses, and do not proceed with auth-walled portals.

--- a/.agents/skills/add-template/SKILL.md
+++ b/.agents/skills/add-template/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: add-template
+description: Register or switch custom LaTeX CV and cover-letter templates. Use when the user says /add-template, add template, list templates, or use a custom CV template.
+---
+
+# add-template
+
+Read `.claude/commands/add-template.md` first and follow it exactly.
+
+Do not activate a template until the source workflow's validation steps pass.

--- a/.agents/skills/apply/SKILL.md
+++ b/.agents/skills/apply/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: apply
+description: Apply to a job posting using the existing drafter-reviewer workflow. Use when the user says /apply, apply to this job, tailor my CV, write a cover letter, or provides a job posting URL/text for an application.
+---
+
+# apply
+
+Read `.claude/commands/apply.md` first and follow it exactly.
+
+Use the pasted job posting or URL as the workflow input. Keep `.claude/commands/apply.md` as the source of truth for evaluation, drafting, reviewer pass, PDF compile/inspection, ATS checks, and final reporting.

--- a/.agents/skills/expand/SKILL.md
+++ b/.agents/skills/expand/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: expand
+description: Expand the candidate profile from documents and public sources. Use when the user says /expand, expand profile, find hidden skills, scan documents for skills, or enrich my profile.
+---
+
+# expand
+
+Read `.claude/commands/expand.md` first and follow it exactly.
+
+This workflow is additive only. Show proposed additions and get confirmation before writing.

--- a/.agents/skills/interview/SKILL.md
+++ b/.agents/skills/interview/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: interview
+description: Prepare for an interview on a tracked application. Use when the user says /interview, interview prep, mock interview, or prepare for an interview.
+---
+
+# interview
+
+Read `.claude/commands/interview.md` first and follow it exactly.
+
+Use tracked application context where available. Keep interview prep consistent with the submitted CV and cover letter.

--- a/.agents/skills/outcome/SKILL.md
+++ b/.agents/skills/outcome/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: outcome
+description: Record application outcomes and interview progress. Use when the user says /outcome, record outcome, log an application result, update application status, or record interview feedback.
+---
+
+# outcome
+
+Read `.claude/commands/outcome.md` first and follow it exactly.
+
+Write outcome data only as that workflow specifies. Do not interpret or recalibrate profile files here.

--- a/.agents/skills/rank/SKILL.md
+++ b/.agents/skills/rank/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: rank
+description: Rank scraped jobs into a shortlist. Use when the user says /rank, rank jobs, shortlist jobs, score scraped jobs, or asks which scraped jobs to apply to first.
+---
+
+# rank
+
+Read `.claude/commands/rank.md` first and follow it exactly.
+
+Use `/rank` semantics from the Claude workflow. Do not apply to jobs directly unless the user chooses one after ranking.

--- a/.agents/skills/reset/SKILL.md
+++ b/.agents/skills/reset/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: reset
+description: Reset candidate profile data or documents. Use when the user says /reset, reset profile, reset documents, start over, or wipe setup data.
+---
+
+# reset
+
+Read `.claude/commands/reset.md` first and follow it exactly.
+
+This workflow is destructive. Show exactly what will be cleared and require the explicit confirmation token from the source workflow before deleting or rewriting anything.

--- a/.agents/skills/scrape/SKILL.md
+++ b/.agents/skills/scrape/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: scrape
+description: Search job portals and deduplicate new postings. Use when the user says /scrape, scrape jobs, find jobs, search jobs, find new jobs, or asks for new openings.
+---
+
+# scrape
+
+Read `.claude/skills/job-scraper/SKILL.md` first and follow it exactly.
+
+Use the existing portal CLI skills under `.agents/skills/*-search/`. Do not guess portal flags; read each portal skill before running its CLI.

--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: setup
+description: Run profile setup/onboarding for this job-search workspace. Use when the user says /setup, setup, run setup, profile setup, onboard, populate profile, import CV, import resume, or read documents.
+---
+
+# setup
+
+Read `.claude/commands/setup.md` first and follow it exactly.
+
+Start at Step 0:
+- inspect `documents/`
+- count files in `cv/`, `linkedin/`, `diplomas/`, `references/`, and `applications/`
+- offer Path A/B/C from the setup workflow
+
+Do not search jobs, scrape portals, rank jobs, read `.claude/skills/job-scraper/SKILL.md`, or invoke any scraper skill before setup completes. Only mention job search after the setup workflow reaches its next-steps section.

--- a/.agents/skills/upskill/SKILL.md
+++ b/.agents/skills/upskill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: upskill
+description: Analyze skill gaps and create a learning plan. Use when the user says /upskill, upskill, skill gaps, what should I learn, or learning plan.
+---
+
+# upskill
+
+Read `.claude/skills/upskill/SKILL.md` first and follow it exactly.
+
+Never invent courses, resources, URLs, or authors. Use current-year searches for learning resources when the workflow asks for web research.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install pyyaml
       - run: python tools/lint_skills.py
 
   latex-smoke:

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ Thumbs.db
 .vscode/
 .idea/
 
+# Codex local project instructions
+AGENTS.md
+
 # Memory files (Claude Code user-specific)
 .claude/projects/
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/MadsLorentzen/ai-job-search/actions/workflows/ci.yml/badge.svg)](https://github.com/MadsLorentzen/ai-job-search/actions/workflows/ci.yml)
 
-An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
+An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code), with additive [Codex](https://openai.com/codex/) compatibility. Fork it, fill in your profile, and let your agent evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
 > Note: This is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic. Anthropic and Claude Code are referenced only to describe the toolchain this workflow uses.
 
@@ -18,7 +18,7 @@ An AI-powered job application framework built on [Claude Code](https://claude.co
 
 ## What this is
 
-A structured workflow that turns Claude Code into a full-stack job application assistant. The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
+A structured workflow that turns Claude Code or Codex into a full-stack job application assistant. The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
 
 ```
 /setup          /scrape              /apply <url>
@@ -40,7 +40,7 @@ The framework encodes career guidance best practices, including structured evalu
 
 ## Prerequisites
 
-- [Claude Code](https://claude.com/claude-code) (CLI)
+- [Claude Code](https://claude.com/claude-code) (CLI) or [Codex](https://openai.com/codex/)
 - Python 3.10+
 - [Bun](https://bun.sh) (for Danish job search CLI tools)
 - LaTeX distribution with `lualatex` and `xelatex`: [TeX Live](https://tug.org/texlive/), [MacTeX](https://tug.org/mactex/), [TinyTeX](https://yihui.org/tinytex/), or [MiKTeX](https://miktex.org/). The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors); the cover letter compiles with `xelatex` because `cover.cls` requires `fontspec`. If using a minimal TeX install such as TinyTeX or BasicTeX, install the extra packages listed in [SETUP.md](SETUP.md#minimal-tex-install-tinytexbasictex).
@@ -82,19 +82,31 @@ For `linkedin-search` the install is optional: it has zero runtime dependencies 
 
 ### 3. Set up your profile
 
+Claude Code:
+
 ```bash
 claude
 # Then inside Claude Code:
 /setup
 ```
 
-`/setup` offers three paths: read your `documents/` folder if you have one populated (CV PDF, LinkedIn export, diplomas, reference letters, past applications), import a single CV pasted in chat, or walk through an interview. It auto-detects what you have and asks. Documents-folder mode is idempotent and safe to re-run as you add more material; see `documents/README.md` for the layout.
+Codex:
+
+```bash
+codex
+# Then ask Codex:
+$setup
+```
+
+`/setup` offers three paths: read your `documents/` folder if you have one populated (CV PDF, LinkedIn export, diplomas, reference letters, past applications), import a single CV pasted in chat, or walk through an interview. It auto-detects what you have and asks. Documents-folder mode is idempotent and safe to re-run as you add more material; see `documents/README.md` for the layout. In Codex surfaces where skills appear in the slash menu, `/setup` may also be selectable; `$setup` is the reliable invocation.
 
 ### 4. Search for jobs
 
 ```bash
 /scrape
 ```
+
+With Codex, ask: `$scrape`.
 
 This searches multiple job portals for positions matching your profile, deduplicates results, and presents them sorted by fit. Pick a match to run `/apply` on it directly — or, when a scrape returns more jobs than you want to eyeball, run `/rank` to batch-score them all against the fit framework and get a ranked shortlist first.
 
@@ -103,6 +115,8 @@ This searches multiple job portals for positions matching your profile, deduplic
 ```bash
 /apply https://jobindex.dk/job/1234567
 ```
+
+With Codex, ask: `$apply https://jobindex.dk/job/1234567`.
 
 If the URL can't be fetched (some job portals block automated access), you can paste the job description directly instead:
 
@@ -114,7 +128,7 @@ This runs the full workflow: evaluate fit, draft CV + cover letter, review with 
 
 ## Other commands
 
-`/setup`, `/scrape`, and `/apply` form the core workflow. Seven more commands extend it once your profile is in place:
+`/setup`, `/scrape`, and `/apply` form the core workflow. Seven more commands extend it once your profile is in place. With Codex, use the matching command-named skill such as `$interview`, `$outcome`, `$rank`, `$expand`, `$upskill`, `$add-template`, `$add-portal`, or `$reset`.
 
 - **`/interview`** preps you for a scheduled interview on a tracked application. It builds a stage-specific prep pack from the application's archive (the exact posting, the CV and cover letter the interviewer actually read, feedback recorded from earlier rounds), researches the company and interviewers with a verify-before-use rule, maps likely questions to your STAR examples, and offers a mock interview following the roleplay protocol in `07-interview-prep.md`. Gaps get honest bridge answers, never invented experience.
 - **`/outcome`** records what happened to an application - interview stages, offers, rejections, silence. It archives the submitted CV, cover letter, and posting text into `documents/applications/<company>_<role>/`, keeps `outcome.md` in the format `/setup` Path A parses, and updates the tracker. Once a few applications resolve, it points you back to `/setup` to calibrate the fit framework from what actually got interviews.
@@ -155,12 +169,25 @@ ai-job-search/
 │   │   ├── job-scraper/               # Job search orchestration
 │   │   └── upskill/                   # /upskill skill gap analysis and learning plan
 │   └── settings.json                  # Claude Code permissions (shared, scoped)
-├── .agents/skills/                    # Job portal CLI tools
-│   ├── jobbank-search/                # Akademikernes Jobbank (Denmark)
-│   ├── jobdanmark-search/             # Jobdanmark.dk (Denmark)
-│   ├── jobindex-search/               # Jobindex.dk (Denmark)
-│   ├── jobnet-search/                 # Jobnet.dk (Denmark, government portal)
-│   └── linkedin-search/               # LinkedIn public job listings (country-agnostic)
+├── .agents/
+│   ├── codex-workflows/               # Codex-to-Claude workflow mapping reference
+│   └── skills/                        # Codex command skills and job portal CLI tools
+│       ├── setup/                     # Codex $setup wrapper for .claude/commands/setup.md
+│       ├── apply/                     # Codex $apply wrapper for .claude/commands/apply.md
+│       ├── scrape/                    # Codex $scrape wrapper for .claude/skills/job-scraper
+│       ├── rank/                      # Codex $rank wrapper for .claude/commands/rank.md
+│       ├── interview/                 # Codex $interview wrapper for .claude/commands/interview.md
+│       ├── outcome/                   # Codex $outcome wrapper for .claude/commands/outcome.md
+│       ├── expand/                    # Codex $expand wrapper for .claude/commands/expand.md
+│       ├── upskill/                   # Codex $upskill wrapper for .claude/skills/upskill
+│       ├── reset/                     # Codex $reset wrapper for .claude/commands/reset.md
+│       ├── add-template/              # Codex $add-template wrapper
+│       ├── add-portal/                # Codex $add-portal wrapper
+│       ├── jobbank-search/            # Akademikernes Jobbank (Denmark)
+│       ├── jobdanmark-search/         # Jobdanmark.dk (Denmark)
+│       ├── jobindex-search/           # Jobindex.dk (Denmark)
+│       ├── jobnet-search/             # Jobnet.dk (Denmark, government portal)
+│       └── linkedin-search/           # LinkedIn public job listings (country-agnostic)
 ├── cv/
 │   └── main_example.tex               # moderncv LaTeX template
 ├── cover_letters/
@@ -197,7 +224,7 @@ The `/apply` command runs a **drafter-reviewer workflow** with mandatory PDF com
 3. **Draft** a tailored CV and cover letter in LaTeX
 4. **Spawn a reviewer agent** that researches the company and critiques the drafts
 5. **Revise** based on the reviewer's feedback
-6. **Compile and inspect** both PDFs: lualatex for the CV, xelatex for the cover letter. Claude reads the rendered pages and iterates on the LaTeX until the CV is exactly 2 pages with no orphaned entry titles, and the cover letter is exactly 1 page with the signature visible and fonts consistent.
+6. **Compile and inspect** both PDFs: lualatex for the CV, xelatex for the cover letter. The agent reads the rendered pages and iterates on the LaTeX until the CV is exactly 2 pages with no orphaned entry titles, and the cover letter is exactly 1 page with the signature visible and fonts consistent.
 7. **ATS-check the CV**: extract the PDF's text layer (`pdftotext`, optional dependency) and verify it the way an ATS parser sees it — contact details present as literal text, no garbled glyphs, sane reading order — then score the posting's keyword coverage against the extraction. Keywords the profile genuinely supports get added; genuine gaps stay visible, never stuffed.
 8. **Present** the final output with a verification checklist
 
@@ -208,10 +235,30 @@ All claims in the CV and cover letter are verified against your actual profile. 
 - **PDF verification loop.** Most LaTeX-resume templates produce "looks fine in the .tex" output that breaks in the PDF: job titles orphan to the next page, cover letters spill onto page 2, bullet fonts silently fall back to the body font. The `/apply` command compiles and visually inspects every PDF and applies targeted fixes (`\needspace`, `\enlargethispage`, font-matching wrappers for list items) until the layout is clean. This runs automatically on every application.
 - **ATS verification on the PDF text layer.** An ATS reads the PDF's embedded text, not the rendered page — and LaTeX can silently produce PDFs whose text extracts as garbage (icon glyphs where the email should be, interleaved lines from multi-column layouts). `/apply` extracts the compiled CV's text layer with `pdftotext` and verifies contact details, reading order, and the posting's keyword coverage against what a parser actually sees. Honesty rule enforced: a keyword the profile doesn't support is acknowledged as a gap, never stuffed in.
 - **Relevance-weighted CV cutting.** When a CV overflows 2 pages, the workflow does not cut mechanically from the "oldest" section. It scores each candidate line by (a) relevance to the target posting, (b) uniqueness in the document, and (c) whether the cover letter depends on it, and cuts the lowest-total-score line first. An older-role bullet that hits posting keywords survives ahead of a recent-role bullet that does not.
-- **Drafter-reviewer separation.** The drafter writes; a second Claude agent, spawned with a fresh context, researches the company and critiques the drafts. The drafter then revises. This catches missed keywords, weak framing, and generic language that a single pass often leaves in.
+- **Drafter-reviewer separation.** The drafter writes; a second reviewer pass researches the company and critiques the drafts. The drafter then revises. This catches missed keywords, weak framing, and generic language that a single pass often leaves in.
 - **Token-efficient reviewer dispatch.** The reviewer agent receives drafts inline rather than re-reading them, and the verification checklist runs once at the end of the workflow rather than being duplicated by both agents. Note: the new compile-and-inspect step in Step 5 spends some of those savings on PDF rendering and layout iteration — the workflow trades some end-to-end token cost for a real reduction in broken PDFs reaching the user.
 
 ## Customization
+
+### Using with Codex
+
+Codex support is additive. The Claude workflow files remain the source of truth, and Codex uses command-named skills to translate those instructions:
+
+```text
+$setup
+$scrape
+$apply <job posting URL or pasted text>
+$rank
+$interview
+$outcome
+$expand
+$upskill
+$reset
+$add-template
+$add-portal
+```
+
+These command-named skills point Codex at the existing `.claude/commands/` and `.claude/skills/` files so Claude Code users keep the same commands. In Codex surfaces where skills appear in the slash menu, `/setup`, `/apply`, and similar entries may also be selectable; `$setup` and the other `$` skill names are the portable form.
 
 ### Which files to edit manually
 
@@ -235,6 +282,12 @@ As your priorities evolve, you can reconfigure just the job search without re-ru
 /setup --section search
 ```
 
+Codex:
+
+```text
+$setup --section search
+```
+
 This re-runs the search configuration interview: which roles to target, which skills to search for, which locations, and which portals. It also suggests role types you may not have considered based on your profile.
 
 ### LaTeX templates
@@ -245,6 +298,12 @@ To use your own template instead, run:
 
 ```
 /add-template
+```
+
+Codex:
+
+```text
+$add-template
 ```
 
 Point it at your `.tex` file (plus any `.cls`/`.sty` files or bundled fonts). The command interviews you for the template's instructions — compile engine, fonts and where they live, style rules to preserve, hard page limit — stores everything under `templates/`, runs a mandatory test compile, and activates the template so `/apply` drafts from it. Templates are stored with `[PLACEHOLDER]` tokens instead of personal data, so they're safe to commit and share.
@@ -263,6 +322,12 @@ The four Danish CLI tools in `.agents/skills/` (Jobbank, Jobdanmark, Jobindex, J
 /add-portal
 ```
 
+Codex:
+
+```text
+$add-portal
+```
+
 Give it your local job board's URL. The command investigates the portal (search-URL pattern, result-page structure, robots.txt/access rules), scaffolds a CLI skill with the same structure, commands, and output contract as the shipped ones, and test-runs a live query before registering anything. Auth-walled portals are declined, and portals with restrictive terms get a prominent personal-use-only warning in the generated skill. The generated skill is market-specific and lives in your fork; the generator itself is the universal part.
 
 For a **country-agnostic** starting point, the repo also includes **`linkedin-search`** — a job-search skill built on LinkedIn's public, unauthenticated `jobs-guest` endpoints. It is field-agnostic, has **zero runtime dependencies** (runs with just `bun`), and takes the search location as an explicit flag, so it works for any market out of the box (`-l "Berlin, Germany"`, `-l "Mumbai, Maharashtra, India"`, `-l "Remote"`, …). It is intended for **personal use only** — automated access is against LinkedIn's Terms of Service, so keep volume low. See `.agents/skills/linkedin-search/SKILL.md`.
@@ -279,6 +344,12 @@ To wipe your profile data and start fresh:
 /reset profile    # clears skill files, preserves framework rules
 /reset documents  # deletes files from documents/ folder
 /reset all        # both
+```
+
+Codex uses the same arguments with `$reset`, for example:
+
+```text
+$reset profile
 ```
 
 `/reset` shows exactly what will be deleted and requires you to type `RESET` to confirm. Nothing is deleted until you do.

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,7 +4,7 @@ Step-by-step instructions for getting the AI Job Search framework running.
 
 ## 1. Prerequisites
 
-### Claude Code
+### Claude Code or Codex
 
 Install Claude Code (Anthropic's CLI for Claude):
 
@@ -13,6 +13,8 @@ npm install -g @anthropic-ai/claude-code
 ```
 
 You'll need an Anthropic API key or a Claude Pro/Team subscription. See the [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) for details.
+
+Or use Codex. This repo includes command-named Codex skills under `.agents/skills/`, while keeping the Claude workflow intact.
 
 ### Python
 
@@ -139,7 +141,7 @@ done
 
 For `linkedin-search` the install is optional: it has zero runtime dependencies and runs with plain `bun`; `bun install` only pulls TypeScript dev types.
 
-If you're outside Denmark, you can generate an equivalent search skill for your local job board with `/add-portal` — it scaffolds the same CLI structure for any public portal and test-runs a live query before registering. See the "Job search tools" section in the README.
+If you're outside Denmark, you can generate an equivalent search skill for your local job board with `/add-portal` in Claude Code or `$add-portal` in Codex. It scaffolds the same CLI structure for any public portal and test-runs a live query before registering. See the "Job search tools" section in the README.
 
 ## 4. Run the setup interview
 
@@ -163,6 +165,20 @@ Claude will offer three paths:
 
 All three paths produce the same result: fully populated profile files.
 
+With Codex, start Codex in the repository instead:
+
+```bash
+codex
+```
+
+Then ask:
+
+```text
+$setup
+```
+
+The Codex setup skill points Codex at the same `.claude/commands/setup.md` workflow. In Codex surfaces where skills appear in the slash menu, `/setup` may also be selectable; `$setup` is the reliable invocation.
+
 ### What gets populated
 
 | File | Content |
@@ -184,6 +200,12 @@ You can update specific sections later:
 /setup --section skills
 /setup --section experience
 /setup --section search
+```
+
+With Codex, use the same arguments with `$setup`:
+
+```text
+$setup --section search
 ```
 
 The `--section search` option is especially useful as your priorities evolve. It re-runs the search configuration interview and suggests role types you may not have considered based on your full profile.
@@ -222,6 +244,20 @@ Claude will:
 4. Have a reviewer agent critique the drafts
 5. Revise and present the final output
 
+With Codex, ask:
+
+```text
+$apply https://jobindex.dk/job/1234567
+```
+
+For job search, ask:
+
+```text
+$scrape
+```
+
+Other Claude commands map to the same Codex skill names: `$rank`, `$interview`, `$outcome`, `$expand`, `$upskill`, `$reset`, `$add-template`, and `$add-portal`.
+
 ## 7. Compile your documents
 
 After `/apply` creates the LaTeX files:
@@ -238,7 +274,7 @@ Set-Location cv; lualatex main_<company>.tex; Set-Location ..
 Set-Location cover_letters; xelatex cover_<company>_<role>.tex; Set-Location ..
 ```
 
-These commands apply to the stock templates (moderncv CV, `cover.cls` cover letter). If you'd rather use your own LaTeX template, run `/add-template` — it captures the template's compile engine, fonts, style rules, and page limit, test-compiles it, and wires it into `/apply`. See the "LaTeX templates" section in the README.
+These commands apply to the stock templates (moderncv CV, `cover.cls` cover letter). If you'd rather use your own LaTeX template, run `/add-template` in Claude Code or `$add-template` in Codex. It captures the template's compile engine, fonts, style rules, and page limit, test-compiles it, and wires it into `/apply`. See the "LaTeX templates" section in the README.
 
 ## Troubleshooting
 

--- a/documents/README.md
+++ b/documents/README.md
@@ -1,6 +1,6 @@
 # Documents Folder
 
-This folder holds your actual career documents. The `/setup` command reads everything here and uses it to populate the candidate skill files under `.claude/skills/job-application-assistant/`. It is safe to re-run `/setup` as you add new documents — it merges intelligently and will never overwrite existing content without asking you first.
+This folder holds your actual career documents. The `/setup` command reads everything here and uses it to populate the candidate skill files under `.claude/skills/job-application-assistant/`. With Codex, ask `$setup`; it uses the same source folder and workflow. It is safe to re-run setup as you add new documents — it merges intelligently and will never overwrite existing content without asking you first.
 
 ---
 

--- a/tools/lint_skills.py
+++ b/tools/lint_skills.py
@@ -14,15 +14,10 @@ Checks:
 Exit code 0 on success, 1 with a failure list otherwise.
 """
 
-import json
 import re
+import json
 import sys
 from pathlib import Path
-
-try:
-    import yaml
-except ImportError:
-    sys.exit("lint_skills.py requires PyYAML: pip install pyyaml")
 
 ROOT = Path(__file__).resolve().parent.parent
 errors: list[str] = []
@@ -30,6 +25,25 @@ errors: list[str] = []
 
 def rel(path: Path) -> str:
     return str(path.relative_to(ROOT))
+
+
+def parse_frontmatter(text: str, path: Path) -> dict[str, str]:
+    data: dict[str, str] = {}
+    current_key: str | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            continue
+        if line.startswith((" ", "\t")) and current_key:
+            data[current_key] = f"{data[current_key]}\n{line.strip()}"
+            continue
+        if ":" not in line:
+            errors.append(f"{rel(path)}: frontmatter line is not key: value syntax: {line[:50]!r}")
+            continue
+        key, value = line.split(":", 1)
+        current_key = key.strip()
+        data[current_key] = value.strip().strip("'\"")
+    return data
 
 
 def check_skill(path: Path) -> None:
@@ -41,14 +55,7 @@ def check_skill(path: Path) -> None:
     if end == -1:
         errors.append(f"{rel(path)}: unterminated YAML frontmatter")
         return
-    try:
-        data = yaml.safe_load(text[4:end])
-    except yaml.YAMLError as exc:
-        errors.append(f"{rel(path)}: frontmatter is not valid YAML: {exc}")
-        return
-    if not isinstance(data, dict):
-        errors.append(f"{rel(path)}: frontmatter did not parse to a mapping")
-        return
+    data = parse_frontmatter(text[4:end], path)
     for key in ("name", "description"):
         if not data.get(key):
             errors.append(f"{rel(path)}: frontmatter missing required key '{key}'")


### PR DESCRIPTION
## Summary

Adds Codex-compatible command skills that mirror the existing Claude command names while keeping the Claude workflows as the source of truth.

This lets Codex users invoke simple command-named skills like `$setup`, `$apply`, `$scrape`, `$rank`, and `$interview` instead of using longer Codex-specific wrapper names. Claude compatibility remains unchanged.

## Changes

- Added thin Codex skill wrappers under `.agents/skills/` for the core workflow commands:
  - `setup`
  - `apply`
  - `scrape`
  - `rank`
  - `interview`
  - `outcome`
  - `expand`
  - `upskill`
  - `reset`
  - `add-template`
  - `add-portal`
- Kept existing `.claude/commands/*` and `.claude/skills/*` files as the canonical workflow definitions.
- Added setup guardrails so `$setup` starts profile onboarding from `.claude/commands/setup.md` Step 0 and does not search jobs before setup is complete.
- Added Codex workflow documentation in `.agents/codex-workflows/README.md`.
- Updated `README.md`, `SETUP.md`, and `documents/README.md` with Codex invocation examples.
- Updated skill linting to avoid requiring `PyYAML`.
- Updated CI to remove the now-unneeded `pip install pyyaml` step.
- Added `AGENTS.md` to `.gitignore` so local Codex/project-agent instructions are not committed.
- Kept personal document folders ignored; only `documents/README.md` and `.gitkeep` placeholders are tracked.
