### PR TITLE
Add quant trading systems profile example

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -179,3 +179,13 @@ The command is designed to be re-run as your document collection grows. Each run
 - After adding reference letters
 - After recording outcomes for completed applications
 - After updating your master CV
+
+---
+
+## Example Source Profiles
+
+The `examples/` folder can contain public-safe example source profiles that show how candidates may describe different technical backgrounds.
+
+Available examples:
+
+- [Quant and Trading Systems Profile Example](examples/quant-trading-systems-profile.md)

--- a/documents/examples/quant-trading-systems-profile.md
+++ b/documents/examples/quant-trading-systems-profile.md
@@ -1,0 +1,168 @@
+﻿# Quant and Trading Systems Profile Example
+
+This example shows how a technical applicant can describe quant, trading-system, market-data, or risk-infrastructure experience for the job-search setup workflow.
+
+It is intentionally generic. It does not include private trading logic, broker credentials, account data, live performance claims, proprietary thresholds, or confidential employer information.
+
+---
+
+## Candidate Positioning
+
+Target profile:
+
+- Quant developer
+- Trading systems engineer
+- Market data engineer
+- Risk infrastructure developer
+- Python backend developer for trading or financial systems
+- C++ developer learning market microstructure and execution systems
+
+Short positioning statement:
+
+> I build systematic trading and financial-data systems with a focus on market-data quality, risk controls, research-to-live validation, testing discipline, and production reliability.
+
+---
+
+## Target Roles
+
+Good-fit roles may include:
+
+- Quantitative Developer
+- Junior Quant Developer
+- Trading Systems Developer
+- Market Data Engineer
+- Risk Infrastructure Developer
+- Python Backend Engineer in FinTech
+- C++ Trading Systems Engineer
+- Research Engineering Assistant
+
+Less direct roles may include:
+
+- Pure discretionary trader
+- Generic data-entry analyst
+- Non-technical finance assistant
+- Sales-heavy financial advisory role
+
+---
+
+## Core Technical Evidence
+
+A strong profile should connect skills to proof.
+
+Example evidence map:
+
+| Area | Evidence to provide |
+|---|---|
+| Python | Backtesting tools, data pipelines, APIs, automation, pytest |
+| PostgreSQL | Tick storage, OHLC construction, time-series queries, audit tables |
+| C++ | Returns, volatility, risk math, order book fundamentals, CMake |
+| Market data | Tick ingestion, duplicate detection, gap checks, OHLC validation |
+| Risk systems | Position sizing, spread gates, drawdown limits, safe-mode logic |
+| Testing | Unit tests, integration tests, CI, parity checks |
+| Trading systems | Signal lifecycle, execution boundaries, research/live alignment |
+
+---
+
+## Project Descriptions
+
+When describing projects, avoid vague claims such as:
+
+- "Built an AI trading bot"
+- "Created a profitable strategy"
+- "Used machine learning for trading"
+
+Prefer specific engineering statements:
+
+- Built a tested Python risk engine that separates candidate signals from trade approval.
+- Designed a PostgreSQL market-data pipeline with synthetic tick ingestion and OHLC bar construction.
+- Implemented C++ utilities for returns, volatility, drawdown, and risk-based position sizing.
+- Added CI-backed tests to validate deterministic behavior.
+- Documented system boundaries and security limits for public-safe portfolio repositories.
+
+---
+
+## Risk and Compliance Language
+
+For finance and trading roles, wording matters.
+
+Good language:
+
+- Research system
+- Public-safe demo
+- Synthetic data
+- Risk governance
+- Validation framework
+- Backtest limitation awareness
+- Execution-safety boundary
+
+Avoid unsupported language:
+
+- Guaranteed returns
+- Institutional-grade alpha, unless clearly documented
+- Live profit claims without audited evidence
+- Broker/account-specific claims
+- Proprietary strategy details
+- Real customer or account information
+
+---
+
+## Interview Story Prompts
+
+Useful STAR-style stories:
+
+1. A time you found a data-quality issue before it affected downstream logic.
+2. A time you separated research logic from live execution logic.
+3. A time you added tests around a risky system assumption.
+4. A time you simplified a complex trading workflow into a safer architecture.
+5. A time you learned a missing technical skill to complete a project.
+
+---
+
+## Role Evaluation Notes
+
+When evaluating a job posting, look for keywords such as:
+
+- Python
+- C++
+- PostgreSQL
+- market data
+- trading systems
+- risk
+- execution
+- low latency
+- backtesting
+- research engineering
+- data quality
+- CI/CD
+- testing
+- Linux
+- production systems
+
+Strong match signals:
+
+- The role values engineering proof over formal finance credentials.
+- The team works on trading infrastructure, market data, risk, execution, or research tooling.
+- The job asks for tested systems, not only notebook research.
+- The posting mentions production reliability, data quality, or validation.
+
+Weak match signals:
+
+- The role is purely discretionary trading with no software component.
+- The role requires direct exchange connectivity experience as a hard requirement.
+- The role is mostly sales, client acquisition, or non-technical finance operations.
+
+---
+
+## Final Guidance
+
+For technical trading roles, the profile should show:
+
+- What you built
+- Why it mattered
+- How you tested it
+- What risks you controlled
+- What you intentionally did not expose publicly
+
+A strong quant/trading-systems applicant profile is not only about signals.
+
+It is about data quality, validation, risk, execution boundaries, and engineering discipline.


### PR DESCRIPTION
Summary:
- Added a public-safe example source profile for quant, trading-systems, market-data, and risk-infrastructure applicants.
- Linked the example from documents/README.md.
- Kept the example generic and non-proprietary.

Why:
This gives technical finance applicants a clearer example of how to describe trading-system engineering experience for the setup workflow without exposing private strategy logic, account data, or performance claims.

Validation:
- Docs-only change.
- Ran git diff --check locally.