### PR TITLE
docs: add no-crypto/no-token disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 An AI-powered job application framework built on [Claude Code](https://claude.com/claude-code). Fork it, fill in your profile, and let Claude evaluate job postings, tailor your CV, write cover letters, and prepare you for interviews.
 
 > Note: This is an independent open-source project and is not affiliated with, endorsed by, sponsored by, or maintained by Anthropic. Anthropic and Claude Code are referenced only to describe the toolchain this workflow uses.
+>
+> This project has **no affiliated cryptocurrency, token, or paid sponsorship program**. Anything claiming otherwise is unauthorized and should be treated as a scam. The only ways to support the project are the Ko-fi link below and contributing on GitHub.
 
 <p align="center">
   <i>Did this save you a Sunday of cover-letter writing? Consider a coffee.<br>


### PR DESCRIPTION
Adds one line to the README disclaimer block: the project has no affiliated cryptocurrency, token, or paid sponsorship program; anything claiming otherwise is a scam. Prompted by multiple pump.fun solicitation emails targeting the maintainer this week - cheap insurance for users before any token appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)