### PR TITLE
Add Codex workflow support without changing the existing Claude workflow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ venv/
 *.fdb_latexmk
 
 # Personal data (never commit these)
-.local/
+my/
 salary_data.json
 job_scraper/seen_jobs.json
 job_scraper/*.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv/
 *.fdb_latexmk
 
 # Personal data (never commit these)
+.local/
 salary_data.json
 job_scraper/seen_jobs.json
 job_scraper/*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ below as the project-local entry point.
   profile and personalization layer. It is intentionally ignored by git.
 - Treat `CLAUDE.md` as the public/template high-level workflow guide when no
   `my/profile/CLAUDE.md` override exists.
+- Treat `codex/commands/*.md` as Codex-facing workflow entry points. These are
+  project command specs, not a native Codex slash-command runtime.
 - Treat `.claude/commands/*.md` and `.claude/skills/*` as reusable workflow
   specifications, even though their names and tool references are Claude-specific.
 - Do not delete or rewrite `.claude/` just to make the repo Codex-friendly; the
@@ -54,25 +56,29 @@ For job postings, applications, CVs, cover letters, and interview prep:
 7. Compile and inspect LaTeX outputs as required by `CLAUDE.md` before presenting
    CV or cover-letter results.
 
-## Claude Slash Command Equivalents
+## Codex Command Equivalents
 
 Codex does not receive Claude slash commands automatically. If the user invokes one
-or asks for the same outcome in natural language, read the matching file and follow
-it as a procedure:
+or asks for the same outcome in natural language, prefer the matching
+`codex/commands/*.md` wrapper. Each wrapper points to the detailed Claude workflow
+spec or skill to execute under Codex tool translation.
 
-| User intent | Claude spec to read |
+| User intent | Codex wrapper to read |
 | --- | --- |
-| Set up or refresh profile | `.claude/commands/setup.md` |
-| Search/scrape jobs | `.claude/skills/job-scraper/SKILL.md` |
-| Apply to a posting | `.claude/commands/apply.md` |
-| Rank scraped jobs | `.claude/commands/rank.md` |
-| Interview preparation | `.claude/commands/interview.md` |
-| Record application outcome | `.claude/commands/outcome.md` |
-| Expand profile from public/source materials | `.claude/commands/expand.md` |
-| Build an upskilling plan | `.claude/skills/upskill/SKILL.md` |
-| Add a LaTeX template | `.claude/commands/add-template.md` |
-| Add a job portal skill | `.claude/commands/add-portal.md` |
-| Reset profile/documents | `.claude/commands/reset.md` |
+| Set up or refresh profile | `codex/commands/setup.md` |
+| Search/scrape jobs | `codex/commands/search.md` |
+| Apply to a posting | `codex/commands/apply.md` |
+| Rank scraped jobs | `codex/commands/rank.md` |
+| Interview preparation | `codex/commands/interview.md` |
+| Record application outcome | `codex/commands/outcome.md` |
+| Expand profile from public/source materials | `codex/commands/expand.md` |
+| Build an upskilling plan | `codex/commands/upskill.md` |
+| Add a LaTeX template | `codex/commands/add-template.md` |
+| Add a job portal skill | `codex/commands/add-portal.md` |
+| Reset profile/documents | `codex/commands/reset.md` |
+
+If a Codex wrapper is missing or stale, fall back to the corresponding
+`.claude/commands/*.md` or `.claude/skills/*` file directly.
 
 ## Job Search Portal Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ below as the project-local entry point.
 ## Priority
 
 - Follow this `AGENTS.md` first for Codex behavior.
-- Treat `CLAUDE.md` as the canonical candidate profile and high-level workflow
-  guide.
+- If `.local/profile/` exists, treat it as the canonical private candidate
+  profile and personalization layer. It is intentionally ignored by git.
+- Treat `CLAUDE.md` as the public/template high-level workflow guide when no
+  `.local/profile/CLAUDE.md` override exists.
 - Treat `.claude/commands/*.md` and `.claude/skills/*` as reusable workflow
   specifications, even though their names and tool references are Claude-specific.
 - Do not delete or rewrite `.claude/` just to make the repo Codex-friendly; the
@@ -32,16 +34,17 @@ When a Claude instruction names a Claude Code tool, use the Codex equivalent:
 
 For job postings, applications, CVs, cover letters, and interview prep:
 
-1. Read `CLAUDE.md`.
+1. Read `.local/profile/CLAUDE.md` if present; otherwise read `CLAUDE.md`.
 2. Read `.claude/skills/job-application-assistant/SKILL.md`.
-3. Read only the referenced files needed for the requested step:
-   - profile facts: `.claude/skills/job-application-assistant/01-candidate-profile.md`
-   - behavior/culture fit: `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+3. For each referenced profile/personalization file, prefer the private
+   `.local/profile/...` version if present; otherwise use the tracked template:
+   - profile facts: `.local/profile/job-application-assistant/01-candidate-profile.md` or `.claude/skills/job-application-assistant/01-candidate-profile.md`
+   - behavior/culture fit: `.local/profile/job-application-assistant/02-behavioral-profile.md` or `.claude/skills/job-application-assistant/02-behavioral-profile.md`
    - writing rules: `.claude/skills/job-application-assistant/03-writing-style.md`
-   - fit scoring: `.claude/skills/job-application-assistant/04-job-evaluation.md`
-   - CV rules: `.claude/skills/job-application-assistant/05-cv-templates.md`
+   - fit scoring: `.local/profile/job-application-assistant/04-job-evaluation.md` or `.claude/skills/job-application-assistant/04-job-evaluation.md`
+   - CV rules: `.local/profile/job-application-assistant/05-cv-templates.md` or `.claude/skills/job-application-assistant/05-cv-templates.md`
    - cover letter rules: `.claude/skills/job-application-assistant/06-cover-letter-templates.md`
-   - interview prep: `.claude/skills/job-application-assistant/07-interview-prep.md`
+   - interview prep: `.local/profile/job-application-assistant/07-interview-prep.md` or `.claude/skills/job-application-assistant/07-interview-prep.md`
 4. Always evaluate fit before drafting application materials unless the user
    explicitly asks for only a narrow artifact.
 5. Never fabricate candidate experience, employer facts, salary data, job
@@ -77,6 +80,9 @@ The installed portal CLIs live under `.agents/skills/`. Before running one, read
 that portal's `SKILL.md` and use its documented flags. Prefer the CLI output over
 free-form web search when the portal skill exists. Keep searches low-volume and
 respect each skill's personal-use or terms-of-service notes.
+
+For search strategy, prefer `.local/profile/job-scraper/search-queries.md` if it
+exists; otherwise use `.claude/skills/job-scraper/search-queries.md`.
 
 ## Repository Hygiene
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,10 @@ below as the project-local entry point.
 ## Priority
 
 - Follow this `AGENTS.md` first for Codex behavior.
-- If `.local/profile/` exists, treat it as the canonical private candidate
+- If `my/profile/` exists, treat it as the canonical private candidate
   profile and personalization layer. It is intentionally ignored by git.
 - Treat `CLAUDE.md` as the public/template high-level workflow guide when no
-  `.local/profile/CLAUDE.md` override exists.
+  `my/profile/CLAUDE.md` override exists.
 - Treat `.claude/commands/*.md` and `.claude/skills/*` as reusable workflow
   specifications, even though their names and tool references are Claude-specific.
 - Do not delete or rewrite `.claude/` just to make the repo Codex-friendly; the
@@ -34,17 +34,17 @@ When a Claude instruction names a Claude Code tool, use the Codex equivalent:
 
 For job postings, applications, CVs, cover letters, and interview prep:
 
-1. Read `.local/profile/CLAUDE.md` if present; otherwise read `CLAUDE.md`.
+1. Read `my/profile/CLAUDE.md` if present; otherwise read `CLAUDE.md`.
 2. Read `.claude/skills/job-application-assistant/SKILL.md`.
 3. For each referenced profile/personalization file, prefer the private
-   `.local/profile/...` version if present; otherwise use the tracked template:
-   - profile facts: `.local/profile/job-application-assistant/01-candidate-profile.md` or `.claude/skills/job-application-assistant/01-candidate-profile.md`
-   - behavior/culture fit: `.local/profile/job-application-assistant/02-behavioral-profile.md` or `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+   `my/profile/...` version if present; otherwise use the tracked template:
+   - profile facts: `my/profile/job-application-assistant/01-candidate-profile.md` or `.claude/skills/job-application-assistant/01-candidate-profile.md`
+   - behavior/culture fit: `my/profile/job-application-assistant/02-behavioral-profile.md` or `.claude/skills/job-application-assistant/02-behavioral-profile.md`
    - writing rules: `.claude/skills/job-application-assistant/03-writing-style.md`
-   - fit scoring: `.local/profile/job-application-assistant/04-job-evaluation.md` or `.claude/skills/job-application-assistant/04-job-evaluation.md`
-   - CV rules: `.local/profile/job-application-assistant/05-cv-templates.md` or `.claude/skills/job-application-assistant/05-cv-templates.md`
+   - fit scoring: `my/profile/job-application-assistant/04-job-evaluation.md` or `.claude/skills/job-application-assistant/04-job-evaluation.md`
+   - CV rules: `my/profile/job-application-assistant/05-cv-templates.md` or `.claude/skills/job-application-assistant/05-cv-templates.md`
    - cover letter rules: `.claude/skills/job-application-assistant/06-cover-letter-templates.md`
-   - interview prep: `.local/profile/job-application-assistant/07-interview-prep.md` or `.claude/skills/job-application-assistant/07-interview-prep.md`
+   - interview prep: `my/profile/job-application-assistant/07-interview-prep.md` or `.claude/skills/job-application-assistant/07-interview-prep.md`
 4. Always evaluate fit before drafting application materials unless the user
    explicitly asks for only a narrow artifact.
 5. Never fabricate candidate experience, employer facts, salary data, job
@@ -81,7 +81,7 @@ that portal's `SKILL.md` and use its documented flags. Prefer the CLI output ove
 free-form web search when the portal skill exists. Keep searches low-volume and
 respect each skill's personal-use or terms-of-service notes.
 
-For search strategy, prefer `.local/profile/job-scraper/search-queries.md` if it
+For search strategy, prefer `my/profile/job-scraper/search-queries.md` if it
 exists; otherwise use `.claude/skills/job-scraper/search-queries.md`.
 
 ## Repository Hygiene

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# Agent Guidance
+
+This repository is a job-application workspace that was originally built for Claude
+Code. Codex should preserve the Claude-compatible files while using the guidance
+below as the project-local entry point.
+
+## Priority
+
+- Follow this `AGENTS.md` first for Codex behavior.
+- Treat `CLAUDE.md` as the canonical candidate profile and high-level workflow
+  guide.
+- Treat `.claude/commands/*.md` and `.claude/skills/*` as reusable workflow
+  specifications, even though their names and tool references are Claude-specific.
+- Do not delete or rewrite `.claude/` just to make the repo Codex-friendly; the
+  fork should remain usable from Claude Code.
+
+## Tool Translation
+
+When a Claude instruction names a Claude Code tool, use the Codex equivalent:
+
+- `Read`, `Glob`, `Grep` -> shell reads, `rg`, `find`, and normal file inspection.
+- `Edit`, `Write` -> `apply_patch` for manual edits.
+- `Bash(...)` -> shell commands, respecting Codex sandbox and approval rules.
+- `WebFetch`, `WebSearch` -> web browsing/search when current external facts or
+  source verification are needed.
+- `Agent` -> use available multi-agent tooling if present; otherwise do the work
+  inline and keep the same separation of concerns.
+- `AskUserQuestion` -> ask a concise direct question only when local context cannot
+  resolve the decision safely.
+
+## Job Application Workflow
+
+For job postings, applications, CVs, cover letters, and interview prep:
+
+1. Read `CLAUDE.md`.
+2. Read `.claude/skills/job-application-assistant/SKILL.md`.
+3. Read only the referenced files needed for the requested step:
+   - profile facts: `.claude/skills/job-application-assistant/01-candidate-profile.md`
+   - behavior/culture fit: `.claude/skills/job-application-assistant/02-behavioral-profile.md`
+   - writing rules: `.claude/skills/job-application-assistant/03-writing-style.md`
+   - fit scoring: `.claude/skills/job-application-assistant/04-job-evaluation.md`
+   - CV rules: `.claude/skills/job-application-assistant/05-cv-templates.md`
+   - cover letter rules: `.claude/skills/job-application-assistant/06-cover-letter-templates.md`
+   - interview prep: `.claude/skills/job-application-assistant/07-interview-prep.md`
+4. Always evaluate fit before drafting application materials unless the user
+   explicitly asks for only a narrow artifact.
+5. Never fabricate candidate experience, employer facts, salary data, job
+   requirements, or application outcomes.
+6. Verify company-specific claims with current external sources before using them
+   in a CV, cover letter, or interview prep pack.
+7. Compile and inspect LaTeX outputs as required by `CLAUDE.md` before presenting
+   CV or cover-letter results.
+
+## Claude Slash Command Equivalents
+
+Codex does not receive Claude slash commands automatically. If the user invokes one
+or asks for the same outcome in natural language, read the matching file and follow
+it as a procedure:
+
+| User intent | Claude spec to read |
+| --- | --- |
+| Set up or refresh profile | `.claude/commands/setup.md` |
+| Search/scrape jobs | `.claude/skills/job-scraper/SKILL.md` |
+| Apply to a posting | `.claude/commands/apply.md` |
+| Rank scraped jobs | `.claude/commands/rank.md` |
+| Interview preparation | `.claude/commands/interview.md` |
+| Record application outcome | `.claude/commands/outcome.md` |
+| Expand profile from public/source materials | `.claude/commands/expand.md` |
+| Build an upskilling plan | `.claude/skills/upskill/SKILL.md` |
+| Add a LaTeX template | `.claude/commands/add-template.md` |
+| Add a job portal skill | `.claude/commands/add-portal.md` |
+| Reset profile/documents | `.claude/commands/reset.md` |
+
+## Job Search Portal Skills
+
+The installed portal CLIs live under `.agents/skills/`. Before running one, read
+that portal's `SKILL.md` and use its documented flags. Prefer the CLI output over
+free-form web search when the portal skill exists. Keep searches low-volume and
+respect each skill's personal-use or terms-of-service notes.
+
+## Repository Hygiene
+
+- Keep edits narrowly scoped to the requested workflow.
+- Preserve user profile data and generated application archives unless the user
+  explicitly asks to reset or delete them.
+- Leave unrelated untracked files alone.
+- When changing generated CV or cover-letter files, re-read and verify the final
+  file contents before reporting completion.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/MadsLorentzen/ai-job-search/actions/workflows/ci.yml/badge.svg)](https://github.com/MadsLorentzen/ai-job-search/actions/workflows/ci.yml)
 
-An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
+An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code), with a Codex compatibility layer in this fork. Fork it, fill in your profile, and let an AI coding agent evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
 > Note: This is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic. Anthropic and Claude Code are referenced only to describe the toolchain this workflow uses.
 
@@ -24,6 +24,8 @@ An AI-powered job application framework built on [Claude Code](https://claude.co
 ## What this is
 
 A structured workflow that turns Claude Code into a full-stack job application assistant. The core workflow (self-profiling, fit evaluation, and the drafter-reviewer application pipeline) is **language- and country-agnostic**. The job portal search skills are built for the Danish market (Jobindex, Jobnet, Akademikernes Jobbank, etc.), but the pattern is designed to be swapped for your local job boards.
+
+This fork also includes `AGENTS.md` so Codex can use the same workflow without needing the Claude slash-command runtime. The `.claude/` files remain the canonical workflow specs for Claude Code; Codex reads them through the mapping in `AGENTS.md`.
 
 ```
 /setup          /scrape              /apply <url>
@@ -45,7 +47,7 @@ The framework encodes career guidance best practices, including structured evalu
 
 ## Prerequisites
 
-- [Claude Code](https://claude.com/claude-code) (CLI)
+- [Claude Code](https://claude.com/claude-code) (CLI) or Codex with project `AGENTS.md` support
 - Python 3.10+
 - [Bun](https://bun.sh) (for job search CLI tools)
 - LaTeX distribution with `lualatex` and `xelatex`: [TeX Live](https://tug.org/texlive/), [MacTeX](https://tug.org/mactex/), [TinyTeX](https://yihui.org/tinytex/), or [MiKTeX](https://miktex.org/). The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors); the cover letter compiles with `xelatex` because `cover.cls` requires `fontspec`. If using a minimal TeX install such as TinyTeX or BasicTeX, install the extra packages listed in [SETUP.md](SETUP.md#minimal-tex-install-tinytexbasictex).
@@ -85,26 +87,50 @@ For `linkedin-search` and `freehire-search` the install is optional: both have z
 
 ### 3. Set up your profile
 
+Claude Code:
+
 ```bash
 claude
 # Then inside Claude Code:
 /setup
 ```
 
+Codex:
+
+```text
+Set up my profile using the repository setup workflow.
+```
+
 `/setup` offers three paths: read your `documents/` folder if you have one populated (CV PDF, LinkedIn export, diplomas, reference letters, past applications), import a single CV pasted in chat, or walk through an interview. It auto-detects what you have and asks. Documents-folder mode is idempotent and safe to re-run as you add more material; see `documents/README.md` for the layout.
 
 ### 4. Search for jobs
 
+Claude Code:
+
 ```bash
 /scrape
+```
+
+Codex:
+
+```text
+Search for new jobs using the repository scraper workflow.
 ```
 
 This searches multiple job portals for positions matching your profile, deduplicates results, and presents them sorted by fit. Pick a match to run `/apply` on it directly — or, when a scrape returns more jobs than you want to eyeball, run `/rank` to batch-score them all against the fit framework and get a ranked shortlist first.
 
 ### 5. Apply to a job
 
+Claude Code:
+
 ```bash
 /apply https://jobindex.dk/job/1234567
+```
+
+Codex:
+
+```text
+Evaluate and apply to this job: https://jobindex.dk/job/1234567
 ```
 
 If the URL can't be fetched (some job portals block automated access), you can paste the job description directly instead:
@@ -133,6 +159,7 @@ This runs the full workflow: evaluate fit, draft CV + cover letter, review with 
 
 ```
 ai-job-search/
+├── AGENTS.md                           # Codex entry point and Claude-to-Codex workflow mapping
 ├── CLAUDE.md                          # Main candidate profile + workflow rules
 ├── .claude/
 │   ├── commands/

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ The framework encodes career guidance best practices, including structured evalu
 
 - [Claude Code](https://claude.com/claude-code) (CLI) or Codex with project `AGENTS.md` support
 - Python 3.10+
-- [Bun](https://bun.sh) (for job search CLI tools)
-- LaTeX distribution with `lualatex` and `xelatex`: [TeX Live](https://tug.org/texlive/), [MacTeX](https://tug.org/mactex/), [TinyTeX](https://yihui.org/tinytex/), or [MiKTeX](https://miktex.org/). The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors); the cover letter compiles with `xelatex` because `cover.cls` requires `fontspec`. If using a minimal TeX install such as TinyTeX or BasicTeX, install the extra packages listed in [SETUP.md](SETUP.md#minimal-tex-install-tinytexbasictex).
-- Optional: `pdftotext` from [poppler](https://poppler.freedesktop.org/) (macOS: `brew install poppler`, Debian/Ubuntu: `apt install poppler-utils`, Windows: `choco install poppler`) — used by `/apply`'s ATS parseability check on the compiled CV. If missing, the check degrades gracefully to a visual keyword review.
+- Docker with Compose support. This fork runs Bun and LaTeX through `compose.yml`, so you do not need to install Bun, TeX Live, MacTeX, TinyTeX, MiKTeX, or Poppler on the host.
+
+Check your local machine from the repo root:
+
+```bash
+tools/check_dependencies.sh
+```
 
 ## Quick start
 
@@ -62,28 +66,14 @@ gh repo fork MadsLorentzen/ai-job-search --clone
 cd ai-job-search
 ```
 
-### 2. Install job search tools
-
-PowerShell:
-
-```powershell
-$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search")
-foreach ($tool in $tools) {
-  Set-Location ".agents/skills/$tool/cli"
-  bun install
-  Set-Location "..\..\..\.."
-}
-```
-
-Bash / zsh / Git Bash:
+### 2. Check project-local tools
 
 ```bash
-for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search; do
-  cd .agents/skills/$tool/cli && bun install && cd ../../../..
-done
+tools/check_dependencies.sh
 ```
 
-For `linkedin-search` and `freehire-search` the install is optional: both have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
+The first tool run pulls Docker images for LaTeX and Bun. Nothing is installed
+into your home directory or system package manager.
 
 ### 3. Set up your profile
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -24,88 +24,46 @@ python3 --version
 
 On Windows, `py --version` is often the most reliable check. If your system exposes Python as `python` instead of `python3`, use `python` in the commands below.
 
-### Bun (for job search tools)
+### Docker (for project-local tools)
 
-The job portal CLIs (four Danish portals plus the country-agnostic `linkedin-search` and `freehire-search` tools) are written in TypeScript and run with Bun.
+This fork keeps the heavy tooling out of your home directory and system package
+manager. LaTeX and Bun run through `compose.yml`:
 
-- macOS/Linux:
+- `latex` service: `texlive/texlive:latest`, provides `lualatex` and `xelatex`
+- `bun` service: `oven/bun:1.3.14`, runs the portal-search CLIs
+
+Install Docker Desktop or another Docker engine with Compose support, then check
+from the repository root:
 
 ```bash
-curl -fsSL https://bun.sh/install | bash
+tools/check_dependencies.sh
 ```
 
-- Windows PowerShell:
+### Bun (for job search tools)
 
-```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://bun.sh/install.ps1 | iex"
+The job portal CLIs are written in TypeScript and run with Bun, but you do not
+need Bun installed on the host. Use the Compose wrapper:
+
+```bash
+tools/run_portal_cli.sh linkedin-search search -q "Engineering Manager" -l "Berlin, Germany" --format table
 ```
-
-If you prefer a package manager, `winget install Oven-sh.Bun` also works on Windows.
 
 ### LaTeX (for compiling CVs and cover letters)
 
-Install a LaTeX distribution to compile the generated `.tex` files to PDF:
-
-- **Windows:** [MiKTeX](https://miktex.org/download)
-- **macOS:** [MacTeX](https://tug.org/mactex/)
-- **Linux:** `sudo apt install texlive-full` or `sudo dnf install texlive-scheme-full`
-
-The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors). The cover letter compiles with `xelatex` because `cover.cls` requires `fontspec` for its custom Lato/Raleway fonts.
-
-#### Minimal TeX install: TinyTeX/BasicTeX
-
-Full TeX distributions work out of the box, but minimal distributions need a few extra packages before the stock templates compile.
-
-On macOS, a user-level TinyTeX install avoids a system-wide installer and does not require `sudo`:
-
-```bash
-curl -fsSL https://yihui.org/tinytex/install-bin-unix.sh -o /tmp/tinytex-install-bin-unix.sh
-sh /tmp/tinytex-install-bin-unix.sh /tmp --no-path
-export PATH="$HOME/Library/TinyTeX/bin/universal-darwin:$PATH"
-```
-
-Then install the template dependencies:
-
-```bash
-tlmgr install \
-  moderncv fontawesome5 fontawesome6 academicons import luatexbase pgf \
-  titlesec textpos xltxtra xunicode cite realscripts
-```
-
-For BasicTeX/MacTeX, make sure the TeX binary directory is on `PATH` first (for example via `/Library/TeX/texbin`), then run the same `tlmgr install ...` command.
+The CV compiles with `lualatex` and the cover letter compiles with `xelatex`,
+both inside the `latex` Compose service. No host TeX install is required.
 
 Quick smoke tests after setup:
 
 ```bash
-cd cv && lualatex -interaction=nonstopmode -halt-on-error main_example.tex && cd ..
-
-SMOKE_DIR="$(mktemp -d /tmp/ai-job-cover-smoke.XXXXXX)"
-cp -R cover_letters/cover.cls cover_letters/OpenFonts "$SMOKE_DIR/"
-cat >"$SMOKE_DIR/cover_smoke.tex" <<'EOF'
-\documentclass[]{cover}
-\begin{document}
-\namesection{Test}{Candidate}{test@example.com}
-\companyname{Example Company}
-\companyaddress{123 Hiring Street\\Example City}
-\currentdate{\today}
-\lettercontent{Dear Hiring Manager,}
-\lettercontent{This smoke test verifies that xelatex can load cover.cls and the bundled fonts.}
-\closing{Sincerely,}
-\signature{Test Candidate}
-\end{document}
-EOF
-(cd "$SMOKE_DIR" && xelatex -interaction=nonstopmode -halt-on-error cover_smoke.tex)
+tools/compile_examples.sh
 ```
 
 ### Optional: pdftotext (for the ATS check)
 
-`/apply` runs an ATS parseability check on the compiled CV: it extracts the PDF's text layer and verifies contact details, reading order, and keyword coverage the way an applicant-tracking system sees them. This uses `pdftotext` from [poppler](https://poppler.freedesktop.org/), which is not part of TeX distributions:
-
-- **macOS:** `brew install poppler`
-- **Debian/Ubuntu:** `sudo apt install poppler-utils`
-- **Windows:** `choco install poppler`
-
-If `pdftotext` is missing, `/apply` skips the mechanical check with a warning and falls back to a visual keyword review — everything else works normally.
+`/apply` runs an ATS parseability check on the compiled CV when `pdftotext` is
+available in the active toolchain. If it is unavailable, `/apply` skips the
+mechanical check with a warning and falls back to a visual keyword review.
 
 ## 2. Fork and clone
 
@@ -116,28 +74,16 @@ cd ai-job-search
 
 Or manually: fork on GitHub, then clone your fork.
 
-## 3. Install job search CLI dependencies
-Run these from the repository root.
+## 3. Check the project-local toolchain
 
-- PowerShell:
+Run this from the repository root:
 
-```powershell
-$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search")
-foreach ($tool in $tools) {
-  Set-Location ".agents/skills/$tool/cli"
-  bun install
-  Set-Location "..\..\..\.."
-}
-```
-
-- Bash / zsh / Git Bash:
 ```bash
-for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search; do
-  cd .agents/skills/$tool/cli && bun install && cd ../../../..
-done
+tools/check_dependencies.sh
 ```
 
-For `linkedin-search` and `freehire-search` the install is optional: both have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
+The first `docker compose run` will pull the container images. This is expected
+and keeps Bun/LaTeX out of the host system.
 
 If you're outside Denmark, you can generate an equivalent search skill for your local job board with `/add-portal` — it scaffolds the same CLI structure for any public portal and test-runs a live query before registering. See the "Job search tools" section in the README.
 
@@ -227,15 +173,8 @@ Claude will:
 After `/apply` creates the LaTeX files:
 
 ```bash
-# Bash / zsh / Git Bash
-cd cv && lualatex main_<company>.tex && cd ..
-cd cover_letters && xelatex cover_<company>_<role>.tex && cd ..
-```
-
-```powershell
-# PowerShell
-Set-Location cv; lualatex main_<company>.tex; Set-Location ..
-Set-Location cover_letters; xelatex cover_<company>_<role>.tex; Set-Location ..
+docker compose run --rm latex 'cd cv && lualatex -interaction=nonstopmode main_<company>.tex'
+docker compose run --rm latex 'cd cover_letters && xelatex -interaction=nonstopmode cover_<company>_<role>.tex'
 ```
 
 These commands apply to the stock templates (moderncv CV, `cover.cls` cover letter). If you'd rather use your own LaTeX template, run `/add-template` — it captures the template's compile engine, fonts, style rules, and page limit, test-compiles it, and wires it into `/apply`. See the "LaTeX templates" section in the README.
@@ -246,12 +185,13 @@ These commands apply to the stock templates (moderncv CV, `cover.cls` cover lett
 This is expected if you haven't set up salary benchmarking. The `/apply` workflow skips this step automatically.
 
 ### Job search CLI tools not working
-Make sure Bun is installed and you ran `bun install` in each CLI directory. The tools require network access to fetch job listings.
+Make sure Docker is running and use `tools/run_portal_cli.sh <portal-skill> ...`.
+The tools require network access to fetch job listings.
 
 ### LaTeX compilation errors
 - CV: uses `lualatex` (pdflatex often fails on modern MiKTeX with `fontawesome5` font-expansion errors; lualatex handles the same sources cleanly)
 - Cover letter: uses `xelatex` (for custom fonts in `OpenFonts/fonts/`)
-- Make sure your LaTeX distribution includes the `moderncv` package
+- Run through `docker compose run --rm latex ...` so the TeX environment is consistent.
 
 ### Fonts not found in cover letter
 The cover letter template expects fonts in `cover_letters/OpenFonts/fonts/`. Make sure this directory exists and contains the Lato and Raleway font files.

--- a/codex/commands/README.md
+++ b/codex/commands/README.md
@@ -1,0 +1,12 @@
+# Codex Command Wrappers
+
+Codex does not currently use this folder as a native slash-command runtime.
+These files are project-local workflow entry points for Codex sessions.
+
+When the user asks for a command-like action, read the matching wrapper first,
+then read and execute the referenced Claude workflow spec or skill using the
+tool translation rules in `AGENTS.md`.
+
+Keep these wrappers thin. The detailed workflow stays in `.claude/commands/`
+and `.claude/skills/` so Claude Code and Codex do not drift apart.
+

--- a/codex/commands/add-portal.md
+++ b/codex/commands/add-portal.md
@@ -1,0 +1,11 @@
+# Codex Command: Add Portal
+
+Use when the user asks to add a job portal/search source.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/add-portal.md` completely.
+3. Follow that workflow using Codex tool equivalents.
+4. Keep generated portal skills tracked only when they are reusable and contain
+   no personal candidate data.
+

--- a/codex/commands/add-template.md
+++ b/codex/commands/add-template.md
@@ -1,0 +1,10 @@
+# Codex Command: Add Template
+
+Use when the user asks to add or register a LaTeX CV or cover-letter template.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/add-template.md` completely.
+3. Follow that workflow using Codex tool equivalents.
+4. Compile and inspect generated documents before reporting completion.
+

--- a/codex/commands/apply.md
+++ b/codex/commands/apply.md
@@ -1,0 +1,17 @@
+# Codex Command: Apply
+
+Use when the user asks to apply to a job, tailor a CV, write a cover letter, or
+generate application materials for a posting.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `my/profile/CLAUDE.md` if present; otherwise read `CLAUDE.md`.
+3. Read `.claude/commands/apply.md` completely.
+4. Read `.claude/skills/job-application-assistant/SKILL.md` and the profile,
+   writing, evaluation, CV, cover-letter, and interview files it references,
+   preferring `my/profile/...` overrides where they exist.
+5. Evaluate fit before drafting unless the user explicitly asks for a narrow
+   artifact only.
+6. Generate application outputs in the existing ignored output paths.
+7. Compile and visually inspect CV and cover-letter PDFs before presenting them.
+

--- a/codex/commands/expand.md
+++ b/codex/commands/expand.md
@@ -1,0 +1,13 @@
+# Codex Command: Expand
+
+Use when the user asks to enrich the candidate profile from source documents,
+LinkedIn exports, public profiles, or other supplied material.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/expand.md` completely.
+3. Follow that workflow using Codex tool equivalents.
+4. Treat the operation as additive only unless the user explicitly asks to
+   replace existing profile facts.
+5. Store private profile output under `my/profile/`.
+

--- a/codex/commands/interview.md
+++ b/codex/commands/interview.md
@@ -1,0 +1,11 @@
+# Codex Command: Interview
+
+Use when the user asks for interview preparation, likely questions, STAR
+answers, interview strategy, or mock interview practice.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/interview.md` completely.
+3. Read the relevant private profile files under `my/profile/...` where present.
+4. Follow the interview-prep workflow using Codex tool equivalents.
+

--- a/codex/commands/outcome.md
+++ b/codex/commands/outcome.md
@@ -1,0 +1,11 @@
+# Codex Command: Outcome
+
+Use when the user wants to record what happened after applying or interviewing.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/outcome.md` completely.
+3. Follow that workflow using Codex tool equivalents.
+4. Write outcome data without reinterpreting the profile unless the user asks
+   for profile recalibration.
+

--- a/codex/commands/rank.md
+++ b/codex/commands/rank.md
@@ -1,0 +1,13 @@
+# Codex Command: Rank
+
+Use when the user asks to rank scraped jobs, prioritize applications, or choose
+which roles to apply to first.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/rank.md` completely.
+3. Read the private fit, profile, and preference files under `my/profile/...`
+   where present.
+4. Rank jobs using the repository scoring framework and the user's current
+   constraints.
+

--- a/codex/commands/reset.md
+++ b/codex/commands/reset.md
@@ -1,0 +1,12 @@
+# Codex Command: Reset
+
+Use when the user asks to reset profile data, generated documents, job-search
+state, or application archives.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/reset.md` completely.
+3. Treat the workflow as destructive.
+4. Do not delete or overwrite anything until the user explicitly confirms the
+   exact scope.
+

--- a/codex/commands/search.md
+++ b/codex/commands/search.md
@@ -1,0 +1,14 @@
+# Codex Command: Search
+
+Use when the user asks to search, scrape, or refresh job listings.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/skills/job-scraper/SKILL.md` completely.
+3. Prefer `my/profile/job-scraper/search-queries.md` when it exists; otherwise
+   read `.claude/skills/job-scraper/search-queries.md`.
+4. Read each portal skill before invoking its CLI.
+5. Prefer project-local container scripts such as `tools/run_portal_cli.sh` over
+   installing tooling globally.
+6. Keep generated search reports and state in ignored personal paths.
+

--- a/codex/commands/setup.md
+++ b/codex/commands/setup.md
@@ -1,0 +1,12 @@
+# Codex Command: Setup
+
+Use when the user asks to set up, refresh, or update the candidate profile.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/commands/setup.md` completely.
+3. Follow that workflow using Codex tool equivalents.
+4. Prefer source documents under `documents/` and write private generated
+   profile data under `my/profile/`.
+5. Do not commit personal documents or generated private profile files.
+

--- a/codex/commands/upskill.md
+++ b/codex/commands/upskill.md
@@ -1,0 +1,13 @@
+# Codex Command: Upskill
+
+Use when the user asks for an upskilling plan, skill-gap analysis, or learning
+roadmap for target roles.
+
+Procedure:
+1. Read `AGENTS.md`.
+2. Read `.claude/skills/upskill/SKILL.md` completely if present.
+3. Read the relevant private profile and target-role files under
+   `my/profile/...` where present.
+4. Store generated upskilling reports in ignored personal output paths unless
+   the user explicitly asks for a tracked template.
+

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,14 @@
+services:
+  latex:
+    image: texlive/texlive:latest
+    working_dir: /work
+    volumes:
+      - .:/work
+    entrypoint: ["bash", "-lc"]
+
+  bun:
+    image: oven/bun:1.3.14
+    working_dir: /work
+    volumes:
+      - .:/work
+    entrypoint: ["bash", "-lc"]

--- a/tools/check_dependencies.sh
+++ b/tools/check_dependencies.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=0
+
+check() {
+  local command="$1"
+  local purpose="$2"
+
+  if command -v "$command" >/dev/null 2>&1; then
+    printf '%-14s ok       %s\n' "$command" "$purpose"
+  else
+    printf '%-14s missing  %s\n' "$command" "$purpose"
+    missing=1
+  fi
+}
+
+echo "Project dependency check"
+echo
+check docker "runs the project-local Compose toolchain"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  printf '%-14s ok       %s\n' "docker compose" "runs latex and bun containers"
+else
+  printf '%-14s missing  %s\n' "docker compose" "runs latex and bun containers"
+  missing=1
+fi
+
+echo
+if [[ "$missing" -ne 0 ]]; then
+  echo "Missing required host dependency: Docker with Compose."
+  echo "All LaTeX and Bun tooling runs inside containers from compose.yml."
+  exit 1
+fi
+
+echo "Host is ready. Tooling is provided by compose.yml."

--- a/tools/compile_examples.sh
+++ b/tools/compile_examples.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose run --rm --user "$(id -u):$(id -g)" latex '
+  cd cv
+  lualatex -interaction=nonstopmode -halt-on-error main_example.tex
+  cd ../cover_letters
+  xelatex -interaction=nonstopmode -halt-on-error cover_example.tex
+'

--- a/tools/run_portal_cli.sh
+++ b/tools/run_portal_cli.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "Usage: tools/run_portal_cli.sh <portal-skill> [cli args...]"
+  echo "Example: tools/run_portal_cli.sh linkedin-search search -q 'Engineering Manager' -l 'Berlin, Germany' --format table"
+  exit 2
+fi
+
+tool="$1"
+shift
+
+cli=".agents/skills/${tool}/cli/src/cli.ts"
+if [[ ! -f "$cli" ]]; then
+  echo "Unknown portal skill or missing CLI: $cli" >&2
+  exit 1
+fi
+
+command_parts=(bun run "$cli" "$@")
+printf -v command_string " %q" "${command_parts[@]}"
+docker compose run --rm --user "$(id -u):$(id -g)" bun "${command_string:1}"


### PR DESCRIPTION
Changes:

  - Add Docker-based project tooling so dependencies can run locally without global installs.
  - Add ignored my/ profile support for private candidate data.
  - Add codex/commands/ wrappers for existing workflows.
  - Update AGENTS.md so Codex uses Codex wrappers first, then falls back to Claude specs.

  No personal/generated application files included.