### PR TITLE
Run CLI test suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@
 # Deliberately NOT here: live smoke tests of the job-portal CLIs. They hit
 # real portals (network-flaky, and the linkedin-search skill is personal-use
 # only per its own ToS warning - CI-automated requests would violate that).
-# CLIs get typechecked instead; live testing stays a local, on-demand step.
+# CI runs typechecks and the checked-in fixture/mock test suites only; live
+# portal testing stays a local, on-demand step.
 #
 # Security posture: this template ships pre-approved Claude Code permissions
 # and CLI code that every fork user executes, so the security-guards job
@@ -129,8 +130,8 @@ jobs:
           grep -q 'Output written on cover_example.pdf (1 page' cover_letters/cover_example.log \
             || { echo '::error::cover_letters/cover_example.tex no longer compiles to exactly 1 page'; exit 1; }
 
-  cli-typecheck:
-    name: Typecheck ${{ matrix.tool }}
+  cli-checks:
+    name: CLI checks ${{ matrix.tool }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -148,6 +149,14 @@ jobs:
       - run: bun install
         working-directory: .agents/skills/${{ matrix.tool }}/cli
       - run: bun run typecheck
+        working-directory: .agents/skills/${{ matrix.tool }}/cli
+      - name: Run fixture/mock tests when present
+        run: |
+          if find tests -type f -name '*.test.ts' | grep -q .; then
+            bun test
+          else
+            echo "No Bun tests found for ${{ matrix.tool }}; skipping"
+          fi
         working-directory: .agents/skills/${{ matrix.tool }}/cli
 
   placeholder-integrity:


### PR DESCRIPTION
## Summary

Extends the existing CLI matrix job so each job-search CLI runs its checked-in Bun test suite in CI, not only TypeScript typechecking.

## What changed

- Renamed the matrix job from `cli-typecheck` to `cli-checks` to reflect that it now performs more than typechecking.
- Kept the existing per-tool matrix across:
  - `freehire-search`
  - `jobbank-search`
  - `jobdanmark-search`
  - `jobindex-search`
  - `jobnet-search`
  - `linkedin-search`
- Kept the existing `bun install` and `bun run typecheck` steps.
- Added a fixture/mock test step that runs `bun test` when a CLI has checked-in `*.test.ts` files.
- Added a skip guard for CLIs that currently have no Bun tests, because `bun test` exits non-zero on “No tests found”. This keeps the workflow mergeable today while automatically enforcing tests for a CLI as soon as test files are added.
- Updated the workflow comment to clarify that CI still does not perform live portal smoke tests. It runs typechecks and checked-in local test suites only.

## Why

The portal CLIs already have useful local tests for parsing, flag validation, error handling, and mocked command behavior, but CI previously only ran `bun run typecheck`. Typechecking catches TypeScript errors, but it does not catch behavioral regressions like:

- broken HTML/entity parsing
- changed CLI output shape
- bad flag validation
- malformed JSON error envelopes
- regressions in mocked command handling

Running the existing test suites in CI makes those regressions visible before merge, without adding network calls to real job portals.

## Why the skip guard exists

On current `master`, at least one CLI may have no checked-in `*.test.ts` files. Running bare `bun test` there fails with “No tests found”, which would make this workflow change fail even though there is no test suite to run yet.

The guard means:

- CLIs with tests run `bun test` normally.
- CLIs without tests print a clear skip message.
- Future tests are picked up automatically once added.

## Verification

Locally ran the existing CLI test suites:

- `freehire-search`: 26 passing tests
- `jobbank-search`: 1 passing test
- `jobdanmark-search`: 1 passing test
- `jobindex-search`: 6 passing tests
- `linkedin-search`: 17 passing tests
- `jobnet-search`: skip guard prints “No Bun tests found” on current upstream master

Also reran representative typechecks after dependency install where needed, including `jobnet-search` and `linkedin-search`.
