### PR TITLE
docs: document complete seen_jobs.json schema including rank fields (#107)

### DIFF
--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -76,6 +76,9 @@ For each new job, do a rapid fit check (NOT the full evaluation from `04-job-eva
   }
 }
 ```
+
+`/rank` extends this schema additively: ranked entries also carry `rank_score` (0–100 overall score), `rank_verdict` (fit band, e.g. "strong fit"), and `rank_date` (ISO date of ranking). The `status` field is set to `"ranked"`. Do not drop these fields when re-writing entries.
+
 2. Only present jobs NOT already in the seen list or tracker.
 
 ### Step 5: Present Results


### PR DESCRIPTION
Adds a note immediately after the scraper's Step 4 schema block documenting the three fields that `/rank` writes additively — `rank_score`, `rank_verdict`, and `rank_date` — and the updated `status` value `"ranked"`, so any command reading `seen_jobs.json` from the scraper's documentation gets the complete picture.

Closes #107