### PR TITLE
docs: add the maintainer's story to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ An AI-powered job application framework built on [Claude Code](https://claude.co
 >
 > This project has **no affiliated cryptocurrency, token, or paid sponsorship program**. Anything claiming otherwise is unauthorized and should be treated as a scam. The only ways to support the project are the Ko-fi link below and contributing on GitHub.
 
+## Does it actually work?
+
+I'm a geophysicist by training. When my position was cut in late 2025, I built this framework to run my own job search - the same `/scrape`, `/apply`, and `/interview` workflow in this repo, used weekly, on my own career. I was upfront about it with every employer I spoke to, and instead of counting against me, it usually sparked a genuine technical conversation.
+
+Sixty-nine tailored applications, twenty first interviews, and one signed contract later, I started as an AI engineer in June 2026. People kept asking whether this actually works. It got me hired. Now it's yours.
+
+*The longer version, including the full application funnel, is on [LinkedIn](https://www.linkedin.com/in/mads-lorentzen/).*
+
 <p align="center">
   <i>Did this save you a Sunday of cover-letter writing? Consider a coffee.<br>
   Did it land you the job? Maybe two.</i> ☕


### PR DESCRIPTION
Adds a short \"Does it actually work?\" section: the framework was built by its maintainer during his own job search, used openly with every employer, and led to a signed contract (69 applications -> 20 first interviews -> 1 offer). One link out to the longer story on LinkedIn.

Placed directly above the Ko-fi block so the support ask lands with the story's context. Answers the question every visitor silently asks, and disambiguates this repo from the other viral Claude Code job-search project whose story keeps getting conflated with ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)