### PR TITLE
Validate salary data before lookup

### DIFF
--- a/salary_lookup.py
+++ b/salary_lookup.py
@@ -43,6 +43,46 @@ STRIP_PATTERNS = [
 ]
 
 
+def fail_data_error(message):
+    """Exit with a user-facing salary data setup error."""
+    print(f"Error: invalid salary_data.json: {message}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("See tools/README_SALARY_TOOL.md for the expected format.", file=sys.stderr)
+    sys.exit(1)
+
+
+def validate_data(data):
+    """Validate the salary data shape before lookups use it."""
+    if not isinstance(data, dict):
+        fail_data_error("top-level JSON value must be an object")
+
+    metadata = data.get("metadata", {})
+    if metadata is not None and not isinstance(metadata, dict):
+        fail_data_error("'metadata' must be an object when provided")
+
+    companies = data.get("companies")
+    if not isinstance(companies, list):
+        fail_data_error("'companies' must be a list")
+
+    for index, entry in enumerate(companies, start=1):
+        if not isinstance(entry, dict):
+            fail_data_error(f"companies[{index}] must be an object")
+
+        company = entry.get("company")
+        if not isinstance(company, str) or not company.strip():
+            fail_data_error(f"companies[{index}].company must be a non-empty string")
+
+        city = entry.get("city")
+        if city is not None and not isinstance(city, str):
+            fail_data_error(f"companies[{index}].city must be a string when provided")
+
+        categories = entry.get("categories", {})
+        if categories is not None and not isinstance(categories, dict):
+            fail_data_error(f"companies[{index}].categories must be an object when provided")
+
+    return data
+
+
 def load_data():
     if not DATA_FILE.exists():
         print("Error: salary_data.json not found.", file=sys.stderr)
@@ -53,8 +93,12 @@ def load_data():
         print("If you don't have salary data, the salary lookup", file=sys.stderr)
         print("step will be skipped during /apply.", file=sys.stderr)
         sys.exit(1)
-    with open(DATA_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    try:
+        with open(DATA_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        fail_data_error(f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}")
+    return validate_data(data)
 
 
 def normalize(s):

--- a/tests/test_salary_lookup.py
+++ b/tests/test_salary_lookup.py
@@ -1,7 +1,12 @@
 """Tests for salary_lookup.py — format_entry, match_score, and search_company."""
 
+import io
+import tempfile
 import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
 
+import salary_lookup
 from salary_lookup import (
     format_entry,
     normalize,
@@ -9,6 +14,7 @@ from salary_lookup import (
     extract_core_words,
     match_score,
     search_company,
+    validate_data,
 )
 
 
@@ -163,6 +169,76 @@ class SearchCompanyTests(unittest.TestCase):
         }
         results = search_company(data, "Acme", city="Aarhus")
         self.assertEqual(results, [])
+
+
+class ValidateDataTests(unittest.TestCase):
+    def assert_invalid_data(self, data, expected_message):
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit) as raised:
+            with redirect_stderr(stderr):
+                validate_data(data)
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("Error: invalid salary_data.json", stderr.getvalue())
+        self.assertIn(expected_message, stderr.getvalue())
+        self.assertIn("tools/README_SALARY_TOOL.md", stderr.getvalue())
+
+    def test_valid_minimal_data_is_returned(self):
+        data = {"metadata": {}, "companies": [{"company": "Example Corp"}]}
+
+        self.assertIs(validate_data(data), data)
+
+    def test_top_level_value_must_be_object(self):
+        self.assert_invalid_data([], "top-level JSON value must be an object")
+
+    def test_companies_must_be_list(self):
+        self.assert_invalid_data({"companies": {"company": "Example Corp"}}, "'companies' must be a list")
+
+    def test_metadata_must_be_object_when_provided(self):
+        self.assert_invalid_data(
+            {"metadata": [], "companies": [{"company": "Example Corp"}]},
+            "'metadata' must be an object when provided",
+        )
+
+    def test_load_data_reports_json_parse_errors_without_traceback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_file = Path(tmpdir) / "salary_data.json"
+            data_file.write_text('{"companies": [', encoding="utf-8")
+
+            original_data_file = salary_lookup.DATA_FILE
+            salary_lookup.DATA_FILE = data_file
+            try:
+                stderr = io.StringIO()
+                with self.assertRaises(SystemExit) as raised:
+                    with redirect_stderr(stderr):
+                        salary_lookup.load_data()
+            finally:
+                salary_lookup.DATA_FILE = original_data_file
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("invalid JSON at line", stderr.getvalue())
+        self.assertIn("tools/README_SALARY_TOOL.md", stderr.getvalue())
+
+    def test_company_entry_must_be_object(self):
+        self.assert_invalid_data({"companies": ["Example Corp"]}, "companies[1] must be an object")
+
+    def test_company_name_is_required(self):
+        self.assert_invalid_data({"companies": [{"city": "Aarhus"}]}, "companies[1].company must be a non-empty string")
+
+    def test_company_name_must_not_be_blank(self):
+        self.assert_invalid_data({"companies": [{"company": "  "}]}, "companies[1].company must be a non-empty string")
+
+    def test_city_must_be_string_when_provided(self):
+        self.assert_invalid_data(
+            {"companies": [{"company": "Example Corp", "city": 123}]},
+            "companies[1].city must be a string when provided",
+        )
+
+    def test_categories_must_be_object_when_provided(self):
+        self.assert_invalid_data(
+            {"companies": [{"company": "Example Corp", "categories": []}]},
+            "companies[1].categories must be an object when provided",
+        )
 
 
 class UtilityTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds validation for `salary_data.json` before the salary lookup code searches or formats entries.

Instead of allowing malformed salary data to fail later with a Python traceback or a less obvious `KeyError`/`AttributeError`, the tool now exits with a clear setup error and points users back to the salary tool documentation.

## What changed

- Added `validate_data(data)` in `salary_lookup.py`.
- Added `fail_data_error(message)` for consistent user-facing salary data errors.
- `load_data()` now:
  - catches `json.JSONDecodeError` and reports the exact line/column,
  - validates the loaded structure before returning it.

The validation checks that:

- the top-level JSON value is an object,
- `metadata`, when provided, is an object,
- `companies` exists and is a list,
- each company entry is an object,
- each company has a non-empty string `company` value,
- `city`, when provided, is a string,
- `categories`, when provided, is an object.

## Why

`salary_data.json` is user-provided data. Users may create it manually or convert it from another source, so malformed data is a realistic setup issue.

Before this change, invalid shapes could make lookup/listing code crash later. For example:

- a missing `company` key could break lookup/list-all paths,
- a non-list `companies` value could behave strangely,
- a non-string `city` could fail during city filtering,
- invalid JSON would raise parser details without the salary-tool setup guidance.

This keeps the failure close to the real problem: the data file format.

## Verification

Ran the full Python test suite:

```bash
python3 -m unittest discover -s tests -t . -v
```

Result: 72 tests passed.
