### PR TITLE
test(linkedin-search): offline test net for pure CLI functions (AIV-986)

### DIFF
--- a/.agents/skills/linkedin-search/cli/package.json
+++ b/.agents/skills/linkedin-search/cli/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "bun run src/cli.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {},

--- a/.agents/skills/linkedin-search/cli/src/commands/detail.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/detail.ts
@@ -6,7 +6,7 @@ export interface DetailOpts {
 }
 
 /** Accept a raw job ID, a job-view URL, or a job URN. */
-function normalizeId(input: string): string | null {
+export function normalizeId(input: string): string | null {
   const urn = input.match(/urn:li:jobPosting:(\d+)/)
   if (urn) return urn[1]
   const url = input.match(/-(\d{6,})(?:\?|$)/) || input.match(/\/(\d{6,})(?:\?|$)/)

--- a/.agents/skills/linkedin-search/cli/src/commands/search.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/search.ts
@@ -18,7 +18,7 @@ export interface SearchOpts {
   format: "json" | "table" | "plain"
 }
 
-function buildUrl(opts: SearchOpts): string {
+export function buildUrl(opts: SearchOpts): string {
   const params = new URLSearchParams()
   if (opts.query) params.set("keywords", opts.query)
   if (opts.location) params.set("location", opts.location)

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -175,7 +175,14 @@ export function parseJobDetail(html: string, id: string): JobDetail {
     const withBreaks = desc[1]
       .replace(/<\s*br\s*\/?>/gi, "\n")
       .replace(/<\/(p|li|ul|ol|div|h\d)>/gi, "\n")
-    description = decodeHtmlEntities(stripTags(withBreaks)).replace(/\n{3,}/g, "\n\n").trim() || null
+    // Strip the remaining tags but keep the newlines we just inserted. The shared
+    // stripTags() collapses *all* whitespace (\s+), which would flatten those
+    // breaks back into one line, so do a newline-preserving strip here instead.
+    const text = withBreaks
+      .replace(/<[^>]+>/g, " ")
+      .replace(/[^\S\n]+/g, " ")
+      .replace(/ *\n */g, "\n")
+    description = decodeHtmlEntities(text).replace(/\n{3,}/g, "\n\n").trim() || null
   }
 
   // Job-criteria items: subheader label -> text value.

--- a/.agents/skills/linkedin-search/cli/test/__fixtures__/README.md
+++ b/.agents/skills/linkedin-search/cli/test/__fixtures__/README.md
@@ -1,0 +1,29 @@
+# Test fixtures
+
+Real HTML captured **once** from LinkedIn's public `jobs-guest` endpoints via the
+CLI's own `htmlFetch`. These are deliberately **not** hand-written: the parsers are
+regex-based against LinkedIn's real markup, so a hand-made fixture would test our
+assumptions rather than the actual page shape.
+
+| File | Source | Captured |
+| --- | --- | --- |
+| `search-list.html` | `search --query "agentic ai engineer" --location Italy --jobage 14 --remote remote` (`seeMoreJobPostings/search`) | 2026-07-14 |
+| `detail-orbis.html` | `detail 4345841651` (`jobPosting/4345841651`) — the "Agentic AI Engineer – Full remote – Europe" @ Orbis Group posting that was still open in AIV-977 (`first_seen 2026-07-06`) | 2026-07-14 |
+
+## Regenerating
+
+Fixtures are static and versioned; regenerate only when LinkedIn's markup changes
+and a parser test starts failing for the right reason. From the `cli/` directory:
+
+```ts
+// capture.ts (throwaway)
+import { htmlFetch, SEARCH_URL, DETAIL_URL } from "./src/helpers.ts"
+await Bun.write(
+  "test/__fixtures__/search-list.html",
+  await htmlFetch(`${SEARCH_URL}?keywords=agentic%20ai%20engineer&location=Italy&f_TPR=r1209600&f_WT=2&start=0`),
+)
+await Bun.write("test/__fixtures__/detail-orbis.html", await htmlFetch(`${DETAIL_URL}/4345841651`))
+```
+
+`bun run capture.ts`, then update the expected values in the tests to match. Keep
+volume low — this hits LinkedIn's public pages (personal use only, LinkedIn ToS).

--- a/.agents/skills/linkedin-search/cli/test/__fixtures__/detail-orbis.html
+++ b/.agents/skills/linkedin-search/cli/test/__fixtures__/detail-orbis.html
@@ -1,0 +1,497 @@
+
+
+    
+<!---->    
+    
+
+    
+    <section class="top-card-layout container-lined overflow-hidden babybear:rounded-[0px]">
+        
+      
+
+      <div class="top-card-layout__card relative p-2 papabear:p-details-container-padding">
+            
+        
+      <a href="https://uk.linkedin.com/company/weareorbis?trk=public_jobs_topcard_logo" target="_self" data-tracking-control-name="public_jobs_topcard_logo" data-tracking-will-navigate>
+        
+          
+      <img class="artdeco-entity-image artdeco-entity-image--square-5
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4E0BAQFO7hIVIEAn0w/company-logo_100_100/company-logo_100_100/0/1712567869900/weareorbis_logo?e=2147483647&amp;v=beta&amp;t=dkLVUinZwTbymlqJRGiZmE_8LUnn39UQ1e-84u5GXkE" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/aajlclc14rr2scznz5qm2rj9u" alt="Orbis Group">
+  
+        
+      </a>
+  
+      
+
+          <div class="top-card-layout__entity-info-container flex flex-wrap papabear:flex-nowrap">
+            <div class="top-card-layout__entity-info flex-grow flex-shrink-0 basis-0 babybear:flex-none babybear:w-full babybear:flex-none babybear:w-full">
+                  
+          <a href="https://www.linkedin.com/jobs/view/agentic-ai-engineer-full-remote-europe-at-orbis-group-4345841651?trk=public_jobs_topcard-title" data-tracking-control-name="public_jobs_topcard-title" class="topcard__link" data-tracking-will-navigate>
+            <h2 class="top-card-layout__title font-sans text-lg papabear:text-xl font-bold leading-open text-color-text mb-0 topcard__title">Agentic AI Engineer - Full remote - Europe</h2>
+          </a>
+      
+<!---->
+<!---->
+                <h4 class="top-card-layout__second-subline font-sans text-sm leading-open text-color-text-low-emphasis mt-0.5">
+                  
+        <div class="topcard__flavor-row">
+          <span class="topcard__flavor">
+              <a class="topcard__org-name-link topcard__flavor--black-link" data-tracking-control-name="public_jobs_topcard-org-name" data-tracking-will-navigate href="https://uk.linkedin.com/company/weareorbis?trk=public_jobs_topcard-org-name" rel="noopener" target="_blank">
+                Orbis Group
+              </a>
+          </span>
+            <span class="topcard__flavor topcard__flavor--bullet">
+              European Union
+            </span>
+        </div>
+        <div class="topcard__flavor-row">
+          
+        <span class="posted-time-ago__text topcard__flavor--metadata">
+          
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      6 months ago
+  
+        </span>
+  
+          
+    
+    
+    
+
+        <figure class="num-applicants__figure topcard__flavor--metadata topcard__flavor--bullet">
+          <span class="num-applicants__icon num-applicants__icon--clock lazy-load"></span>
+          <figcaption class="num-applicants__caption">
+            Be among the first 25 applicants
+          </figcaption>
+        </figure>
+      
+        </div>
+          
+    
+
+    
+      
+    
+
+    
+      <a href="https://www.linkedin.com/login?session_redirect=https%3A%2F%2Fwww%2Elinkedin%2Ecom%2Fsearch%2Fresults%2Fpeople%2F%3FfacetCurrentCompany%3D3522089&amp;emailAddress=&amp;fromSignIn=&amp;trk=public_jobs_see-who-was-hired_people-search-link_face-pile-cta" target="_self" data-tracking-control-name="full-link" data-tracking-will-navigate class="face-pile flex !no-underline see-who-was-hired">
+        
+      <div class="face-pile__images-container self-start flex-shrink-0 mr-1 leading-[1]">
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/aemitl4w713xg3xvy9bcrecox" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/2ns9yaob5oyfsn61s7ihupvd9" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/ccme3th179hovxui57zwev0p3" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+      </div>
+        <div class="face-pile__text-container self-center">
+          <p class="face-pile__text font-sans text-sm
+              link-styled hover:underline">
+            See who Orbis Group has hired for this role
+          </p>
+<!---->        </div>
+          
+      </a>
+  
+  
+  
+  
+          
+    
+
+    <figure class="closed-job closed-job__flavor topcard__flavor-row">
+      <span class="closed-job__icon closed-job__icon--error-pebble lazy-load"></span>
+      <figcaption class="closed-job__flavor--closed">No longer accepting applications</figcaption>
+    </figure>
+  
+      
+                </h4>
+
+              <div class="top-card-layout__cta-container flex flex-wrap mt-0.5 papabear:mt-0 ml-[-12px]">
+                    
+<!---->      
+
+                    
+<!---->      
+              </div>
+            </div>
+
+<!---->          </div>
+
+          
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      <div class="ellipsis-menu absolute right-0 top-0 top-card-layout__ellipsis-menu mr-1 papabear:mt-0.5 papabear:mr-2">
+        
+
+    
+
+    <div class="collapsible-dropdown flex items-center relative hyphens-auto">
+          
+            <button class="ellipsis-menu__trigger
+                collapsible-dropdown__button btn-md btn-tertiary cursor-pointer
+                !py-[6px] !px-1 flex items-center rounded-[50%]
+                
+                " aria-expanded="false" aria-label="Open menu" data-tracking-control-name="public_jobs_ellipsis-menu-trigger" tabindex="0">
+              <icon class="ellipsis-menu__trigger-icon m-0 p-0 centered-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/671xosfpvk4c0kqtyl87hashi"></icon>
+            </button>
+          
+
+        <ul class="collapsible-dropdown__list hidden container-raised absolute w-auto overflow-y-auto flex-col items-stretch z-[9999] bottom-auto top-[100%]" role="menu" tabindex="-1">
+          
+              
+
+                <li class="ellipsis-menu__item border-t-1 border-solid border-color-border-low-emphasis first-of-type:border-none flex" role="presentation">
+                  
+
+    
+    
+
+    
+
+    
+
+    <a href="https://www.linkedin.com/help/linkedin/ask/TS-RIC-LO?entityUrn=https%3A%2F%2Fwww.linkedin.com%2Fjobs%2Fview%2Fagentic-ai-engineer-full-remote-europe-at-orbis-group-4345841651" data-tracking-control-name="public_jobs_ellipsis-menu-semaphore-sign-in-redirect" data-tracking-will-navigate data-item-type="semaphore" data-semaphore-content-type="JOB" data-semaphore-content-urn="urn:li:jobPosting:4345841651" data-semaphore-tracking-prefix="public_jobs_ellipsis-menu-semaphore" data-is-logged-in="false" data-modal="semaphore__toggle" class="semaphore__toggle visited:text-color-text-secondary ellipsis-menu__semaphore ellipsis-menu__item-button flex items-center w-full p-1 cursor-pointer font-sans text-sm font-bold link-styled focus:link-styled link:no-underline active:bg-color-background-container-tint focus:bg-color-background-container-tint hover:bg-color-background-container-tint outline-offset-[-2px]" role="menuitem">
+<!---->        
+                      <icon class="ellipsis-menu__item-icon text-color-text h-[24px] w-[24px] mr-1" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/iq0x9q37wj214o129ai1yjut">
+                      </icon>
+                      Report this job
+                    
+    </a>
+
+<!---->  
+                </li>
+<!---->          
+        </ul>
+
+<!---->    </div>
+  
+
+      </div>
+  
+
+<!---->      </div>
+    </section>
+  
+  
+
+    <div class="decorated-job-posting__details">
+<!---->
+      
+    
+    
+    
+    
+    
+
+    
+    <section class="core-section-container
+        my-3 description">
+<!---->
+<!---->
+<!---->
+      <div class="core-section-container__content break-words">
+        
+      
+    
+    
+
+      <div class="message-the-recruiter">
+        <p>Direct message the job poster from Orbis Group</p>
+        
+    
+    
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-main-card flex flex-wrap py-1.5 pr-2 babybear:pr-0
+        
+        base-main-card--link
+        ">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://uk.linkedin.com/in/a2stom" data-tracking-control-name="public_jobs" data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+          
+        Tom Jeffs
+
+<!---->      
+      
+          </span>
+        </a>
+
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-6 h-6
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D5603AQHXVABPHrjkyQ/profile-displayphoto-scale_400_400/B56ZyE7ndNKMAg-/0/1771756747364?e=2147483647&amp;v=beta&amp;t=-nIR9_EW9aHYYAZS5wQ5InR0nNl60G-9w29p4OEF1Sk" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt="Click here to view Tom Jeffs’ profile">
+      
+
+        <div class="base-main-card__info self-center ml-1 flex-1 relative break-words papabear:min-w-0 mamabear:min-w-0 babybear:w-full
+            ">
+<!---->          <h3 class="base-main-card__title line-clamp-1 font-sans text-md font-bold text-color-text overflow-hidden
+              
+              
+              base-main-card__title--link">
+            
+        Tom Jeffs
+
+<!---->      
+          </h3>
+          
+
+            <h4 class="base-main-card__subtitle body-text text-color-text overflow-hidden
+                ">
+              
+          💼 Talent Sourcer | 🧠 Recovery Coach | Founder @ A2S &amp; TJS
+      
+            </h4>
+
+<!---->
+<!----><!---->        </div>
+
+          <div class="base-main-card__ctas z-[3] self-center ml-3 babybear:ml-1 babybear:self-start">
+            
+        
+            <a aria-label="Message Tom Jeffs" class="message-the-recruiter__cta" href="https://www.linkedin.com/login?emailAddress=&amp;fromSignIn=&amp;session_redirect=https%3A%2F%2Fuk.linkedin.com%2Fin%2Fa2stom&amp;trk=public_jobs_message-the-recruiter-cta" data-tracking-control-name="public_jobs_message-the-recruiter-cta" data-tracking-will-navigate>
+              <icon class="message-the-recruiter__cta-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/em62t8ujch4hqqc45owxy6auu" data-tracking-will-navigate></icon>
+            </a>
+          
+      
+          </div>
+      
+    
+      </div>
+  
+  
+  
+  
+      </div>
+  
+
+      <div class="description__text description__text--rich">
+        
+    
+    
+    
+
+    <section class="show-more-less-html" data-max-lines="5">
+        <div class="show-more-less-html__markup show-more-less-html__markup--clamp-after-5
+            relative overflow-hidden">
+          <p><strong>Agentic AI Engineer - Full remote - Europe</strong></p><p><br></p><p>Our SaaS client based in The Netherlands are in need of a number of AI Engineers who can design, build and deploy agentic systems to their customers.</p><p><br></p><p>This is a hands-on engineering role, focused on turning ideas into fast POCs and then scaling them into production-ready systems.</p><p><br></p><p><u>What you’ll be doing:</u></p><ul><li>Designing and building agentic &amp; multi-agent systems</li><li>Developing high-performance APIs that power AI agents at scale</li><li>Improving agent performance, responsiveness and reliability</li><li>Collaborating closely with Product to deliver quick POCs and iterate fast</li><li>Deploying AI systems into production using the Azure ecosystem</li><li>Making smart technical trade-offs and clearly explaining them to stakeholders</li></ul><p><br></p><p><u>Tech environment:</u></p><ul><li>Python / Kotlin</li><li>Azure (DevOps, backend services, AI services)</li><li>API-driven architectures</li><li>Agentic / multi-agent systems</li><li>Scalable backend &amp; cloud deployments</li></ul><p><br></p><p><u>What we’re looking for:</u></p><ul><li>Strong experience as an AI Engineer / Backend Engineer</li><li>Proven work with agentic or multi-agent systems</li><li>Solid API development experience at scale</li><li>Comfortable deploying and operating systems in Azure</li><li>Able to explain how agents perform, scale and improve particularly with technical and non-technical stakeholders</li><li>Someone who can deliver fast POCs and think long-term</li></ul><p><br></p><p>Location : Fully remote (Europe)</p><p>Duration : 3-month rolling contract</p><p>Headcount : 2</p><p>Rate : €375 - 400 a day</p><p><br></p><p>If this sounds like you, or you know someone who fits, drop me a message and I’ll share more details.</p>
+        </div>
+
+        
+
+    
+    
+    
+
+    <button class="show-more-less-html__button show-more-less-button
+        show-more-less-html__button--more
+        ml-0.5" data-tracking-control-name="public_jobs_show-more-html-btn" aria-label="Show more" aria-expanded="false">
+<!---->
+        
+            Show more
+          
+
+          <icon class="show-more-less-html__button-icon show-more-less-button-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/cyolgscd0imw2ldqppkrb84vo"></icon>
+    </button>
+  
+
+        
+
+    
+    
+    
+
+    <button class="show-more-less-html__button show-more-less-button
+        show-more-less-html__button--less
+        ml-0.5" data-tracking-control-name="public_jobs_show-less-html-btn" aria-label="Show less" aria-expanded="true">
+<!---->
+        
+            Show less
+          
+
+          <icon class="show-more-less-html__button-icon show-more-less-button-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/4chtt12k98xwnba1nimld2oyg"></icon>
+    </button>
+  
+<!---->    </section>
+  
+      </div>
+
+      <ul class="description__job-criteria-list">
+        <li class="description__job-criteria-item">
+          <h3 class="description__job-criteria-subheader">
+            Seniority level
+          </h3>
+          <span class="description__job-criteria-text description__job-criteria-text--criteria">
+            Mid-Senior level
+          </span>
+        </li>
+        <li class="description__job-criteria-item">
+          <h3 class="description__job-criteria-subheader">
+            Employment type
+          </h3>
+          <span class="description__job-criteria-text description__job-criteria-text--criteria">
+            Contract
+          </span>
+        </li>
+          <li class="description__job-criteria-item">
+            <h3 class="description__job-criteria-subheader">
+              Job function
+            </h3>
+            <span class="description__job-criteria-text description__job-criteria-text--criteria">
+              Information Technology
+            </span>
+          </li>
+          <li class="description__job-criteria-item">
+            <h3 class="description__job-criteria-subheader">
+              Industries
+            </h3>
+            <span class="description__job-criteria-text description__job-criteria-text--criteria">
+            Technology, Information and Media
+            </span>
+          </li>
+      </ul>
+    
+      </div>
+    </section>
+  
+  
+
+        
+    
+
+    
+
+      
+    <section class="core-section-container
+        my-3 find-a-referral">
+<!---->
+<!---->
+<!---->
+      <div class="core-section-container__content break-words">
+        
+        
+      
+    
+
+    
+      <div class="face-pile flex !no-underline">
+        
+      <div class="face-pile__images-container self-start flex-shrink-0 mr-1 leading-[1]">
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/bdn0lfh0ybw8v8uvyqz35l06l" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/c090wioxqh0gduwjdkzvfj7j7" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/cb4flmlee1eo4dfd0sjdwrmt3" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+      </div>
+        
+          
+            <div class="find-a-referral__cta-container">
+              <p>Referrals increase your chances of interviewing at Orbis Group by 2x</p>
+              <a class="find-a-referral__cta" href="https://www.linkedin.com/login?session_redirect=https%3A%2F%2Fwww%2Elinkedin%2Ecom%2Fsearch%2Fresults%2Fpeople%2F%3FfacetCurrentCompany%3D3522089&amp;emailAddress=&amp;fromSignIn=&amp;trk=public_jobs_find-a-referral-cta" data-impression-id="public_jobs_find-a-referral-cta" data-tracking-control-name="public_jobs_find-a-referral-cta" data-tracking-will-navigate>
+                See who you know
+              </a>
+            </div>
+          
+        
+    
+      </div>
+  
+  
+  
+      
+      </div>
+    </section>
+  
+  
+
+<!---->    </div>
+
+<!---->
+<!---->
+    <code id="decoratedJobPostingId" style="display: none"><!--"4345841651"--></code>
+      <code id="referenceId" style="display: none"><!--"d2TOUsiYRiOc2MQZAOTwuA=="--></code>
+    <code id="joinUrlWithRedirect" style="display: none"><!--"https://www.linkedin.com/signup/cold-join?source=jobs_registration&session_redirect=https%3A%2F%2Fwww.linkedin.com%2Fjobs%2Fview%2Fagentic-ai-engineer-full-remote-europe-at-orbis-group-4345841651%3Fguest-to-member-job-apply%3Denabled"--></code>
+  
+  

--- a/.agents/skills/linkedin-search/cli/test/__fixtures__/search-list.html
+++ b/.agents/skills/linkedin-search/cli/test/__fixtures__/search-list.html
@@ -1,0 +1,1163 @@
+<!DOCTYPE html>
+
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4425498329" data-impression-id="jobs-search-result-0" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="xlkXMyr4ByKPoDagDz77pg==" data-column="1" data-row="1">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/artificial-intelligence-engineer-at-humans-tech-4425498329?position=1&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=xlkXMyr4ByKPoDagDz77pg%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Artificial Intelligence Engineer
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4D0BAQGzAG6Xx3nmcA/company-logo_100_100/company-logo_100_100/0/1703243057096/wearekromin_logo?e=2147483647&amp;v=beta&amp;t=zaP3tbQvW4WbshE93SaJi-v-NuDmtSlfvCz7lr6xXCE" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Artificial Intelligence Engineer
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/wearehumanstech?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Humans.tech
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+      <div class="job-posting-benefits text-sm">
+        <icon class="job-posting-benefits__icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/3p1v0uhy7uq0cm5zdvzp4eo18" data-svg-class-name="job-posting-benefits__icon-svg"></icon>
+        <span class="job-posting-benefits__text">
+          Actively Hiring
+<!---->        </span>
+      </div>
+  
+
+          <time class="job-search-card__listdate" datetime="2026-07-10">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      4 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4425494976" data-impression-id="jobs-search-result-1" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="qBQxhsuHhbnEPiON5x8+yQ==" data-column="1" data-row="2">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/machine-learning-engineer-at-humans-tech-4425494976?position=2&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=qBQxhsuHhbnEPiON5x8%2ByQ%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Machine Learning Engineer
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4D0BAQGzAG6Xx3nmcA/company-logo_100_100/company-logo_100_100/0/1703243057096/wearekromin_logo?e=2147483647&amp;v=beta&amp;t=zaP3tbQvW4WbshE93SaJi-v-NuDmtSlfvCz7lr6xXCE" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Machine Learning Engineer
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/wearehumanstech?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Humans.tech
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+      <div class="job-posting-benefits text-sm">
+        <icon class="job-posting-benefits__icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/3p1v0uhy7uq0cm5zdvzp4eo18" data-svg-class-name="job-posting-benefits__icon-svg"></icon>
+        <span class="job-posting-benefits__text">
+          Actively Hiring
+<!---->        </span>
+      </div>
+  
+
+          <time class="job-search-card__listdate" datetime="2026-07-10">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      4 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4435670877" data-impression-id="jobs-search-result-2" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="KVB5kc/MMlBKYWpWrOuhmQ==" data-column="1" data-row="3">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/machine-learning-engineer-100%25-remote-at-vita-health-4435670877?position=3&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=KVB5kc%2FMMlBKYWpWrOuhmQ%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Machine Learning Engineer- (100% Remote)
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D560BAQHIAjvxxraCbA/company-logo_100_100/B56Z6DgbsoH0AI-/0/1780322778203/vitameals_logo?e=2147483647&amp;v=beta&amp;t=jkez8J4PVjyzUGCZ0f7pB_SwNVDauohLjw5Br_lUh6w" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Machine Learning Engineer- (100% Remote)
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/vitameals?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Vita Health
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+<!---->  
+
+          <time class="job-search-card__listdate" datetime="2026-07-09">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      4 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4416626491" data-impression-id="jobs-search-result-3" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="01FhP9tywIWso3qk6957VQ==" data-column="1" data-row="4">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/senior-ai-full-stack-engineer-freelance-at-bitrock-4416626491?position=4&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=01FhP9tywIWso3qk6957VQ%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Senior AI/Full Stack Engineer - Freelance
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/C4D0BAQEryl5zoRPAdA/company-logo_100_100/company-logo_100_100/0/1630558667466/bitrock_srl_logo?e=2147483647&amp;v=beta&amp;t=diHNLEHAfR2sX1NxMhBZvDSa7KCyCTKg9G_g69xx8XA" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Senior AI/Full Stack Engineer - Freelance
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/bitrock-srl?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Bitrock
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+<!---->  
+
+          <time class="job-search-card__listdate" datetime="2026-07-10">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      4 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4429996601" data-impression-id="jobs-search-result-4" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="jg/ag5m82Zusxbk1xf/P0w==" data-column="1" data-row="5">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/ai-cloud-engineer-at-mc-engineering-4429996601?position=5&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=jg%2Fag5m82Zusxbk1xf%2FP0w%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        AI / Cloud Engineer
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4E0BAQGP-mV2vWJ6Aw/company-logo_100_100/company-logo_100_100/0/1721397588306/mcengineering_logo?e=2147483647&amp;v=beta&amp;t=NAtS1EWHMItVkDBGzuziXpEfIK3dgYKS75lxWbWYYcs" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        AI / Cloud Engineer
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/mcengineering?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            MC Engineering
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+<!---->  
+
+          <time class="job-search-card__listdate" datetime="2026-07-09">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      4 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4427014306" data-impression-id="jobs-search-result-5" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="0YodTRXsxhcBa9M+thqOAA==" data-column="1" data-row="6">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/ai-engineer-production-ai-agentic-systems-full-remote-at-techyon-4427014306?position=6&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=0YodTRXsxhcBa9M%2BthqOAA%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        AI ENGINEER | PRODUCTION AI &amp; AGENTIC SYSTEMS | FULL REMOTE
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/C560BAQHXCcWkyTZT1g/company-logo_100_100/company-logo_100_100/0/1630671881172/techyon_recruitment_logo?e=2147483647&amp;v=beta&amp;t=Sg9ouOw478fHiIafL6-TwkM4LDoExDLgiIvpluw-cz8" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        AI ENGINEER | PRODUCTION AI &amp; AGENTIC SYSTEMS | FULL REMOTE
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/techyon-recruitment?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Techyon
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+<!---->  
+
+          <time class="job-search-card__listdate" datetime="2026-07-02">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      1 week ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4425603038" data-impression-id="jobs-search-result-6" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="erbTwKzjPS4Sziegp8SM8A==" data-column="1" data-row="7">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/senior-machine-learning-engineer-at-humans-tech-4425603038?position=7&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=erbTwKzjPS4Sziegp8SM8A%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Senior Machine Learning Engineer
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4D0BAQGzAG6Xx3nmcA/company-logo_100_100/company-logo_100_100/0/1703243057096/wearekromin_logo?e=2147483647&amp;v=beta&amp;t=zaP3tbQvW4WbshE93SaJi-v-NuDmtSlfvCz7lr6xXCE" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Senior Machine Learning Engineer
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://it.linkedin.com/company/wearehumanstech?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Humans.tech
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+      <div class="job-posting-benefits text-sm">
+        <icon class="job-posting-benefits__icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/3p1v0uhy7uq0cm5zdvzp4eo18" data-svg-class-name="job-posting-benefits__icon-svg"></icon>
+        <span class="job-posting-benefits__text">
+          Actively Hiring
+<!---->        </span>
+      </div>
+  
+
+          <time class="job-search-card__listdate" datetime="2026-07-10">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      4 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4438202431" data-impression-id="jobs-search-result-7" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="F6HK+W7SnzyLDzB1bRueLg==" data-column="1" data-row="8">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/conversational-ai-application-developer-english-and-spanish-speaker-at-omilia-4438202431?position=8&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=F6HK%2BW7SnzyLDzB1bRueLg%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Conversational AI Application Developer (English and Spanish speaker)
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4D0BAQFIufpbG2XbmQ/company-logo_100_100/B4DZZsD4dRGsAQ-/0/1745569680947/omilia_ltd_logo?e=2147483647&amp;v=beta&amp;t=CLG8u2CBgAHfvkFeh9nntZLRURHXdwxn7ACWk-qBC-I" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Conversational AI Application Developer (English and Spanish speaker)
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://cy.linkedin.com/company/omilia-ltd?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Omilia
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+      <div class="job-posting-benefits text-sm">
+        <icon class="job-posting-benefits__icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/8zmuwb93gzlb935fk4ao4z779" data-svg-class-name="job-posting-benefits__icon-svg"></icon>
+        <span class="job-posting-benefits__text">
+          Be an early applicant
+<!---->        </span>
+      </div>
+  
+
+          <time class="job-search-card__listdate" datetime="2026-07-08">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      5 days ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4437449942" data-impression-id="jobs-search-result-8" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="sO3VxWAQ6WaBhjgvx+KioA==" data-column="1" data-row="9">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/senior-ai-engineer-at-ruby-labs-4437449942?position=9&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=sO3VxWAQ6WaBhjgvx%2BKioA%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Senior AI Engineer
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4D0BAQHag218ZcBdPQ/company-logo_100_100/B4DZYalhpnGkBE-/0/1744202767362/rlabs_company_logo?e=2147483647&amp;v=beta&amp;t=vpCi68KVK4yhmsME2OjDqFKjbETBsRMlUZSzaHk5Q-4" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Senior AI Engineer
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://www.linkedin.com/company/rlabs-company?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Ruby Labs
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Meolo, Veneto, Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+      <div class="job-posting-benefits text-sm">
+        <icon class="job-posting-benefits__icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/8zmuwb93gzlb935fk4ao4z779" data-svg-class-name="job-posting-benefits__icon-svg"></icon>
+        <span class="job-posting-benefits__text">
+          Be an early applicant
+<!---->        </span>
+      </div>
+  
+
+          <time class="job-search-card__listdate" datetime="2026-07-06">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      1 week ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+      <li>
+        
+    
+
+    
+    
+    
+      <div class="base-card relative w-full hover:no-underline focus:no-underline
+        base-card--link
+         base-search-card base-search-card--link job-search-card" data-entity-urn="urn:li:jobPosting:4436355022" data-impression-id="jobs-search-result-9" data-reference-id="rgFs/22WxICKVQ1aeDSZxA==" data-tracking-id="8UZxkyTMCBNbD6dA2z7hGA==" data-column="1" data-row="10">
+        
+
+        <a class="base-card__full-link absolute top-0 right-0 bottom-0 left-0 p-0 z-[2] outline-offset-[4px]" href="https://it.linkedin.com/jobs/view/senior-ai-engineer-at-jimdo-4436355022?position=10&amp;pageNum=0&amp;refId=rgFs%2F22WxICKVQ1aeDSZxA%3D%3D&amp;trackingId=8UZxkyTMCBNbD6dA2z7hGA%3D%3D" data-tracking-control-name="public_jobs_jserp-result_search-card" data-tracking-client-ingraph data-tracking-will-navigate>
+          
+          <span class="sr-only">
+              
+        
+        Senior AI Engineer
+      
+      
+          </span>
+        </a>
+
+      
+        
+    <div class="search-entity-media">
+        
+      <img class="artdeco-entity-image artdeco-entity-image--square-4
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4E0BAQEUHHBYkA68Ag/company-logo_100_100/company-logo_100_100/0/1725582343009/jimdo_logo?e=2147483647&amp;v=beta&amp;t=j7d-kkgc_tNPK0dDdPaiKKM40aOIuHVr0OLydwJWL_U" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/6puxblwmhnodu6fjircz4dn4h" alt>
+  
+    </div>
+  
+
+        <div class="base-search-card__info">
+          <h3 class="base-search-card__title">
+            
+        Senior AI Engineer
+      
+          </h3>
+
+            <h4 class="base-search-card__subtitle">
+              
+          <a class="hidden-nested-link" data-tracking-client-ingraph data-tracking-control-name="public_jobs_jserp-result_job-search-card-subtitle" data-tracking-will-navigate href="https://de.linkedin.com/company/jimdo?trk=public_jobs_jserp-result_job-search-card-subtitle">
+            Jimdo
+          </a>
+      
+            </h4>
+
+<!---->
+            <div class="base-search-card__metadata">
+              
+          <span class="job-search-card__location">
+            Italy
+          </span>
+
+        
+    
+    
+    
+    
+
+<!---->  
+
+          <time class="job-search-card__listdate" datetime="2026-07-02">
+            
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      1 week ago
+  
+          </time>
+
+<!---->      
+            </div>
+        </div>
+<!---->      
+    
+      </div>
+  
+  
+  
+  
+      </li>
+  

--- a/.agents/skills/linkedin-search/cli/test/detail.test.ts
+++ b/.agents/skills/linkedin-search/cli/test/detail.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeId } from "../src/commands/detail.ts"
+
+describe("normalizeId", () => {
+  test("accepts a bare numeric id", () => {
+    expect(normalizeId("4345841651")).toBe("4345841651")
+  })
+
+  test("extracts the id from a jobs/view URL", () => {
+    expect(
+      normalizeId(
+        "https://www.linkedin.com/jobs/view/agentic-ai-engineer-full-remote-europe-at-orbis-group-4345841651",
+      ),
+    ).toBe("4345841651")
+  })
+
+  test("extracts the id from a jobs/view URL with a query string", () => {
+    expect(
+      normalizeId("https://www.linkedin.com/jobs/view/4345841651?refId=abc"),
+    ).toBe("4345841651")
+  })
+
+  test("extracts the id from a job-posting URN", () => {
+    expect(normalizeId("urn:li:jobPosting:4345841651")).toBe("4345841651")
+  })
+
+  test("returns null when no id can be parsed", () => {
+    expect(normalizeId("not-a-job")).toBeNull()
+    expect(normalizeId("")).toBeNull()
+    expect(normalizeId("12345")).toBeNull() // too short to be a job id
+  })
+})

--- a/.agents/skills/linkedin-search/cli/test/helpers.test.ts
+++ b/.agents/skills/linkedin-search/cli/test/helpers.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test"
+import {
+  parseJobCards,
+  parseJobDetail,
+  jobageToTPR,
+  workTypeFlag,
+} from "../src/helpers.ts"
+
+const SEARCH_HTML = await Bun.file(
+  new URL("./__fixtures__/search-list.html", import.meta.url),
+).text()
+const DETAIL_HTML = await Bun.file(
+  new URL("./__fixtures__/detail-orbis.html", import.meta.url),
+).text()
+
+describe("parseJobCards", () => {
+  const cards = parseJobCards(SEARCH_HTML)
+
+  test("extracts every card in the search list", () => {
+    expect(cards).toHaveLength(10)
+  })
+
+  test("maps id / title / company / location / date / url for a card", () => {
+    // First card in the captured fixture.
+    expect(cards[0]).toEqual({
+      id: "4425498329",
+      title: "Artificial Intelligence Engineer",
+      company: "Humans.tech",
+      companyUrl: "https://it.linkedin.com/company/wearehumanstech",
+      location: "Italy",
+      date: "2026-07-10",
+      url: "https://it.linkedin.com/jobs/view/artificial-intelligence-engineer-at-humans-tech-4425498329",
+    })
+  })
+
+  test("every card has a numeric id and a job-view url", () => {
+    for (const c of cards) {
+      expect(c.id).toMatch(/^\d+$/)
+      expect(c.url).toContain("/jobs/view/")
+    }
+  })
+
+  test("a malformed card does not break the rest", () => {
+    // A card whose chunk has no numeric id and no title: it must be skipped
+    // (parsing is chunk-independent) without throwing or dropping good cards.
+    const broken =
+      '<li><div data-entity-urn="urn:li:jobPosting:not-a-number">' +
+      '<h3 class="base-search-card__title">ignored</h3></div></li>'
+    const withBroken = parseJobCards(SEARCH_HTML + broken)
+    expect(withBroken).toHaveLength(10)
+    expect(withBroken.map((c) => c.id)).toEqual(cards.map((c) => c.id))
+  })
+
+  test("a card missing its title is skipped, later cards still parse", () => {
+    // Malformed chunk in the *middle*: valid id, no title -> skipped; the good
+    // card that follows must still come through.
+    const good = parseJobCards(SEARCH_HTML)[0]
+    const titleless = 'data-entity-urn="urn:li:jobPosting:9999999999"><li></li>'
+    const spliced = SEARCH_HTML.replace(
+      'data-entity-urn="urn:li:jobPosting:',
+      titleless + 'data-entity-urn="urn:li:jobPosting:',
+    )
+    const out = parseJobCards(spliced)
+    expect(out).toHaveLength(10)
+    expect(out[0]).toEqual(good)
+  })
+
+  test("returns an empty array for HTML with no cards", () => {
+    expect(parseJobCards("<html><body>nothing here</body></html>")).toEqual([])
+  })
+})
+
+describe("parseJobDetail", () => {
+  const job = parseJobDetail(DETAIL_HTML, "4345841651")
+
+  test("extracts the core fields", () => {
+    expect(job.id).toBe("4345841651")
+    expect(job.title).toBe("Agentic AI Engineer - Full remote - Europe")
+    expect(job.company).toBe("Orbis Group")
+    expect(job.companyUrl).toBe("https://uk.linkedin.com/company/weareorbis")
+    expect(job.location).toBe("European Union")
+    expect(job.url).toBe("https://www.linkedin.com/jobs/view/4345841651")
+  })
+
+  test("extracts the job criteria", () => {
+    expect(job.seniority).toBe("Mid-Senior level")
+    expect(job.employmentType).toBe("Contract")
+    expect(job.jobFunction).toBe("Information Technology")
+    expect(job.industries).toBe("Technology, Information and Media")
+  })
+
+  test("preserves paragraph breaks in the description as newlines", () => {
+    expect(job.description).toBeTruthy()
+    expect(job.description).toContain("\n")
+    // Distinct paragraphs must stay on distinct lines, not collapse into one.
+    const lines = job.description!.split("\n").filter((l) => l.trim())
+    expect(lines.length).toBeGreaterThan(1)
+    // Content from separate paragraphs of the real posting.
+    expect(job.description).toContain(
+      "Our SaaS client based in The Netherlands",
+    )
+    expect(job.description).toContain("€375 - 400 a day")
+    // No run of tags left behind, no 3+ blank lines.
+    expect(job.description).not.toContain("<")
+    expect(job.description).not.toMatch(/\n{3,}/)
+  })
+
+  test("applyUrl is null when the posting only offers in-platform apply", () => {
+    // This Orbis posting renders a login-gated apply button, not an outbound
+    // apply link, so there is no URL to surface. See NOTE in the test file.
+    expect(job.applyUrl).toBeNull()
+  })
+
+  test("degrades gracefully on empty markup", () => {
+    const empty = parseJobDetail("", "123456")
+    expect(empty.id).toBe("123456")
+    expect(empty.title).toBe("(untitled)")
+    expect(empty.description).toBeNull()
+    expect(empty.seniority).toBeNull()
+  })
+})
+
+// NOTE on applyUrl: across the 10 real target jobs captured on 2026-07-14, none
+// exposed an outbound apply URL — LinkedIn's guest detail pages now render an
+// in-platform <button> (apply is behind login), so parseJobDetail's
+// `topcard__link[href]` selector matched nothing and applyUrl was null for all
+// of them. The tests lock in that real behavior. A fixture that *does* carry an
+// outbound apply link (an "offsite apply" posting) should be added if/when one
+// is captured, to also cover the non-null extraction path. See AIV-986 report.
+
+describe("jobageToTPR", () => {
+  test("maps day windows to f_TPR seconds", () => {
+    expect(jobageToTPR(1)).toBe("r86400")
+    expect(jobageToTPR(7)).toBe("r604800")
+    expect(jobageToTPR(14)).toBe("r1209600")
+    expect(jobageToTPR(30)).toBe("r2592000")
+  })
+
+  test("returns null for the sentinel / out-of-range values", () => {
+    expect(jobageToTPR(0)).toBeNull()
+    expect(jobageToTPR(9999)).toBeNull()
+    expect(jobageToTPR(-5)).toBeNull()
+  })
+})
+
+describe("workTypeFlag", () => {
+  test("maps workplace modes to f_WT flags", () => {
+    expect(workTypeFlag("remote")).toBe("2")
+    expect(workTypeFlag("hybrid")).toBe("3")
+    expect(workTypeFlag("onsite")).toBe("1")
+    expect(workTypeFlag("on-site")).toBe("1")
+  })
+
+  test("is case-insensitive", () => {
+    expect(workTypeFlag("Remote")).toBe("2")
+    expect(workTypeFlag("HYBRID")).toBe("3")
+  })
+
+  test("returns null for unknown or missing modes", () => {
+    expect(workTypeFlag("anywhere")).toBeNull()
+    expect(workTypeFlag("")).toBeNull()
+    expect(workTypeFlag(undefined)).toBeNull()
+  })
+})

--- a/.agents/skills/linkedin-search/cli/test/search.test.ts
+++ b/.agents/skills/linkedin-search/cli/test/search.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { buildUrl, type SearchOpts } from "../src/commands/search.ts"
+
+function params(opts: Partial<SearchOpts>): URLSearchParams {
+  const full: SearchOpts = {
+    location: "Italy",
+    jobage: 9999,
+    page: 1,
+    format: "json",
+    ...opts,
+  }
+  return new URL(buildUrl(full)).searchParams
+}
+
+describe("buildUrl", () => {
+  test("composes keywords / location / f_TPR / f_WT / start", () => {
+    const p = params({
+      query: "agentic ai engineer",
+      location: "Milan, Italy",
+      jobage: 14,
+      remote: "remote",
+      page: 1,
+    })
+    expect(p.get("keywords")).toBe("agentic ai engineer")
+    expect(p.get("location")).toBe("Milan, Italy")
+    expect(p.get("f_TPR")).toBe("r1209600")
+    expect(p.get("f_WT")).toBe("2")
+    expect(p.get("start")).toBe("0")
+  })
+
+  test("start is (page - 1) * 10", () => {
+    expect(params({ page: 1 }).get("start")).toBe("0")
+    expect(params({ page: 2 }).get("start")).toBe("10")
+    expect(params({ page: 5 }).get("start")).toBe("40")
+  })
+
+  test("omits f_TPR when jobage is the all-time sentinel", () => {
+    expect(params({ jobage: 9999 }).has("f_TPR")).toBe(false)
+    expect(params({ jobage: 0 }).has("f_TPR")).toBe(false)
+  })
+
+  test("omits f_WT when the workplace mode is unknown or unset", () => {
+    expect(params({ remote: "anywhere" }).has("f_WT")).toBe(false)
+    expect(params({ remote: undefined }).has("f_WT")).toBe(false)
+    expect(params({ remote: "hybrid" }).get("f_WT")).toBe("3")
+  })
+
+  test("omits keywords when no query is given", () => {
+    expect(params({ query: undefined }).has("keywords")).toBe(false)
+  })
+
+  test("targets the public seeMoreJobPostings search endpoint", () => {
+    const url = buildUrl({
+      location: "Italy",
+      jobage: 9999,
+      page: 1,
+      format: "json",
+    })
+    expect(url).toContain(
+      "linkedin.com/jobs-guest/jobs/api/seeMoreJobPostings/search",
+    )
+  })
+})

--- a/.claude/skills/job-application-assistant/01-candidate-profile.md
+++ b/.claude/skills/job-application-assistant/01-candidate-profile.md
@@ -4,57 +4,79 @@
 <!-- After running /setup, all sections will be filled with your actual information -->
 
 ## Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_ADDRESS]
-- **Phone:** [YOUR_PHONE]
-- **Email:** [YOUR_EMAIL]
-- **LinkedIn:** [YOUR_LINKEDIN_URL]
-- **GitHub:** [YOUR_GITHUB_URL]
-- **Languages:** [YOUR_LANGUAGES with proficiency levels]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
+- **Name:** Simone Alberucci
+- **Location:** Sanremo, Liguria, Italy
+- **Phone:** +39 379 100 3477
+- **Email:** simonealberucci@gmail.com
+- **LinkedIn:** https://linkedin.com/in/simone-alberucci
+- **GitHub:** [YOUR_GITHUB_URL] <!-- user has one but wants to clean it up before sharing - revisit later -->
+- **Languages:** Italian (native), English (B2, professional working proficiency), French (basic)
+- **Status:** Employed (GenAI/Backend Developer at Graziano Ricami), open to new opportunities
+- **Constraints:** Remote-first; open to on-site presence a few days per month, not full relocation
 
 ## Education
 
 | Degree | Period | Institution | Key Topics |
 |--------|--------|-------------|------------|
-| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+| Master in AI Development (Agentic AI specialization) | 2025 | Profession AI | Agentic AI systems |
+| Master in AI Engineering | 2024 | Profession AI | AI engineering fundamentals |
+| Percorso AI | 2024 | DataMaster | Agentic AI, LangChain, LangGraph |
 
 ## Professional Experience
 
-### [JOB_TITLE] - [COMPANY] ([START] - [END])
-[LOCATION]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+### GenAI / Backend Developer - Graziano Ricami (October 2025 - Present)
+Sanremo, Liguria, Italy
+- Designed and built a multi-tenant, multi-vertical SaaS platform (embroidery and knitwear) for the fashion industry, with a Python (FastAPI) backend deployed on Google Cloud
+- Integrated Google ADK agents and generative capabilities into the product, with Label Studio as the source of truth for data
+- Built semantic text and visual search over the archive, segmented by vertical and tenant, using Gemini Embeddings and the Qdrant vector database
+- Built image generation/editing features (editing an embroidery or knitwear design) based on Gemini 2.5 Flash
+- Built an automated tagging pipeline applying each vertical/tenant's taxonomy, based on Gemini Flash-Lite, with a quality evaluation component
+- Managed multi-tenancy and data isolation to support multiple clients on shared infrastructure
 
-<!-- Add more roles as needed -->
+### GenAI Developer, Multimodal RAG & MCP - Graziano Ricami (August 2025 - October 2025)
+Sanremo, Liguria, Italy
+- Developed an agentic RAG system with Google ADK and an MCP toolbox for natural-language search over an embroidery archive
+- Implemented the Python (FastAPI) backend for query orchestration and search API exposure
+- Used Qdrant as the vector database for semantic and multimodal retrieval
+- Designed secure, controlled queries against a Google Cloud database via Model Context Protocol, compliant with client policies
+- Built a multimodal search module (text-to-image and image-to-image) with Jina v4, enabling visual retrieval over the archive
+
+### AI Engineer, Agentic AI Systems - Telco client under NDA, via Operatore Telefonico (May 2025 - July 2025)
+Sanremo, Liguria, Italy
+- Designed and implemented a multi-agent orchestrator based on Google ADK for intelligent customer care, routing requests to the most appropriate tool based on intent
+- Developed the Python (FastAPI) backend exposing the RAG pipeline, called by the agent as a tool for accurate, contextualized responses
+- Integrated access to a SQL database via an MCP toolbox as an alternative data source depending on request type
+- Worked on evaluating and improving response quality, reducing manual intervention on repetitive requests through agentic automation and LLMs
 
 ## Independent Projects
 <!-- Projects outside of employment: freelance, open source, personal -->
-- **[PROJECT_NAME]**: [DESCRIPTION]
+- **Multimodal virtual finance agent**: AI system processing text and visual input for financial analysis and advice, orchestrating heterogeneous tools
+- **Meeting summary agent (LangChain + OpenAI)**: pipeline for automatic transcript summarization with context retention across long conversations
+- **ML systems productionization**: deployed classification and regression models as production-ready APIs
+- **CNN for animal recognition (automotive)**: convolutional neural network for identifying animals in autonomous-driving scenarios
 
 ## Technical Skills
 
 ### Programming & ML
-- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
-- [OTHER_SKILLS]
+- **Python** (Advanced): FastAPI, Flask, PyTorch, Scikit-learn, Pandas
+- LangChain, LangGraph, Google ADK
 
 ### Domain Expertise
-- [DOMAIN_1]
-- [DOMAIN_2]
+- Agentic AI / Multi-Agent Systems
+- Retrieval-Augmented Generation (RAG), including multimodal retrieval
+- Generative AI product development, prototype to production
+- Multi-tenant SaaS architecture
 
 ### Software & Tools
-- [TOOL_LIST]
+- Google ADK, MCP (Model Context Protocol), Gemini (2.5 Flash, Flash-Lite), Gemini Embeddings, Qdrant, Jina v4, Google Cloud (Vertex AI), Label Studio, Keycloak, OpenAI API
 
 ## Publications
-<!-- List peer-reviewed publications, if any -->
-1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+No publications yet.
 
 ## Awards
-- [AWARD] - [EVENT] ([YEAR])
+No awards yet.
 
 ## References
-- [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])
+None provided yet.
 
 More references available upon request.

--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -16,9 +16,10 @@ How well do the required/preferred skills align with the candidate's capabilitie
 | 40-59 | Partial match, significant upskilling needed |
 | 0-39 | Fundamental mismatch |
 
-**Strong match areas:** [YOUR_PRIMARY_SKILLS]
-**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
-**Weak match areas:** [SKILLS_YOU_LACK]
+**Strong match areas:** Agentic AI, multi-agent systems, RAG (incl. multimodal), MCP (Model Context Protocol), Python (FastAPI, Flask), Google ADK, LangChain/LangGraph, Gemini models, vector databases (Qdrant), GenAI systems from prototype to production
+**Moderate match areas:** Google Cloud/Vertex AI infrastructure, classical ML (PyTorch, scikit-learn, Pandas), multi-tenant SaaS architecture, multimodal retrieval (Jina v4)
+**Weak match areas:** [SKILLS_YOU_LACK] <!-- ask user - e.g. non-Google cloud stacks (AWS/Azure), Kubernetes/MLOps, people management -->
+<!-- Career note: ~1 year of professional AI/GenAI experience (since May 2025), following two AI-focused masters in 2024-2025. Early-career profile - factor this into Experience Match scoring for senior/lead postings. -->
 
 ### 2. Experience Match (0-100)
 Does work history align with what they're looking for?
@@ -30,9 +31,9 @@ Does work history align with what they're looking for?
 | 40-59 | Adjacent experience, would need to make the case |
 | 0-39 | Unrelated experience |
 
-**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
-**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
-**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+**Strong:** GenAI/agentic AI product development, backend API development for AI systems, RAG and multimodal search systems
+**Moderate:** Multi-tenant SaaS architecture, customer-facing conversational AI (Telco NDA project)
+**Entry-level:** Independent/portfolio projects (finance agent, meeting summarizer, CNN) rather than paid production roles
 
 ### 3. Behavioral/Culture Fit (0-100)
 Does the role and company culture match the behavioral profile?
@@ -63,19 +64,19 @@ Does this role advance career goals and contain tasks that energize?
 | 0-39 | Dead end or backwards step |
 
 **Career goals:**
-- [YOUR_CAREER_GOAL_1]
-- [YOUR_CAREER_GOAL_2]
-- [YOUR_CAREER_GOAL_3]
+- Primary direction: Agentic AI Engineer / GenAI Developer roles
+- Secondary/adjacent direction: Platform Engineering or AI Consulting roles that build on the same LLM/agentic skill set
+- Target compensation: ~200-250 EUR/day equivalent
 
 **Motivation filter:** Evaluate not just whether you *can* do the tasks, but whether the tasks will *energize* you. Consider:
-- Tasks that energize: [YOUR_ENERGIZING_TASKS]
-- Tasks that drain: [YOUR_DRAINING_TASKS]
+- Tasks that energize: Building agents or agent ecosystems that autonomize roles/work
+- Tasks that drain: [YOUR_DRAINING_TASKS] <!-- not yet collected, ask user -->
 - Non-task factors: leadership style, department culture, company values, degree of autonomy
 
 **Life situation alignment:** Consider personal constraints:
-- **Security**: [YOUR_FINANCIAL_SITUATION_CONTEXT]
-- **Flexibility**: [YOUR_SCHEDULE_CONSTRAINTS]
-- **Professional development**: [YOUR_GROWTH_PRIORITIES]
+- **Security**: Currently employed at Graziano Ricami; evaluating a move if the right opportunity comes up
+- **Flexibility**: Remote-first; can accommodate on-site presence a few days per month, not full relocation
+- **Professional development**: [YOUR_GROWTH_PRIORITIES] <!-- not yet collected, ask user -->
 
 ### 6. Salary Benchmark (Optional)
 

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -106,11 +106,11 @@ Write 5-7 lines that function as an "elevator pitch": a concise, compelling intr
 **Create 2-3 profile statement templates for your main role types:**
 
 <!-- SETUP: These are populated based on your background -->
-**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+**For GenAI / Agentic AI Engineer roles:**
+> AI Engineer and GenAI Developer with hands-on experience building agentic systems, RAG pipelines, and multi-tenant SaaS applications on cloud-native infrastructure. Takes LLM solutions from prototype to production using Python (FastAPI), Google ADK, Gemini models, and multimodal retrieval. Focused on reliability, scalability, and end-to-end integration.
 
-**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+**For Platform Engineering / AI Consulting roles:**
+> Backend and platform engineer with production experience shipping multi-tenant, cloud-native SaaS systems and integrating LLM-based agents into existing infrastructure. Skilled in designing secure, policy-compliant data access (Model Context Protocol) and orchestrating multi-agent workflows end-to-end. Brings a builder's focus on reliability, data isolation, and scalable API design.
 
 ### Core Competencies / Skills Section (Best Practice)
 Reorder and emphasize based on the role. Use bold category labels.

--- a/.claude/skills/job-application-assistant/07-interview-prep.md
+++ b/.claude/skills/job-application-assistant/07-interview-prep.md
@@ -35,6 +35,49 @@ Keep answers to 1-2 minutes. Be specific. End with what you learned or would do 
 
 <!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
 
+## STAR Candidates (Complete Manually)
+<!-- Extracted from documents/cv - fill in Situation/Task/Action/Result details before using in interviews -->
+
+### Multi-tenant, multi-vertical SaaS platform architecture (Graziano Ricami)
+**Source:** CV - GenAI/Backend Developer, Graziano Ricami (Oct 2025-Present)
+**What happened:** Designed and built a multi-tenant SaaS platform spanning two verticals (embroidery, knitwear) with data isolation across clients on shared infrastructure.
+**Why it matters:** Answers questions about system architecture, scalability, and multi-tenant design decisions.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Agentic RAG system with Google ADK and MCP toolbox
+**Source:** CV - GenAI Developer, Multimodal RAG & MCP, Graziano Ricami (Aug-Oct 2025)
+**What happened:** Built a natural-language search system over an embroidery archive using an agentic RAG pipeline, MCP toolbox for secure DB access, and multimodal (text+image) retrieval via Jina v4.
+**Why it matters:** Answers questions about RAG design, agent tool orchestration, and secure/controlled data access patterns.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Multi-agent orchestrator for intelligent customer care (Telco NDA client)
+**Source:** CV - AI Engineer, Agentic AI Systems (May-Jul 2025)
+**What happened:** Designed a multi-agent orchestrator that routed customer requests to the right tool based on intent, backed by a RAG pipeline and MCP-based SQL access, reducing manual handling of repetitive requests.
+**Why it matters:** Answers questions about intent routing, agent design, and measurable reduction in manual effort.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Multimodal visual search module (Jina v4)
+**Source:** CV - GenAI Developer, Multimodal RAG & MCP, Graziano Ricami
+**What happened:** Built a text-to-image and image-to-image retrieval module enabling visual search over a large archive.
+**Why it matters:** Answers questions about multimodal AI, embedding-based retrieval, and handling non-text data.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
 ## Common Tough Questions
 
 ### "Why did you leave [previous company]?"

--- a/.github/workflows/linkedin-cli-tests.yml
+++ b/.github/workflows/linkedin-cli-tests.yml
@@ -1,0 +1,33 @@
+name: linkedin-search CLI tests
+
+# Runs the offline test net over the linkedin-search CLI's pure functions
+# (AIV-986). Deterministic, network-free — protects the fragile parsing /
+# URL-building logic that is the primary source for /job-scraper (AIV-984).
+
+on:
+  push:
+    paths:
+      - ".agents/skills/linkedin-search/cli/**"
+      - ".github/workflows/linkedin-cli-tests.yml"
+  pull_request:
+    paths:
+      - ".agents/skills/linkedin-search/cli/**"
+      - ".github/workflows/linkedin-cli-tests.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .agents/skills/linkedin-search/cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Install dev dependencies
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Test
+        run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,9 @@ None yet.
 - `.claude/skills/` - AI skill definitions for the application workflow
 - `.agents/skills/` - Job search CLI tools
 
+## Testing
+- The `linkedin-search` CLI (`.agents/skills/linkedin-search/cli/`) — the primary source for `/job-scraper` — has an offline test net over its fragile parsing / URL-building logic. **Run `bun run test` in that directory after any change to the CLI's parsing or search-URL code.** Tests are deterministic and network-free (they run on saved HTML fixtures in `test/__fixtures__/`); CI runs them automatically on changes under the CLI path. Regenerate fixtures only when LinkedIn's markup changes (see `test/__fixtures__/README.md`).
+
 ## Workflow for New Job Applications
 1. User provides a job posting (URL or text)
 2. **Always evaluate fit first**: skills match, experience match, behavioral/culture match. Present this assessment to the user before proceeding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
-# Job Application Assistant for [YOUR_NAME]
+# Job Application Assistant for Simone Alberucci
 
 <!-- SETUP: This file is populated by running /setup -->
 <!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
 
 ## Role
-This repo is a job application workspace. Claude acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+This repo is a job application workspace. Claude acts as a career advisor and application assistant for Simone Alberucci, helping with:
 1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
 2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
 3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
@@ -16,65 +16,65 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 <!-- This section is auto-populated by /setup. You can also fill it in manually. -->
 
 ### Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
-- **Languages:** [YOUR_LANGUAGES]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+- **Name:** Simone Alberucci
+- **Location:** Sanremo, Italy (Remote-first; open to on-site presence a few days per month, not full relocation)
+- **Languages:** Italian (native), English (B2, professional working proficiency), French (basic)
+- **Status:** Employed (GenAI/Backend Developer at Graziano Ricami), open to new opportunities
+- **LinkedIn headline:** "AI Engineer | GenAI Developer | Agentic AI Specialist"
 
 ### Education
 <!-- List your degrees, most recent first -->
-- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
-  - Thesis: "[THESIS_TITLE]"
-  - Topics: [KEY_TOPICS]
+- **Master in AI Development, Agentic AI Specialization** (2025) - Profession AI
+- **Master in AI Engineering** (2024) - Profession AI
+- **Percorso AI - Agentic AI, LangChain & LangGraph** (2024) - DataMaster
 
 ### Professional Experience
 <!-- List your roles, most recent first -->
-- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
-  - [KEY_RESPONSIBILITY_1]
-  - [KEY_RESPONSIBILITY_2]
-  - [KEY_ACHIEVEMENT]
+- **GenAI / Backend Developer** (Oct 2025 - Present) - **Graziano Ricami** (Sanremo, Italy)
+  - Designed and built a multi-tenant, multi-vertical SaaS platform (embroidery, knitwear) with a Python (FastAPI) backend on Google Cloud
+  - Integrated Google ADK agents and generative features (semantic/visual search, image generation/editing, automated tagging) into the product
+  - Managed multi-tenancy and data isolation across clients on shared infrastructure
+- **GenAI Developer, Multimodal RAG & MCP** (Aug 2025 - Oct 2025) - **Graziano Ricami** (Sanremo, Italy)
+  - Built an agentic RAG system (Google ADK + MCP toolbox) for natural-language search over an archive
+  - Built a multimodal (text-to-image, image-to-image) search module with Jina v4
+- **AI Engineer, Agentic AI Systems** (May 2025 - Jul 2025) - **Telco client under NDA** (Sanremo, Italy)
+  - Designed a multi-agent orchestrator (Google ADK) for intelligent customer care, routing by intent
+  - Integrated MCP-based SQL access, reducing manual handling of repetitive requests
 
 ### Technical Skills
-- **Primary:** [YOUR_PRIMARY_SKILLS]
-- **Secondary:** [YOUR_SECONDARY_SKILLS]
-- **Domain:** [YOUR_DOMAIN_EXPERTISE]
-- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+- **Primary:** Agentic AI, Multi-Agent Systems, RAG (incl. multimodal), MCP, Python (FastAPI, Flask)
+- **Secondary:** PyTorch, Scikit-learn, Pandas, Keycloak
+- **Domain:** Generative AI product development (prototype to production), multi-tenant SaaS architecture
+- **Software:** Google ADK, LangChain, LangGraph, Gemini (2.5 Flash, Flash-Lite), Gemini Embeddings, Qdrant, Jina v4, Google Cloud (Vertex AI), Label Studio, OpenAI API
 
 ### Certifications
 <!-- List relevant certifications with dates -->
-- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+None yet beyond the Education entries above.
 
 ### Publications
 <!-- List peer-reviewed publications, if any -->
-- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+None yet.
 
 ### Awards
 <!-- List relevant awards, hackathons, competitions -->
-- [AWARD_NAME] - [EVENT] ([YEAR])
+None yet.
 
 ### Behavioral Profile
 <!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
-- **[TRAIT_1]** - [DESCRIPTION]
-- **[TRAIT_2]** - [DESCRIPTION]
-- **Strengths:** [YOUR_STRENGTHS]
-- **Growth areas:** [YOUR_GROWTH_AREAS]
-- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+[NOT YET COLLECTED] <!-- ask user: no formal assessment on file; offer to synthesize from a few quick questions (thrives-in environment, energy drains, decision-making style, communication style) -->
 
 ### What Excites You
 <!-- What motivates you professionally -->
-- [PASSION_1]
-- [PASSION_2]
+- Building agents and agent ecosystems that autonomize roles/work
 
 ### Target Sectors
 <!-- Industries and companies you're targeting -->
-- [SECTOR_1]: [EXAMPLE_COMPANIES]
-- [SECTOR_2]: [EXAMPLE_COMPANIES]
+[NOT YET COLLECTED] <!-- ask user: no target sectors/companies identified yet -->
 
 ### Deal-breakers
 <!-- Hard constraints on job search -->
-- [DEALBREAKER_1]
-- [DEALBREAKER_2]
+- Full-time on-site roles with no remote option <!-- inferred from remote-first preference, confirm wording -->
+- Target compensation: ~200-250 EUR/day equivalent
 
 ## Repo Structure
 - `cv/` - LaTeX CV variants (moderncv template, banking style)

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -1,4 +1,4 @@
-%% Example CV - [YOUR_NAME]
+%% Example CV - Simone Alberucci
 %% Comprehensive overview of all competencies, experience, and achievements.
 %% Use as a master reference when tailoring role-specific CVs.
 %%
@@ -24,18 +24,20 @@
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Simone Alberucci - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}
+\usepackage{needspace}
 
 % personal data
-\name{[First]}{[Last]}
-\address{[Your Address, City, Country]}{}{}
-\phone[mobile]{[+XX XXXXXXXXXX]}
-\email{[your.email@example.com]}
-\extrainfo{\href{[https://linkedin.com/in/your-profile]}{LinkedIn}, \href{[https://github.com/your-username]}{GitHub}}
+\name{Simone}{Alberucci}
+\address{Sanremo, Liguria, Italy}{}{}
+\phone[mobile]{+39 379 100 3477}
+\email{simonealberucci@gmail.com}
+\extrainfo{\href{https://linkedin.com/in/simone-alberucci}{LinkedIn}}
+% GitHub not provided yet - add \href{...}{GitHub} to \extrainfo once known
 
 \begin{document}
 
@@ -46,7 +48,7 @@
 % ============================================================
 
 \vspace{6pt}
-\small{[Write a 3-5 line profile statement tailored to the role you're applying for. Focus on what makes you uniquely qualified. Example: "Data scientist with a PhD in [field] and X years of industry experience. Combines deep domain expertise in [domain] with strong applied machine learning and Python development skills. Experienced in developing end-to-end ML pipelines, from data ingestion to stakeholder-facing dashboards."]}
+\small{AI Engineer and GenAI Developer with hands-on experience building agentic systems, RAG pipelines, and multi-tenant SaaS applications on cloud-native infrastructure. Takes LLM solutions from prototype to production using Python (FastAPI), Google ADK, Gemini models, and multimodal retrieval. Focused on reliability, scalability, and end-to-end integration.}
 
 % ============================================================
 %     CORE COMPETENCIES
@@ -56,15 +58,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item \textbf{[Skill Category 1]}: [Specific skills, frameworks, tools. Be concrete.]
+\item \textbf{Agentic AI \& Multi-Agent Systems}: Google ADK, LangChain, LangGraph -- orchestrating multi-agent workflows for customer care and semantic search
 
-\item \textbf{[Skill Category 2]}: [Specific skills, frameworks, tools.]
+\item \textbf{Retrieval-Augmented Generation}: Multimodal RAG pipelines (text + image) with Qdrant, Gemini Embeddings, Jina v4
 
-\item \textbf{[Skill Category 3]}: [Specific skills, frameworks, tools.]
+\item \textbf{Backend \& API Development}: Python (FastAPI, Flask) services powering production GenAI features
 
-\item \textbf{[Skill Category 4]}: [Domain expertise, methods, approaches.]
+\item \textbf{Model Context Protocol (MCP)}: Secure, policy-compliant tool and data access for LLM agents
 
-\item \textbf{[Skill Category 5]}: [Tools, platforms, software.]
+\item \textbf{Cloud-Native GenAI Deployment}: Google Cloud (Vertex AI), multi-tenant SaaS architecture, Gemini model integration
 
 \end{itemize}
 
@@ -77,31 +79,34 @@
 \begin{itemize}
 
 % --- Most Recent Role ---
-\item{\cventry{[YYYY--Present]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{Oct 2025--Present}{GenAI / Backend Developer}{Graziano Ricami}{Sanremo, Italy}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1 - be specific, use numbers where possible]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
-    \item [Achievement or responsibility 4]
+    \item Designed and built a multi-tenant, multi-vertical SaaS platform (embroidery and knitwear) with a Python (FastAPI) backend deployed on Google Cloud
+    \item Integrated Google ADK agents and generative capabilities into the product, with Label Studio as the source of truth for data
+    \item Built semantic text and visual search over the archive using Gemini Embeddings and the Qdrant vector database
+    \item Built an automated tagging pipeline applying per-tenant taxonomy, based on Gemini Flash-Lite, with a quality evaluation component
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Previous Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{Aug 2025--Oct 2025}{GenAI Developer, Multimodal RAG \& MCP}{Graziano Ricami}{Sanremo, Italy}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
+    \item Developed an agentic RAG system with Google ADK and an MCP toolbox for natural-language search over an archive
+    \item Designed secure, controlled queries against a Google Cloud database via Model Context Protocol, compliant with client policies
+    \item Built a multimodal search module (text-to-image and image-to-image) with Jina v4
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Earlier Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{May 2025--Jul 2025}{AI Engineer, Agentic AI Systems}{Telco client under NDA}{Sanremo, Italy}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
+    \item Designed a multi-agent orchestrator (Google ADK) for intelligent customer care, routing requests by intent
+    \item Integrated MCP-based SQL access as an alternative data source, reducing manual intervention on repetitive requests
 \end{itemize}}}
 
 \end{itemize}
@@ -114,15 +119,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-Thesis: ``[Thesis Title].'' [Brief description of research focus.]
-}}
+\item{\cventry{2025}{Master in AI Development -- Agentic AI Specialization}{Profession AI}{Italy}{}{}}
 
 \vspace{3pt}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-[Brief description or key topics.]
-}}
+\item{\cventry{2024}{Master in AI Engineering}{Profession AI}{Italy}{}{}}
+
+\vspace{3pt}
+
+\item{\cventry{2024}{Percorso AI -- Agentic AI, LangChain \& LangGraph}{DataMaster}{Italy}{}{}}
 
 \end{itemize}
 
@@ -133,7 +138,7 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Languages}
 \vspace{1pt}
 \begin{itemize}
-\item [Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).
+\item Italian (native), English (B2, professional working proficiency), French (basic).
 \end{itemize}
 
 % ============================================================
@@ -143,7 +148,7 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Publications}
 \vspace{1pt}
 \begin{itemize}
-\item [Author(s)] ([Year]). [Title]. [Journal/Conference]. \href{[DOI_URL]}{DOI link}
+\item No publications yet.
 \end{itemize}
 
 % ============================================================
@@ -153,7 +158,7 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Honors and Awards}
 \vspace{1pt}
 \begin{itemize}
-\item{\textbf{[Award Name]} -- [Event/Organization] ([Year]).}
+\item{No awards yet.}
 \end{itemize}
 
 % ============================================================


### PR DESCRIPTION
## AIV-986 — Rete di test offline sulle funzioni pure della CLI `linkedin-search`

Chiude [AIV-986](https://linear.app/aivolve/issue/AIV-986). Test **offline e deterministici** sulle funzioni pure della CLI `linkedin-search` — la fonte primaria di `/job-scraper` ([AIV-984](https://linear.app/aivolve/issue/AIV-984)) — per proteggere da regressioni la logica fragile di parsing/URL (il `detail` era la modalità di fallimento della Fase 3, AIV-673).

**`27 pass / 0 fail`, typecheck pulito, zero nuove dipendenze runtime (`bun test` è integrato in bun).**

### Cosa contiene
- Script `test` in `cli/package.json` (il repo non aveva infra di test).
- Fixture HTML **reali** catturate una volta via l'`htmlFetch` della CLI (non a mano): lista `search` (10 card) + detail Orbis (il caso "ancora aperto" di AIV-977), con README di rigenerazione.
- Test: `parseJobCards` (incl. resilienza a card malformata), `parseJobDetail` (criteria + descrizione con newline preservati), `jobageToTPR`, `workTypeFlag`, `buildUrl`, `normalizeId`.
- **Prefactor:** esportate `buildUrl` (`search.ts`) e `normalizeId` (`detail.ts`) per testare al seam puro.
- **CI:** GitHub Action che esegue typecheck + test su ogni modifica sotto il path della CLI.

### ⚠️ Due deviazioni da rivedere in review
1. **Fix di un bug reale**: la descrizione veniva appiattita su una riga perché `stripTags()` collassa tutti gli spazi, annullando la conversione `<br>`/`</p>` → `\n` che il codice fa deliberatamente. Fix chirurgico nel solo branch della descrizione. (Deviazione da "codice immutato" del ticket — invertibile se si preferisce.)
2. **`applyUrl` = `null`** su tutti e 10 gli annunci reali del campione (apply in-piattaforma dietro login). I test bloccano questo comportamento; il path di estrazione non-nullo resta scoperto → follow-up tracciato in **AIV-997** (non dimostrato che il selettore sia rotto).