### PR TITLE
docs(apply): surface /interview in Step 6 Fixes #108

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -282,3 +282,8 @@ List the files written:
 Tell the user: "Both files are ready for your review. Open them to check the final output before compiling."
 
 Also mention: once they have actually submitted the application, `/outcome <company>` logs it in the tracker and starts the per-application record that `/setup` later uses to calibrate the fit framework.
+
+### Next Steps
+
+- **Submitted?** Run `/outcome <company>` to log it in the tracker and start the per-application record that `/setup` later uses to calibrate the fit framework.
+- **Interview scheduled?** Run `/interview <company>` for a stage-specific prep pack built from this posting and the documents you just submitted.


### PR DESCRIPTION
Fixes #108

/apply Step 6 mentioned /outcome as a single buried sentence and never referenced /interview, even though the natural flow is /apply → submit → /outcome → /interview. This splits the existing "Also mention" line into two parallel bullets, phrased to match the conditional /interview suggestion outcome.md already makes in its own Step 6.
