### PR TITLE
Clean all /add-template test compile artifacts

### DIFF
--- a/.claude/commands/add-template.md
+++ b/.claude/commands/add-template.md
@@ -112,7 +112,7 @@ Never register a template without a successful test compile. LaTeX templates tha
    ```
 3. If the compile fails: show the user the relevant error lines, diagnose (missing font file, wrong engine, missing class), fix what you can (e.g. font `Path` values), and re-compile. If the fix needs input only the user has (a missing font file, a license-restricted class), ask for it and wait.
 4. On success, Read the PDF and confirm the layout renders sensibly (no overlapping text, fonts loaded, page count plausible for dummy content). Record any surprises in the manifest's "Known pitfalls".
-5. Delete the scratch files: `_compile_test.tex`, `_compile_test.pdf`, and all `.aux`/`.log`/`.out` artifacts.
+5. Delete the scratch files and generated artifacts for the test compile: `_compile_test.tex`, `_compile_test.pdf`, `_compile_test.aux`, `_compile_test.log`, `_compile_test.out`, `_compile_test.fls`, `_compile_test.fdb_latexmk`, `_compile_test.synctex.gz`, and any other `_compile_test.*` byproducts.
 
 Do not proceed to Step 5 until the test compile passes.
 


### PR DESCRIPTION
## Summary
- Expand /add-template's test-compile cleanup instruction beyond .aux/.log/.out.
- Scope cleanup to _compile_test.* byproducts so generated LaTeX scratch files do not remain in registered template folders.

## What changed
Step 4 already requires compiling a scratch _compile_test.tex before registering a custom template. The cleanup instruction only named _compile_test.tex, _compile_test.pdf, and generic .aux/.log/.out artifacts. This patch makes the expected cleanup explicit for common LaTeX byproducts such as _compile_test.fls, _compile_test.fdb_latexmk, and _compile_test.synctex.gz, plus any other _compile_test.* files produced by the compile.

## Tests
- python3 tools/lint_skills.py
- python3 -m unittest discover