### PR TITLE
fix(salary): detect company column from header token, not exact match

### DIFF
--- a/tests/test_convert_salary_excel.py
+++ b/tests/test_convert_salary_excel.py
@@ -87,6 +87,23 @@ class DetectColumnTypeTests(unittest.TestCase):
 
         self.assertEqual(companies[0]["categories"]["software_engineering"], {"count": 8, "index": 110.0})
 
+    def test_parse_sheet_detects_company_column_with_token_header(self):
+        # Real-world salary sheets rarely use the bare token "Company";
+        # headers like "Company Name" / "Employer Name" must still be
+        # detected as the company column (previously silently skipped -> []).
+        for header in ("Company", "Company Name", "Employer Name"):
+            with self.subTest(header=header):
+                ws = FakeWorksheet([
+                    (header, "Salary"),
+                    ("Example Corp", 105.5),
+                ])
+                companies = parse_sheet(ws)
+                self.assertEqual(len(companies), 1)
+                self.assertEqual(companies[0]["company"], "Example Corp")
+                self.assertEqual(
+                    companies[0]["categories"]["salary"], {"index": 105.5}
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/convert_salary_excel.py
+++ b/tools/convert_salary_excel.py
@@ -91,7 +91,7 @@ def parse_sheet(ws, sheet_label=None):
     header_row = None
     for row_idx, row in enumerate(ws.iter_rows(min_row=1, max_row=10, values_only=False), start=1):
         for cell in row:
-            if cell.value and str(cell.value).strip().lower() in COMPANY_PATTERNS:
+            if cell.value and header_matches(str(cell.value), COMPANY_PATTERNS):
                 header_row = row_idx
                 break
         if header_row:
@@ -111,7 +111,7 @@ def parse_sheet(ws, sheet_label=None):
     city_col = None
     for i, h in enumerate(headers):
         h_lower = h.lower()
-        if h_lower in COMPANY_PATTERNS:
+        if header_matches(h, COMPANY_PATTERNS):
             company_col = i
         elif h_lower in CITY_PATTERNS:
             city_col = i


### PR DESCRIPTION
## Summary

`tools/convert_salary_excel.py` detected the company column via **exact** membership in `COMPANY_PATTERNS`, so real-world headers such as `"Company Name"` or `"Employer Name"` were never matched. `parse_sheet` then returned `[]` for that sheet and printed `Could not find header row`, **silently dropping the sheet from `salary_data.json`** (or producing no output at all for a single-sheet file).

This is the same "salary column detection" robustness class as #64 / #146.

## Failing case

A salary sheet whose company column is headed `Company Name` (or any header containing the token `company` / `firma` / `employer`, e.g. `Employer Name`) is not detected. `parse_sheet` returns `[]` for that sheet — so in a multi-sheet workbook the sheet is silently dropped from `salary_data.json`, and for a single-sheet file the converter prints `Could not find header row` and exits with no output.

## Exact reproduction

Reproduce on `master` (no fix):

```python
from tools.convert_salary_excel import parse_sheet
from tests.test_convert_salary_excel import FakeWorksheet

ws = FakeWorksheet([("Company Name", "Salary"), ("Example Corp", 105.5)])
print(parse_sheet(ws))   # -> []  (bug)
```

The added regression test `tests/test_convert_salary_excel.py::DetectColumnTypeTests::test_parse_sheet_detects_company_column_with_token_header` **fails on `master`** (the `Company Name` / `Employer Name` subtests return `[]`) and **passes after the fix**.

## Fix

Route company-column detection through the existing `header_matches()` token matcher (already used for count/index detection) — ~2 lines:

- header-row scan: `str(cell.value).strip().lower() in COMPANY_PATTERNS` → `header_matches(str(cell.value), COMPANY_PATTERNS)`
- company-col detection: `h_lower in COMPANY_PATTERNS` → `header_matches(h, COMPANY_PATTERNS)`

This **only adds detections**; inputs that already worked (bare `Company` / `Firma` / `Employer`) are single tokens still matched, so there is **zero regression**. The `h_lower` / `CITY_PATTERNS` branch is left untouched, so the diff is exactly two lines.

## Scope guard (one concern per PR)

Per CONTRIBUTING's "one concern per PR", the following are deliberately **excluded** and can be separate PRs if wanted:

- **F2:** non-numeric / `Id` columns ingested as bogus salary categories — more invasive behavioral change.
- **F3:** `salary_lookup.py` `format_entry` crash on `categories: null` — weaker, more contrived failing case.

## Verification

- `python -m unittest discover -s tests -t . -v` → 89 tests, all pass (new test included).
- `python tools/lint_skills.py` → OK
- `python tools/security_guards.py` → OK
- New test fails on `master`, passes after the fix (polarity verified locally).
