### PR TITLE
added missing template dependency to SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -69,7 +69,7 @@ Then install the template dependencies:
 ```bash
 tlmgr install \
   moderncv fontawesome5 fontawesome6 academicons import luatexbase pgf \
-  titlesec textpos xltxtra xunicode cite realscripts
+  titlesec textpos xltxtra xunicode cite realscripts needspace
 ```
 
 For BasicTeX/MacTeX, make sure the TeX binary directory is on `PATH` first (for example via `/Library/TeX/texbin`), then run the same `tlmgr install ...` command.


### PR DESCRIPTION
i just followed the instructions to setup the latex engine, but the smoke tests failed. figured out there's a missing dependency, and this pr is just mentioning it in SETUP.md file.