### PR TITLE
docs: sync onboarding with linkedin-search + freehire-search

### DIFF
--- a/.claude/commands/add-portal.md
+++ b/.claude/commands/add-portal.md
@@ -1,6 +1,6 @@
 # /add-portal - Generate a Job-Portal Search Skill for Your Local Market
 
-You are helping the user build a job-portal search skill for a job board in their market. The repo ships worked examples of the pattern (four Danish portals plus the country-agnostic `linkedin-search`), and the README invites users elsewhere to build equivalents — this command turns that invitation into a guided workflow: investigate the portal, scaffold the skill from the canonical structure, and test-run a live query before registering anything.
+You are helping the user build a job-portal search skill for a job board in their market. The repo ships worked examples of the pattern (four Danish portals plus the country-agnostic `linkedin-search` and `freehire-search`), and the README invites users elsewhere to build equivalents — this command turns that invitation into a guided workflow: investigate the portal, scaffold the skill from the canonical structure, and test-run a live query before registering anything.
 
 The generator is **country-agnostic**: it works for any portal in any market and language. The skills it produces are typically market-specific and live in the user's fork (per repo policy, country-specific portal skills are not merged upstream — the generator is the upstream feature, its output is yours).
 
@@ -118,7 +118,9 @@ Do not proceed to Step 5 until search, detail, and tests all pass.
 
 ## Step 5: Register
 
-1. Ask whether the user wants the new portal added to their `/scrape` search strategy. If yes, add the portal's site to the relevant query categories in `.claude/skills/job-scraper/search-queries.md` (site-specific queries, like the existing `jobindex.dk` entries) so `/scrape` includes it.
+1. Ask whether the user wants the new portal added to their `/scrape` search strategy. If yes:
+   - The portal CLI itself is already picked up automatically by `/scrape` (it discovers `.agents/skills/*/SKILL.md`) — no further wiring is needed for CLI search/detail.
+   - Optionally add WebSearch/`site:` placeholder queries for that board in `.claude/skills/job-scraper/search-queries.md` (use the `[YOUR_JOB_BOARD]` style placeholders already there) so the fallback path still covers the board if the CLI is unavailable.
 2. Remind the user to add the install line for their own records if they maintain a fork README:
    ```bash
    cd .agents/skills/<name>/cli && bun install && cd ../../../..

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -313,7 +313,7 @@ Ask about:
 - **Key skills as search terms:** "Which of your skills are most likely to appear in job postings?" Pick 3-5 that are distinctive and searchable.
 - **Target companies (optional):** "Are there specific companies you'd like to monitor for openings?"
 - **Geographic scope:** "Which cities or regions should I search in? How far are you willing to commute?" Use this to define the location filter tiers (ideal, acceptable, borderline, too far).
-- **Job portals:** "The framework includes tools for Danish job portals (Jobindex, Jobbank, Jobdanmark, Jobnet). Are these the right ones for you, or do you use other sites?" Note: if the user is outside Denmark, acknowledge that the built-in CLI tools are Denmark-specific and suggest they can add their own portal integrations or rely on LinkedIn/Google site-searches.
+- **Job portals:** "The framework ships country-agnostic search CLIs (`linkedin-search`, `freehire-search`) plus Danish portal demos (Jobindex, Jobbank, Jobdanmark, Jobnet). `/scrape` auto-discovers whatever portal skills are installed under `.agents/skills/`. Which of these fit your market, and do you use other job boards?" If the user needs a local board that is not shipped, guide them to `/add-portal` (market-specific skills live in their fork). WebSearch/`site:` queries remain the fallback for portals without a CLI skill.
 
 **Important:** Also suggest role types the user may not have considered, based on their skill profile. For example:
 - If they have strong Python + domain expertise: "Have you considered roles like 'Technical Consultant' or 'Solutions Engineer' in your domain?"

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -2,11 +2,17 @@
 
 <!-- SETUP: Customize these queries based on your skills, target roles, and location -->
 
+## Installed portal CLIs (primary for `/scrape`)
+
+`/scrape` discovers every portal skill under `.agents/skills/*/SKILL.md` and runs its CLI first. Shipped country-agnostic CLIs include `linkedin-search` and `freehire-search`; Danish demos and any skill you add with `/add-portal` are included the same way. You do **not** need a matching `site:` line below for those CLIs to run.
+
+The `site:` query templates in this file are the **WebSearch fallback** — for portals without a CLI, company career pages, or when a CLI fails.
+
 ## Search Sites
 
 Primary (your market's job boards - scaffold one with `/add-portal`):
 - **[YOUR_JOB_BOARD]** - your market's largest general job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY])
+- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY]); also covered by `linkedin-search` CLI
 - **[YOUR_INDUSTRY_JOB_BOARD]** - a niche/industry board for your field (optional)
 - **[YOUR_ADDITIONAL_JOB_BOARD]** - another major board for your market (optional)
 


### PR DESCRIPTION
## Summary

`/setup` and `/add-portal` still describe the world from before `linkedin-search` / `freehire-search` became first-class country-agnostic CLIs, and before `/scrape` auto-discovered portal skills (#52 / #102). README and SETUP already document those tools — this PR aligns the onboarding commands and `search-queries.md` with that reality.

**3 docs files only** — no CLI/runtime changes.

---

## Master vs this PR

### `/setup` Section 9 — Job portals guidance

| | **master (old)** | **this PR (new)** |
|--|------------------|-------------------|
| What `/setup` claims | Built-in CLI tools are **Denmark-specific** | Ships **country-agnostic** CLIs (`linkedin-search`, `freehire-search`) + Danish demos |
| Advice for users outside Denmark | Rely on LinkedIn/**Google site-searches** | Use shipped CLIs; local boards via **`/add-portal`**; WebSearch only as fallback |
| Does `/scrape` find installed skills? | Not explained | Explicit: **auto-discovers** `.agents/skills/` |
| Matches README/SETUP? | **No** | **Yes** |

### `/add-portal` — shipped examples + registration

| | **master (old)** | **this PR (new)** |
|--|------------------|-------------------|
| Worked examples listed | 4 Danish + `linkedin-search` | 4 Danish + `linkedin-search` + **`freehire-search`** |
| How new portal gets into `/scrape` | Add `site:` lines “like existing **jobindex.dk** entries” | CLI auto-discovered; optional `site:` placeholders only for **WebSearch fallback** |
| Stale after #95? | **Yes** — `jobindex.dk` entries were removed | Fixed |

### `search-queries.md`

| | **master (old)** | **this PR (new)** |
|--|------------------|-------------------|
| Role of `site:` queries | Unclear — looks like the primary search list | Explicitly **WebSearch fallback** |
| Role of installed CLIs | Not mentioned | Primary path — `/scrape` discovers CLIs automatically |

---

## Why this matters

| Scenario | **master** | **this PR** |
|----------|------------|-------------|
| User outside Denmark runs `/setup` | Told “CLIs are Denmark-specific → use Google” | Told to use `linkedin-search` / `freehire-search`, then `/add-portal` for local boards |
| User runs `/add-portal` then `/scrape` | Docs imply they must edit `search-queries.md` with old jobindex-style lines | Docs say CLI is already wired; `search-queries.md` is optional fallback only |

---

## What this does NOT change

- No new portal code, flags, or query templates
- No scraper Step 1/2 logic (#52 / #102 stay as-is)
- No country-specific skills

## Files

- `.claude/commands/setup.md`
- `.claude/commands/add-portal.md`
- `.claude/skills/job-scraper/search-queries.md`

## Test plan

- [ ] Diff is docs-only (3 markdown files)
- [ ] `/setup` Section 9 no longer claims all built-in CLIs are Denmark-only
- [ ] `/add-portal` lists `freehire-search` and no longer references removed `jobindex.dk` entries
- [ ] `search-queries.md` states CLI auto-discovery = primary, `site:` = WebSearch fallback
- [ ] Wording matches README/SETUP (`linkedin-search`, `freehire-search`)