### PR TITLE
brand: tagline line + the hired-moment coffee ask

### DIFF
--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -117,6 +117,10 @@ If the update recorded an upcoming or newly scheduled interview stage, also sugg
 
 > "Interview coming up? `/interview <company>` builds a prep pack for that stage from this application's archive - the posting, the documents you submitted, and any feedback recorded from earlier rounds."
 
+If the recorded status is `hired`, congratulate the user warmly first - this is the moment the whole framework exists for. Then add this single line (once; never on re-runs for the same application, and never for any other status):
+
+> "If this framework helped you get there, consider [buying it a coffee](https://ko-fi.com/madslorentzen) - a recruiter would have charged 15-20% of your first-year salary for the same outcome. ☕"
+
 ---
 
 ## Important Rules

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -119,7 +119,7 @@ If the update recorded an upcoming or newly scheduled interview stage, also sugg
 
 If the recorded status is `hired`, congratulate the user warmly first - this is the moment the whole framework exists for. Then add this single line (once; never on re-runs for the same application, and never for any other status):
 
-> "If this framework helped you get there, consider [buying it a coffee](https://ko-fi.com/madslorentzen) - a recruiter would have charged 15-20% of your first-year salary for the same outcome. ☕"
+> "If this framework helped you get there, consider [buying it a coffee](https://ko-fi.com/madslorentzen) - it keeps this free for the next job-seeker out there. ☕"
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # AI Job Search
 
+*The job search that runs on your machine.*
+
 <p align="center">
   <a href="https://trendshift.io/repositories/43622?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-43622" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/43622/daily" alt="MadsLorentzen%2Fai-job-search | Trendshift" width="250" height="55"/></a>
 </p>


### PR DESCRIPTION
Two small items from the branding strategy, now unblocked by the mascot shipping:

- **README tagline**: *"The job search that runs on your machine."* under the H1 - the positioning line was in the repo description but not the README itself.
- **The hired moment** (`/outcome`): when an application's status lands on `hired`, the assistant congratulates first, then adds one value-framed line: a recruiter would have charged 15-20% of first-year salary for the same outcome; consider a coffee. Explicitly once per application, never on re-runs, never for any other status - this is the only donation ask in the entire workflow beyond the existing README button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)