### PR TITLE
fix(salary): skip non-numeric and identifier columns in Excel conversion

### DIFF
--- a/tests/test_convert_salary_excel.py
+++ b/tests/test_convert_salary_excel.py
@@ -104,6 +104,42 @@ class DetectColumnTypeTests(unittest.TestCase):
                     companies[0]["categories"]["salary"], {"index": 105.5}
                 )
 
+    def test_skips_free_text_column(self):
+        # A free-text "Notes" column must not become a bogus salary category.
+        ws = FakeWorksheet([
+            ("Company", "Salary Index", "Notes"),
+            ("Example Corp", 105.5, "good"),
+        ])
+
+        companies = parse_sheet(ws)
+
+        self.assertIn("salary_index", companies[0]["categories"])
+        self.assertNotIn("notes", companies[0]["categories"])
+
+    def test_skips_numeric_identifier_column(self):
+        # A numeric "Id" column (employee id) must not be treated as a salary index.
+        ws = FakeWorksheet([
+            ("Company", "Salary Index", "Id"),
+            ("Example Corp", 105.5, 7),
+        ])
+
+        companies = parse_sheet(ws)
+
+        self.assertIn("salary_index", companies[0]["categories"])
+        self.assertNotIn("id", companies[0]["categories"])
+
+    def test_keeps_numeric_salary_column(self):
+        # A genuine numeric salary column still produces a salary category.
+        ws = FakeWorksheet([
+            ("Company", "Salary Index"),
+            ("Example Corp", 105.5),
+        ])
+
+        companies = parse_sheet(ws)
+
+        self.assertIn("salary_index", companies[0]["categories"])
+        self.assertEqual(companies[0]["categories"]["salary_index"], {"index": 105.5})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/convert_salary_excel.py
+++ b/tools/convert_salary_excel.py
@@ -48,6 +48,10 @@ INDEX_PATTERNS = {"indeks", "index", "idx", "salary", "løn", "median", "average
 # Ships populated for this repo's Danish demonstration data; a fork targeting
 # another locale edits this constant.
 COMPOUND_PATTERNS = {"antal", "indeks", "løn", "gennemsnit", "medarbejdere"}
+# Identifier columns (employee id, Danish "personnummer", etc.) are never salary
+# data. They are dropped at classification so they are not mistaken for a salary
+# category. Matched as whole tokens only, like other pattern sets.
+ID_PATTERNS = {"id", "personnummer"}
 
 
 def header_matches(header, patterns):
@@ -120,10 +124,12 @@ def parse_sheet(ws, sheet_label=None):
         print(f"Warning: Could not find company column in sheet '{ws.title}'.", file=sys.stderr)
         return []
 
-    # Identify data columns (everything that's not company/city)
+    # Identify data columns (everything that's not company/city or an identifier)
     data_cols = []
     for i, h in enumerate(headers):
         if i == company_col or i == city_col or not h:
+            continue
+        if header_matches(h, ID_PATTERNS):
             continue
         data_cols.append((i, h))
 
@@ -205,6 +211,10 @@ def parse_sheet(ws, sheet_label=None):
                         index_val = float(row[cat["index_col"]])
                     except (ValueError, TypeError):
                         pass
+                # A count/index pair that is entirely empty for this row carries
+                # no salary information, so skip it rather than emit nulls.
+                if count_val is None and index_val is None:
+                    continue
                 entry["categories"][cat_name] = {"count": count_val, "index": index_val}
             elif "value_col" in cat:
                 if cat["value_col"] < len(row) and row[cat["value_col"]] is not None:
@@ -212,7 +222,9 @@ def parse_sheet(ws, sheet_label=None):
                     try:
                         val = float(val)
                     except (ValueError, TypeError):
-                        val = str(val)
+                        # Non-numeric standalone value (e.g. a free-text "Notes"
+                        # column) is not salary data; skip it for this row.
+                        continue
                     entry["categories"][cat_name] = {"index": val}
 
         companies.append(entry)


### PR DESCRIPTION
## Summary

`tools/convert_salary_excel.py` treated **every** column that was not `company`/`city` as a salary category, with no check that the column actually held numeric salary data. This produced bogus categories:

- A free-text `"Notes"` column became `categories["notes"] = {"index": "good"}`.
- A numeric identifier `"Id"` column became `categories["id"] = {"index": 7.0}` (an employee id mistaken for a salary index).

This violates the tool's own documented contract: _"Any number of **numeric** data columns (salary index, count, etc.)"_.

## Fix

A two-layer guard, with no new dependencies:

1. **Identifier headers dropped at classification** — `ID_PATTERNS = {"id", "personnummer"}` are skipped when building the data-column list, so employee-id style columns never become categories.
2. **Row-level validation** — non-numeric standalone values (e.g. free-text `Notes`) are skipped per row, and fully-null count/index pairs are skipped instead of emitting `{"count": None, "index": None}`.

Valid numeric salary columns are untouched (proven by `keeps_numeric_salary_column`).

## Failing case & reproduction

Regression tests added to `tests/test_convert_salary_excel.py`:

- `skips_free_text_column` — `("Company","Salary Index","Notes")` expects **no** `notes` category.
- `skips_numeric_identifier_column` — `("Company","Salary Index","Id")` expects **no** `id` category.
- `keeps_numeric_salary_column` — a genuine numeric salary column still produces a category.

Verified locally: the two `skips_*` tests **fail** against `upstream/master` code and **pass** after the fix. The full suite (91 tests) plus `tools/lint_skills.py` and `tools/security_guards.py` are green.

## Relationship to other work

This is a **separate PR** from the already-submitted F1 fix (company-column *header* token detection). It targets a different concern (column *content* validation), is based on clean `upstream/master`, and shares only the test file — so it does not conflict with F1's code changes. After F1 merges, this branch can be rebased onto `upstream/master` (only the shared test file may need a trivial merge; both tests are kept).
