### PR TITLE
Clarify /add-template --use activation metadata

### DIFF
--- a/.claude/commands/add-template.md
+++ b/.claude/commands/add-template.md
@@ -11,7 +11,7 @@ Follow these steps **in order**.
 ## Step 0: Parse Arguments
 
 - If `$ARGUMENTS` contains `--list`: run **List Mode** below and stop.
-- If `$ARGUMENTS` contains `--use <name>`: skip to **Step 5: Activate** with that template name. `--use default` deactivates any custom template and restores the stock guidance (see Step 5).
+- If `$ARGUMENTS` contains `--use <name>`: run **Switch Mode** below, then continue to **Step 5: Activate** with the resolved template metadata. `--use default` deactivates any custom template and restores the stock guidance (see Step 5).
 - If `$ARGUMENTS` contains a file path or @-mentioned file: treat it as the template source and carry it into Step 1.
 - Otherwise: start the registration flow at Step 1.
 
@@ -28,6 +28,25 @@ Use Glob with `templates/**/TEMPLATE.md` to find registered templates. For each,
 ```
 
 A template is **active** if `05-cv-templates.md` (CV) or `06-cover-letter-templates.md` (cover letter) contains an `ACTIVE-TEMPLATE` managed block naming it. If no custom templates exist, say so and explain that `/add-template` registers one. Stop here.
+
+### Switch Mode
+
+If `$ARGUMENTS` contains `--use <name>`:
+
+1. If `<name>` is `default`, skip template resolution and continue to Step 5 with `default` as the activation target.
+2. Use Glob with `templates/**/TEMPLATE.md` and find manifests whose parent folder name exactly matches `<name>`.
+3. If no manifest matches, stop and say the template is not registered. Suggest `/add-template --list` to see available names.
+4. If more than one manifest matches, stop and list the matching manifest paths. Ask the user to rename one of the templates; activation must be unambiguous.
+5. Read the matching `TEMPLATE.md` and extract:
+   - **Type:** `CV` or `Cover letter`
+   - **Engine:** `lualatex`, `xelatex`, or `pdflatex`
+   - **Page limit:** `<N> page(s)`
+   - **Fonts:** the full font summary line
+6. Derive the template folder from the manifest path and verify `template.tex` exists in the same folder. If it is missing, stop with an error; the template registration is incomplete.
+7. Derive `<type>` for Step 5 from the manifest path:
+   - `templates/cv/<name>/TEMPLATE.md` -> `cv`
+   - `templates/cover_letters/<name>/TEMPLATE.md` -> `cover_letters`
+8. Continue to Step 5 using the resolved `<name>`, `<type>`, `<engine>`, font summary, page limit, template skeleton path, and manifest path. Do not re-run Steps 1-4; `--use` switches an already-registered template.
 
 ---
 
@@ -121,6 +140,8 @@ Do not proceed to Step 5 until the test compile passes.
 ## Step 5: Activate the Template
 
 Activation wires the template into `/apply` by adding a **managed block** to the top of the relevant guidance file — `05-cv-templates.md` for CVs, `06-cover-letter-templates.md` for cover letters. `/apply` reads these files in its drafting step, so the block is all it takes.
+
+If Step 5 was reached from Switch Mode, use the template metadata resolved from `TEMPLATE.md`. If Step 5 was reached after registering a new template, use the metadata collected and verified in Steps 2-4.
 
 Insert (or replace, if one exists) this block immediately after the file's H1 title:
 


### PR DESCRIPTION
## Summary
- Add a dedicated Switch Mode for /add-template --use <name>.
- Resolve the registered template manifest before activation so Step 5 has the metadata it needs.
- Document clean failure cases for missing, duplicate, or incomplete template registrations.

## What changed
Previously, Step 0 sent /add-template --use <name> straight to Step 5 with only the template name. Step 5 needs more than that: the template type, engine, font summary, page limit, skeleton path, and manifest path. This patch makes the switch path explicit by finding templates/**/TEMPLATE.md, matching the folder name, reading the manifest, verifying template.tex exists, deriving the activation type from the template path, and then continuing to activation with resolved metadata.

The default path remains simple: /add-template --use default skips template lookup and removes the managed override block as before.

## Tests
- python3 tools/lint_skills.py
- python3 -m unittest discover