### PR TITLE
docs: mention /interview as next step after /apply (#108)

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -281,4 +281,6 @@ List the files written:
 
 Tell the user: "Both files are ready for your review. Open them to check the final output before compiling."
 
-Also mention: once they have actually submitted the application, `/outcome <company>` logs it in the tracker and starts the per-application record that `/setup` later uses to calibrate the fit framework.
+### Next Steps
+- **Submitted?** `/outcome <company>` logs it in the tracker and starts the per-application record that `/setup` later uses to calibrate the fit framework.
+- **Interview scheduled?** `/interview` builds a stage-specific prep pack from this posting and the documents you just created.


### PR DESCRIPTION
Adds a "Next Steps" block at the end of `/apply` Step 6 pointing users to `/outcome` to log a submission and `/interview` to start interview prep — so users discover the full workflow without reading the README.

Closes #108