### PR TITLE
zhipin-search: scroll for more results, remove dead --page flag

### DIFF
--- a/.agents/skills/zhipin-search/SKILL.md
+++ b/.agents/skills/zhipin-search/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: zhipin-search
+version: 1.0.0
+description: >
+  Search BOSS直聘 (zhipin.com) — mainland China's largest tech/security/general job
+  board — for job postings in any Chinese city. Requires an authenticated ego-browser
+  session (the site is a login-gated, client-rendered SPA with no public API and a
+  restrictive robots.txt); personal use only, low volume. Trigger phrases: BOSS直聘,
+  zhipin, 找工作, 搜索BOSS直聘, boss直聘招聘, search zhipin, 招聘 上海/北京/杭州/苏州.
+context: fork
+allowed-tools: Bash(bun run skills/zhipin-search/cli/src/cli.ts *)
+---
+
+# BOSS直聘 (zhipin.com) Search Skill
+
+Search live job listings from BOSS直聘 for mainland Chinese cities. Zero *npm* runtime
+dependencies (`bun` + `node:child_process`), but — unlike this repo's other portal
+skills — it is **not** a stateless HTTP client: zhipin.com has no public API and no
+server-rendered HTML to parse (see `url-reference.md`), so this drives a real,
+authenticated browser session via the `ego-browser` CLI instead of `fetch`.
+
+## ⚠️ Personal use only — and an extra prerequisite
+
+robots.txt disallows automated access to the query-string paths this needs
+(`?query=`, `?city=`, and a catch-all `/*?*`), and the site is login-gated. This skill
+doesn't fake or bypass that — it drives **your own real, logged-in browser session**
+at low, interactive volume, the same access you'd have searching manually. Keep it
+that way: a handful of searches, not a crawl. Don't use this commercially or for bulk
+data collection. Run it on your own responsibility.
+
+**Prerequisite this skill's siblings don't have**: `ego-browser` must be installed and
+on `PATH`, and Chrome must be running with an active BOSS直聘 (求职者) login session.
+If either is missing, `search`/`detail` fail with a clear error rather than silently
+returning nothing.
+
+## When to use this skill
+
+- Search for job openings on BOSS直聘 in a supported Chinese city
+- Get the full description (with the real, unmasked salary) of a specific posting
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run skills/zhipin-search/cli/src/cli.ts search --location "<city>" [flags]
+```
+
+Key flags:
+- `--location <city>` / `-l <city>` — **required.** A verified city name/alias (上海,
+  北京, 杭州, 苏州, or `shanghai`/`beijing`/`hangzhou`/`suzhou`) or a raw 9-digit
+  BOSS直聘 city code. See `url-reference.md` for how to verify and add a new one.
+- `--query <text>` / `-q <text>` — keyword search (title, skill, role). Recommended.
+- `--limit <n>` / `-n <n>` — cap total results emitted, **and how far `search` scrolls to find them**: it
+  scrolls the results list until at least this many cards have loaded, up to a fixed safety ceiling. Omit to
+  use a conservative default scroll target (45 cards) instead of just the first screenful.
+- `--format json|table|plain` — default `json`.
+
+**Salary is not available from `search`** — BOSS直聘 masks it in the list view
+(returns `null`); use `detail` for the real figure. Not supported: `--jobage`
+(no posting-date filter/field exists on this portal).
+
+**Pagination is scroll-driven, not a flag.** BOSS直聘's result list is infinite-scroll, not
+page-numbered — an earlier `--page` flag never did anything and has been removed. `search` now
+scrolls automatically (bounded — a handful of steps, not a deep crawl, matching this skill's
+personal-use-only posture) before scraping.
+
+### Fetch full job detail
+
+```bash
+bun run skills/zhipin-search/cli/src/cli.ts detail <id|url> [--format json|plain]
+```
+
+`id` is the job id from `search` results (an opaque hash, e.g.
+`cf386d859ead4dc40nF92NS0FVNX`). You may also pass a full `job_detail/...html` URL.
+Returns the full description, experience/education requirements, address, and the
+real (unmasked) salary.
+
+## Usage examples
+
+```bash
+# Security-operations roles in Shanghai
+bun run skills/zhipin-search/cli/src/cli.ts search -q "安全运营" -l "上海" --format table
+
+# AI Agent security roles in Hangzhou, capped at 10 results
+bun run skills/zhipin-search/cli/src/cli.ts search -q "AI Agent 安全" -l 杭州 --limit 10 --format table
+
+# SOC/threat-intel roles in Beijing
+bun run skills/zhipin-search/cli/src/cli.ts search -q "威胁情报" -l 北京 --format table
+
+# Full detail (real salary included) for a specific posting
+bun run skills/zhipin-search/cli/src/cli.ts detail cf386d859ead4dc40nF92NS0FVNX --format plain
+```
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing ids to `detail` |
+| `table` | Quick human-readable scanning |
+| `plain` | Reading a single job's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the
+process exits with code `1`.
+
+## Notes
+
+- Data comes from driving a real, authenticated Chrome tab via `ego-browser` — there
+  is no HTTP fetch involved and no rate-limit/backoff logic the way `linkedin-search`
+  has, because the failure mode here is "ego-browser/Chrome/login session isn't
+  available," not "the server is rate-limiting an HTTP client."
+- Description text is read via `.innerText` (not raw HTML) specifically because the
+  site injects invisible anti-scraping watermark text mid-word into the raw markup —
+  see `url-reference.md` for details. Even so, expect occasional minor garbling in a
+  JD's text; verify against the live page before quoting a posting verbatim.
+- Only 4 city codes are verified so far (上海/北京/杭州/苏州) — see
+  `url-reference.md` for how to verify and add more without guessing.

--- a/.agents/skills/zhipin-search/cli/README.md
+++ b/.agents/skills/zhipin-search/cli/README.md
@@ -1,0 +1,87 @@
+# zhipin-cli
+
+CLI for searching jobs on **BOSS直聘** (zhipin.com), mainland China's largest tech/security
+job board.
+
+**Data source**: no public API, no parseable server HTML — zhipin.com is a login-gated,
+fully client-rendered SPA. This CLI drives a real, authenticated browser session via the
+[`ego-browser`](https://www.npmjs.com/package/ego-browser) CLI instead of `fetch`.
+**Authentication**: required — Chrome must be running with an active BOSS直聘 (求职者)
+login session; `ego-browser` reuses that session.
+**Dependencies**: zero *npm* runtime dependencies (`bun` + `node:child_process`), but this
+skill has a real external dependency the other portal skills don't: the `ego-browser` binary
+on `PATH` and a live, logged-in Chrome.
+
+> **Personal use only.** robots.txt disallows automated access to the query-string search
+> paths this needs (`?query=`, `?city=`, and a catch-all `/*?*`). This tool doesn't evade
+> that with a fake browser fingerprint — it drives your own real, authenticated session at
+> low, interactive volume, the same way you'd search manually. Keep it that way: a handful
+> of searches, not a crawl. Run on your own responsibility.
+
+## Installation
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun install   # only installs TypeScript dev types
+```
+
+You also need `ego-browser` installed and configured, and Chrome open with you logged into
+BOSS直聘 as a candidate (求职者). If `ego-browser` isn't on `PATH`, `search`/`detail` fail
+with a clear `SEARCH_FAILED`/`DETAIL_FAILED` error explaining that.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `search` | Search job listings (`--location` required). Salary is **not** available here — see below. |
+| `detail` | Fetch full detail for a single listing, including the real salary. |
+
+`search` accepts `--format json|table|plain` (default `json`); `detail` accepts
+`--format json|plain`. All errors are written to **stderr** as
+`{ "error": "...", "code": "..." }` with exit code `1`.
+
+## Quick examples
+
+```bash
+# Security-ops roles in Shanghai
+bun run src/cli.ts search -q "安全运营" -l "上海" --format table
+
+# AI Agent security roles in Hangzhou, capped at 10 results
+bun run src/cli.ts search -q "AI Agent 安全" -l 杭州 --limit 10 --format table
+
+# Full detail (real salary included) for one posting
+bun run src/cli.ts detail cf386d859ead4dc40nF92NS0FVNX --format plain
+bun run src/cli.ts detail https://www.zhipin.com/job_detail/cf386d859ead4dc40nF92NS0FVNX.html --format plain
+```
+
+See `../SKILL.md` for the full flag reference and `../url-reference.md` for the DOM
+selectors and portal quirks this relies on.
+
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--location` | `-l` | **Required.** A verified city name/alias (上海, 北京, 杭州, 苏州, or shanghai/beijing/hangzhou/suzhou) or a raw 9-digit BOSS直聘 city code. |
+| `--query` | `-q` | Keywords (title / skill / role). Recommended. |
+| `--limit` | `-n` | Cap results emitted, and how far `search` scrolls to find them (see below). |
+| `--format` | | `json` \| `table` \| `plain`. |
+
+Not supported: `--jobage` (no posting-date filter or field exists in this portal's UI),
+`--remote` (no workplace-type filter observed).
+
+**Scroll-driven pagination.** BOSS直聘's result list is infinite-scroll, not page-numbered
+(an earlier `--page` flag never worked and has been removed). `search` scrolls the page,
+in bounded steps, until either `--limit` cards have loaded, the list stops growing, or a
+low fixed step ceiling is hit — never an unbounded crawl, matching this skill's
+personal, low-volume use only posture. Omit `--limit` to use a default scroll target of
+45 cards.
+
+## Why this isn't a plain `fetch` CLI
+
+An unauthenticated request to the search URL returns an empty `<div id="app">` shell (see
+`url-reference.md`) — there's no HTML to parse and no discovered JSON API. Real listings only
+exist after the page's JS executes inside a session that's actually logged in. Rather than
+reverse-engineer and replay that login flow (which would mean embedding session cookies in a
+committed script — a security and maintenance liability), this CLI shells out to
+`ego-browser nodejs`, which drives your own already-authenticated Chrome tab and reads the
+rendered DOM back as JSON.

--- a/.agents/skills/zhipin-search/cli/package.json
+++ b/.agents/skills/zhipin-search/cli/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "zhipin-cli",
+  "version": "1.0.0",
+  "description": "CLI for searching jobs on BOSS直聘 (zhipin.com), mainland China's largest tech/security job board, via an authenticated ego-browser session (no public API; login-gated SPA). Personal use only — requires ego-browser + a logged-in Chrome session.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "zhipin-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 60000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/cli.ts
+++ b/.agents/skills/zhipin-search/cli/src/cli.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env bun
+// Self-contained CLI for searching jobs on BOSS直聘 (zhipin.com), mainland China's
+// largest tech/security job board. Unlike linkedin-search, this is NOT a stateless
+// HTTP client: zhipin.com is a login-gated, fully client-rendered SPA with no public
+// API, so this drives a real authenticated browser session via the `ego-browser`
+// CLI, reusing your own logged-in Chrome profile — the same access a human doing
+// this search manually would have.
+//
+// Personal use only. robots.txt disallows automated access to the query-string
+// search paths this needs; keep volume low (a handful of searches, not a crawl) and
+// do not use this commercially or for bulk data collection. Run it on your own
+// responsibility. Requires: ego-browser installed and configured, Chrome running
+// with an active BOSS直聘 (求职者) login session.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", l: "location", n: "limit" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `zhipin-cli — search jobs on BOSS直聘 (zhipin.com), mainland China
+
+USAGE
+  bun run src/cli.ts search --location "<city>" [flags]
+  bun run src/cli.ts detail <id|url> [--format json|plain]
+
+SEARCH FLAGS
+  --location, -l <text>   City. REQUIRED. A known city name (上海/北京/杭州/苏州, or
+                          shanghai/beijing/hangzhou/suzhou) or a raw 9-digit BOSS直聘
+                          city code. See helpers.ts CITY_CODES for the verified list
+                          — add more only after verifying them (url-reference.md).
+  --query, -q <text>      Keywords (job title, skill, or role). Recommended.
+  --limit, -n <n>         Cap results emitted, and how far \`search\` scrolls to
+                          find them: it scrolls the results list until at least
+                          this many cards have loaded (bounded by a low, fixed
+                          safety ceiling). Omit to use a conservative default
+                          scroll target (45 cards) instead of just the first
+                          screenful.
+  --format <fmt>          json (default) | table | plain.
+
+NOT SUPPORTED: --jobage (posting age). BOSS直聘's search UI exposes no posting-date
+filter and listings don't show a post date, so there's nothing to map this to.
+
+SALARY NOTE: the search-results list masks salary (canvas overlay; DOM shows a
+literal "-K" placeholder) — \`search\` returns salary: null. Only \`detail\` shows the
+real, unmasked salary.
+
+EXAMPLES
+  bun run src/cli.ts search -q "安全运营" -l "上海" --format table
+  bun run src/cli.ts search -q "AI Agent 安全" -l 杭州 --limit 10 --format table
+  bun run src/cli.ts detail cf386d859ead4dc40nF92NS0FVNX --format plain
+  bun run src/cli.ts detail https://www.zhipin.com/job_detail/cf386d859ead4dc40nF92NS0FVNX.html --format plain
+
+Personal use only — requires ego-browser + a logged-in BOSS直聘 Chrome session; keep
+volume low (robots.txt disallows automated access to these paths).
+`
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  if (cmd === "search") {
+    const location = typeof flags.location === "string" ? flags.location : undefined
+    if (!location) {
+      process.stderr.write(
+        JSON.stringify({
+          error: 'the --location/-l flag is required (e.g. -l "上海", -l shanghai, or a raw city code)',
+          code: "NO_LOCATION",
+        }) + "\n",
+      )
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+
+    const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
+      const val = parseInt(raw as string, 10)
+      if (isNaN(val)) {
+        process.stderr.write(
+          JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n",
+        )
+        return null
+      }
+      return val
+    }
+
+    if (flags.limit !== undefined) {
+      const v = parseIntFlag("limit", flags.limit)
+      if (v === null) return 1
+      flags.limit = String(v)
+    }
+
+    const opts: SearchOpts = {
+      query: typeof flags.query === "string" ? flags.query : undefined,
+      location,
+      limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(JSON.stringify({ error: "detail requires an <id|url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      id,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main().then((code) => process.exit(code))

--- a/.agents/skills/zhipin-search/cli/src/commands/detail.ts
+++ b/.agents/skills/zhipin-search/cli/src/commands/detail.ts
@@ -1,0 +1,118 @@
+import { runEgoBrowser, lastJson, writeError, BASE_URL, companyFromTitle, type JobDetail } from "../helpers.js"
+
+export interface DetailOpts {
+  id: string
+  format: "json" | "plain"
+}
+
+/** Raw shape cliLog'd back by the embedded browser script for a single posting. */
+export interface RawDetail {
+  title: string | null
+  salary: string | null
+  city: string | null
+  experience: string | null
+  education: string | null
+  address: string | null
+  company: string | null
+  description: string | null
+  pageTitle: string
+}
+
+// Verified selectors — see url-reference.md. Two things matter here that don't
+// apply to the search-list scrape:
+//  1. Salary (`.info-primary .salary`) is REAL on the detail page, unlike the
+//     list view's masked placeholder.
+//  2. Description is read via `.innerText`, never `.textContent`/raw HTML — the
+//     page injects invisible watermark spans (e.g. "BOSS直聘") mid-word into the
+//     description's DOM that only `.innerText` (CSS-visibility-aware) filters out.
+const DOM_SCRIPT = `(() => {
+  const q = s => document.querySelector(s)
+  const text = el => el ? el.innerText.trim() : null
+  const h1 = q('.info-primary h1')
+  const companyA = q('.sider-company .company-info a')
+  return {
+    title: h1 ? (h1.getAttribute('title') || h1.innerText.trim()) : null,
+    salary: text(q('.info-primary .salary')),
+    city: text(q('.info-primary .text-city')),
+    experience: text(q('.info-primary .text-experiece')),
+    education: text(q('.info-primary .text-degree')),
+    address: text(q('.location-address')),
+    company: companyA ? (companyA.getAttribute('title') || companyA.innerText.trim()) : null,
+    description: text(q('.job-sec-text, .job-detail-section .text')),
+    pageTitle: document.title,
+  }
+})()`
+
+export function buildBrowserScript(url: string): string {
+  return [
+    `await gotoAndWait(${JSON.stringify(url)}, { timeout: 25, settle: 2 })`,
+    `await wait(1)`,
+    `const result = await js(${JSON.stringify(DOM_SCRIPT)})`,
+    `cliLog(JSON.stringify(result))`,
+  ].join("\n")
+}
+
+/** Accept a bare BOSS直聘 job id (the hash in /job_detail/<id>.html) or a full URL. */
+export function normalizeUrl(input: string): string | null {
+  if (/^https?:\/\//.test(input)) return input
+  if (/^[A-Za-z0-9_~-]+$/.test(input)) return `${BASE_URL}/job_detail/${input}.html`
+  return null
+}
+
+/** Pure: raw page data -> the documented JobDetail output shape. */
+export function shapeDetail(raw: RawDetail, url: string): JobDetail | null {
+  if (!raw.title) return null
+  const idMatch = url.match(/\/job_detail\/([^./]+)\.html/)
+  return {
+    id: idMatch ? idMatch[1] : url,
+    title: raw.title,
+    company: raw.company || companyFromTitle(raw.pageTitle),
+    location: raw.address || raw.city,
+    date: null,
+    url,
+    salary: raw.salary,
+    experience: raw.experience,
+    education: raw.education,
+    description: raw.description,
+  }
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const url = normalizeUrl(opts.id)
+  if (!url) {
+    writeError(
+      `Could not build a job_detail URL from "${opts.id}" — pass the id from search results or a full zhipin.com job_detail URL`,
+      "BAD_ID",
+    )
+    return 1
+  }
+  try {
+    const stdout = await runEgoBrowser(buildBrowserScript(url))
+    const raw = lastJson<RawDetail>(stdout)
+    const job = shapeDetail(raw, url)
+    if (!job) {
+      writeError("Job not found (expired/removed posting, or the page failed to render)", "NOT_FOUND")
+      return 1
+    }
+
+    if (opts.format === "plain") {
+      const lines = [
+        job.title,
+        `${job.company || "—"} · ${job.location || "—"} · ${job.salary || "—"}`,
+        job.experience ? `经验: ${job.experience}` : "",
+        job.education ? `学历: ${job.education}` : "",
+        "",
+        job.description || "(no description)",
+        "",
+        `URL: ${job.url}`,
+      ].filter((l) => l !== "")
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/commands/search.ts
+++ b/.agents/skills/zhipin-search/cli/src/commands/search.ts
@@ -1,0 +1,176 @@
+import {
+  runEgoBrowser,
+  lastJson,
+  writeError,
+  resolveCity,
+  buildSearchUrl,
+  idFromHref,
+  urlFromHref,
+  realSalary,
+  type JobCard,
+} from "../helpers.js"
+
+export interface SearchOpts {
+  query?: string
+  location: string
+  page: number
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+
+/** Raw shape cliLog'd back by the embedded browser script — one entry per job card. */
+export interface RawCard {
+  href: string | null
+  title: string | null
+  company: string | null
+  companyHref: string | null
+  location: string | null
+  salaryRaw: string | null
+  experience: string | null
+  education: string | null
+}
+
+// Scroll-loop tuning. BOSS直聘's result list loads in fixed +15-card batches;
+// live spike testing (see docs/superpowers/specs/2026-07-14-zhipin-search-scroll-pagination-design.md)
+// found real growth never produces more than 1 consecutive flat step, so 3 is a
+// safe margin for "genuinely done." Kept as fixed constants (not flags) — this
+// tool is personal, low-volume use only, not meant to become a deep crawler.
+export const DEFAULT_TARGET_RESULTS = 45
+export const MAX_SCROLL_STEPS = 12
+export const NO_GROWTH_STOP_THRESHOLD = 3
+export const SCROLL_STEP_PX = 1400
+export const SCROLL_WAIT_SECONDS = 1.2
+
+export interface ScrollState {
+  count: number
+  target: number
+  noGrowthStreak: number
+  steps: number
+}
+
+/** Pure: decide whether the scroll loop should stop after observing this step's card count. */
+export function shouldStopScrolling(state: ScrollState): boolean {
+  if (state.count >= state.target) return true
+  if (state.noGrowthStreak >= NO_GROWTH_STOP_THRESHOLD) return true
+  if (state.steps >= MAX_SCROLL_STEPS) return true
+  return false
+}
+
+// Verified selectors (li.job-card-box) — see url-reference.md for how these were
+// confirmed against a live page dump. Salary is deliberately read raw here;
+// realSalary() decides whether it's real data or the site's masked placeholder.
+const DOM_SCRIPT = `(() => {
+  const cards = [...document.querySelectorAll('li.job-card-box')]
+  return cards.map(c => {
+    const a = c.querySelector('a.job-name')
+    const bossA = c.querySelector('a.boss-info')
+    const bossName = bossA ? bossA.querySelector('.boss-name') : null
+    const salaryEl = c.querySelector('.job-salary')
+    const tags = [...c.querySelectorAll('.tag-list li')].map(li => li.innerText.trim())
+    const locEl = c.querySelector('.company-location')
+    return {
+      href: a ? a.getAttribute('href') : null,
+      title: a ? a.innerText.trim() : null,
+      company: bossName ? bossName.innerText.trim() : null,
+      companyHref: bossA ? bossA.getAttribute('href') : null,
+      location: locEl ? locEl.innerText.trim() : null,
+      salaryRaw: salaryEl ? salaryEl.innerText.trim() : null,
+      experience: tags[0] || null,
+      education: tags[1] || null,
+    }
+  })
+})()`
+
+export function buildBrowserScript(searchUrl: string): string {
+  return [
+    `await gotoAndWait(${JSON.stringify(searchUrl)}, { timeout: 25, settle: 2 })`,
+    `await wait(1)`,
+    `const results = await js(${JSON.stringify(DOM_SCRIPT)})`,
+    `cliLog(JSON.stringify(results))`,
+  ].join("\n")
+}
+
+/** Pure: raw cards from the page -> the documented JobCard output shape. */
+export function shapeResults(raw: RawCard[], limit?: number): JobCard[] {
+  let cards: JobCard[] = raw
+    .map((r) => {
+      const id = idFromHref(r.href)
+      const url = urlFromHref(r.href)
+      if (!id || !r.title || !url) return null
+      const card: JobCard = {
+        id,
+        title: r.title,
+        company: r.company,
+        location: r.location,
+        date: null,
+        url,
+        salary: realSalary(r.salaryRaw),
+        experience: r.experience,
+        education: r.education,
+      }
+      return card
+    })
+    .filter((c): c is JobCard => c !== null)
+
+  if (limit !== undefined && limit >= 0) cards = cards.slice(0, limit)
+  return cards
+}
+
+export function renderTable(cards: JobCard[]): string {
+  if (cards.length === 0) return "No results."
+  const rows = cards.map((c) => {
+    const title = (c.title || "").slice(0, 28).padEnd(28)
+    const company = (c.company || "—").slice(0, 20).padEnd(20)
+    const loc = (c.location || "—").slice(0, 20).padEnd(20)
+    const sal = (c.salary || "见detail").padEnd(10)
+    return `${c.id.padEnd(30)} ${title} ${company} ${loc} ${sal}`
+  })
+  const header =
+    "ID".padEnd(30) +
+    " " +
+    "TITLE".padEnd(28) +
+    " " +
+    "COMPANY".padEnd(20) +
+    " " +
+    "LOCATION".padEnd(20) +
+    " SALARY"
+  return [header, "-".repeat(header.length), ...rows].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  const cityCode = resolveCity(opts.location)
+  if (!cityCode) {
+    writeError(
+      `Unknown location "${opts.location}" — pass a known city name (see CITY_CODES in helpers.ts: 上海/北京/杭州/苏州) or a raw 9-digit BOSS直聘 city code. See url-reference.md for how to verify a new one.`,
+      "BAD_LOCATION",
+    )
+    return 1
+  }
+  try {
+    const url = buildSearchUrl(opts.query || "", cityCode)
+    const stdout = await runEgoBrowser(buildBrowserScript(url))
+    const raw = lastJson<RawCard[]>(stdout)
+    const cards = shapeResults(raw, opts.limit)
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(cards) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        cards
+          .map(
+            (c) =>
+              `${c.title}\n  ${c.company || "—"} · ${c.location || "—"} · ${c.salary || "薪资见 detail（列表页已脱敏）"}\n  id: ${c.id}\n  ${c.url}`,
+          )
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify({ meta: { count: cards.length, page: opts.page }, results: cards }, null, 2) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/commands/search.ts
+++ b/.agents/skills/zhipin-search/cli/src/commands/search.ts
@@ -13,7 +13,6 @@ import {
 export interface SearchOpts {
   query?: string
   location: string
-  page: number
   limit?: number
   format: "json" | "table" | "plain"
 }
@@ -81,10 +80,23 @@ const DOM_SCRIPT = `(() => {
   })
 })()`
 
-export function buildBrowserScript(searchUrl: string): string {
+const COUNT_CARDS_SCRIPT = `document.querySelectorAll('li.job-card-box').length`
+
+export function buildBrowserScript(searchUrl: string, target: number): string {
   return [
     `await gotoAndWait(${JSON.stringify(searchUrl)}, { timeout: 25, settle: 2 })`,
     `await wait(1)`,
+    `let count = await js(${JSON.stringify(COUNT_CARDS_SCRIPT)})`,
+    `let noGrowthStreak = 0`,
+    `let steps = 0`,
+    `while (count < ${target} && noGrowthStreak < ${NO_GROWTH_STOP_THRESHOLD} && steps < ${MAX_SCROLL_STEPS}) {`,
+    `  await scrollBy(${SCROLL_STEP_PX})`,
+    `  await wait(${SCROLL_WAIT_SECONDS})`,
+    `  const newCount = await js(${JSON.stringify(COUNT_CARDS_SCRIPT)})`,
+    `  noGrowthStreak = newCount > count ? 0 : noGrowthStreak + 1`,
+    `  count = newCount`,
+    `  steps++`,
+    `}`,
     `const results = await js(${JSON.stringify(DOM_SCRIPT)})`,
     `cliLog(JSON.stringify(results))`,
   ].join("\n")
@@ -148,7 +160,8 @@ export async function runSearch(opts: SearchOpts): Promise<number> {
   }
   try {
     const url = buildSearchUrl(opts.query || "", cityCode)
-    const stdout = await runEgoBrowser(buildBrowserScript(url))
+    const target = opts.limit ?? DEFAULT_TARGET_RESULTS
+    const stdout = await runEgoBrowser(buildBrowserScript(url, target))
     const raw = lastJson<RawCard[]>(stdout)
     const cards = shapeResults(raw, opts.limit)
 
@@ -165,7 +178,7 @@ export async function runSearch(opts: SearchOpts): Promise<number> {
       )
     } else {
       process.stdout.write(
-        JSON.stringify({ meta: { count: cards.length, page: opts.page }, results: cards }, null, 2) + "\n",
+        JSON.stringify({ meta: { count: cards.length }, results: cards }, null, 2) + "\n",
       )
     }
     return 0

--- a/.agents/skills/zhipin-search/cli/src/helpers.ts
+++ b/.agents/skills/zhipin-search/cli/src/helpers.ts
@@ -1,0 +1,164 @@
+// Data source: BOSS直聘 (zhipin.com), mainland China's largest tech/security job
+// board. Unlike linkedin-search's htmlFetch, this CANNOT be a stateless HTTP client:
+// an unauthenticated `fetch()` of the search page returns an empty <div id="app">
+// shell (a client-rendered Vue SPA — see url-reference.md). There is no public JSON
+// API. Real results only render after JS executes inside an authenticated browser
+// session. So instead of `fetch`, every command here shells out to the `ego-browser`
+// CLI, which drives a real Chrome tab reusing your own logged-in session — the same
+// access a human doing this search manually would have.
+//
+// Personal use only — this is browser automation of your own account, at low,
+// interactive volume. robots.txt disallows automated access to the query-string
+// search paths this needs (`?query=`, `?city=`, and a catch-all `/*?*`); keep this to
+// what you'd do by hand (a handful of searches, not a crawl). Run on your own
+// responsibility. Requires `ego-browser` on PATH and Chrome running with an active
+// BOSS直聘 (求职者) login session.
+
+import { spawn } from "node:child_process"
+
+export const BASE_URL = "https://www.zhipin.com"
+const TASK_SPACE = "zhipin-cli"
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+/**
+ * Run a JS snippet inside a shared ego-browser task space and return its
+ * combined output. The snippet must end with exactly one
+ * `cliLog(JSON.stringify(...))` call — we parse the last JSON-shaped line of
+ * output for it. Empirically, `ego-browser nodejs` writes ALL output
+ * (console.log AND cliLog) to stderr when run non-interactively via stdin —
+ * nothing appears on stdout — so we concatenate both streams rather than
+ * assume either one.
+ */
+export async function runEgoBrowser(script: string, timeoutMs = 45000): Promise<string> {
+  const full = `const task = await useOrCreateTaskSpace(${JSON.stringify(TASK_SPACE)})\n${script}`
+  return new Promise((resolve, reject) => {
+    const proc = spawn("ego-browser", ["nodejs"], { stdio: ["pipe", "pipe", "pipe"] })
+    let stdout = ""
+    let stderr = ""
+    const timer = setTimeout(() => {
+      proc.kill()
+      reject(new Error(`ego-browser timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()))
+    proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()))
+    proc.on("error", (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer)
+      if (err.code === "ENOENT") {
+        reject(
+          new Error(
+            "ego-browser CLI not found on PATH — install/configure it first (see the ego-browser skill's references/install.md)",
+          ),
+        )
+      } else {
+        reject(err)
+      }
+    })
+    proc.on("close", (code: number | null) => {
+      clearTimeout(timer)
+      const combined = stdout + stderr
+      if (code !== 0 && !combined.trim()) {
+        reject(new Error(`ego-browser exited ${code} with no output`))
+        return
+      }
+      resolve(combined)
+    })
+    proc.stdin.write(full)
+    proc.stdin.end()
+  })
+}
+
+/** Extract the last JSON value printed to stdout. */
+export function lastJson<T = unknown>(stdout: string): T {
+  const lines = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      return JSON.parse(lines[i]) as T
+    } catch {
+      continue
+    }
+  }
+  throw new Error(`No JSON found in ego-browser output:\n${stdout}`)
+}
+
+export interface JobCard {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  date: string | null
+  url: string
+  salary: string | null
+  experience: string | null
+  education: string | null
+}
+
+export interface JobDetail extends JobCard {
+  description: string | null
+}
+
+// Known verified city codes (BOSS直聘 `city=` param). Empirically confirmed by
+// running a live search and checking that result locations match the requested
+// city — do NOT add a code here without verifying it the same way (see
+// url-reference.md "Finding more city codes").
+export const CITY_CODES: Record<string, string> = {
+  上海: "101020100",
+  shanghai: "101020100",
+  北京: "101010100",
+  beijing: "101010100",
+  杭州: "101210100",
+  hangzhou: "101210100",
+  苏州: "101190400",
+  suzhou: "101190400",
+}
+
+export function resolveCity(input: string): string | null {
+  const trimmed = input.trim()
+  if (/^\d{9}$/.test(trimmed)) return trimmed
+  return CITY_CODES[trimmed] ?? CITY_CODES[trimmed.toLowerCase()] ?? null
+}
+
+export function buildSearchUrl(query: string, cityCode: string): string {
+  const params = new URLSearchParams()
+  if (query) params.set("query", query)
+  params.set("city", cityCode)
+  return `${BASE_URL}/web/geek/job?${params.toString()}`
+}
+
+/** BOSS直聘 job_detail hrefs are relative, e.g. "/job_detail/<id>.html". */
+export function idFromHref(href: string | null): string | null {
+  if (!href) return null
+  const m = href.match(/\/job_detail\/([^./]+)\.html/)
+  return m ? m[1] : null
+}
+
+export function urlFromHref(href: string | null): string | null {
+  if (!href) return null
+  return href.startsWith("http") ? href : `${BASE_URL}${href}`
+}
+
+/**
+ * The search-results list masks salary behind a canvas overlay; the underlying
+ * DOM text node is a literal placeholder like "-K" with no digits. Only the
+ * detail page shows the real, unmasked salary. Treat a placeholder as missing
+ * data (null) rather than returning garbage.
+ */
+export function realSalary(raw: string | null): string | null {
+  if (!raw || !/\d/.test(raw)) return null
+  return raw
+}
+
+/**
+ * Fallback company-name parse from the detail page's <title>, e.g.
+ * "「安全运营工程师招聘」_NIO蔚来招聘-BOSS直聘" -> "NIO蔚来".
+ */
+export function companyFromTitle(pageTitle: string): string | null {
+  const m = pageTitle.match(/_(.+?)招聘-BOSS直聘\s*$/)
+  return m ? m[1] : null
+}

--- a/.agents/skills/zhipin-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/zhipin-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test";
+import { runCLI } from "./helpers";
+
+const LOCATION = "上海";
+
+function parsedStderr(stderr: string): { error?: string; code?: string } {
+  try {
+    return JSON.parse(stderr);
+  } catch {
+    return {};
+  }
+}
+
+describe("zhipin CLI flag validation", () => {
+  describe("--location validation", () => {
+    test("missing --location exits 1 with NO_LOCATION", async () => {
+      const result = await runCLI(["search"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("NO_LOCATION");
+    });
+
+    test("unknown city name exits 1 with BAD_LOCATION", async () => {
+      const result = await runCLI(["search", "-l", "Atlantis"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_LOCATION");
+    });
+
+    test("a raw 9-digit city code passes location validation", async () => {
+      const result = await runCLI(["search", "-l", "101020100", "--limit", "1"]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("BAD_LOCATION");
+      expect(err.code).not.toBe("NO_LOCATION");
+    });
+  });
+
+  describe("--limit NaN validation", () => {
+    test("non-numeric string exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--limit", "xyz"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/limit/);
+    });
+  });
+
+  describe("valid flags", () => {
+    test("known city name + numeric limit produce no BAD_ARG/BAD_LOCATION", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--limit", "5"]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("BAD_ARG");
+      expect(err.code).not.toBe("BAD_LOCATION");
+      expect(err.code).not.toBe("NO_LOCATION");
+    });
+  });
+
+  describe("detail command validation", () => {
+    test("missing id exits 1 with NO_ID", async () => {
+      const result = await runCLI(["detail"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("NO_ID");
+    });
+
+    test("id with disallowed characters exits 1 with BAD_ID", async () => {
+      const result = await runCLI(["detail", "not a valid id!!"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ID");
+    });
+  });
+
+  describe("help", () => {
+    test("search --help prints usage and exits 0", async () => {
+      const result = await runCLI(["search", "--help"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/zhipin-cli/);
+    });
+
+    test("bare --help (no command) prints usage but exits 1, matching linkedin-search's convention", async () => {
+      const result = await runCLI(["--help"]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toMatch(/zhipin-cli/);
+    });
+
+    test("unknown command exits 1 with BAD_CMD", async () => {
+      const result = await runCLI(["frobnicate"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_CMD");
+    });
+  });
+});

--- a/.agents/skills/zhipin-search/cli/tests/helpers.ts
+++ b/.agents/skills/zhipin-search/cli/tests/helpers.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/zhipin-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/zhipin-search/cli/tests/parsing.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveCity,
+  buildSearchUrl,
+  idFromHref,
+  urlFromHref,
+  realSalary,
+  companyFromTitle,
+} from "../src/helpers";
+import {
+  shapeResults,
+  shouldStopScrolling,
+  NO_GROWTH_STOP_THRESHOLD,
+  MAX_SCROLL_STEPS,
+  type RawCard,
+} from "../src/commands/search";
+import { shapeDetail, normalizeUrl, type RawDetail } from "../src/commands/detail";
+
+describe("resolveCity", () => {
+  test("resolves known Chinese city names", () => {
+    expect(resolveCity("上海")).toBe("101020100");
+    expect(resolveCity("杭州")).toBe("101210100");
+  });
+
+  test("resolves known English aliases case-insensitively", () => {
+    expect(resolveCity("shanghai")).toBe("101020100");
+    expect(resolveCity("Shanghai")).toBe("101020100");
+  });
+
+  test("passes through a raw 9-digit city code", () => {
+    expect(resolveCity("101280600")).toBe("101280600");
+  });
+
+  test("returns null for an unknown city", () => {
+    expect(resolveCity("Atlantis")).toBeNull();
+  });
+});
+
+describe("buildSearchUrl", () => {
+  test("includes query and city params", () => {
+    const url = buildSearchUrl("安全运营", "101020100");
+    expect(url).toContain("/web/geek/job?");
+    expect(url).toContain("city=101020100");
+    expect(url).toContain(encodeURIComponent("安全运营"));
+  });
+
+  test("omits query param when query is empty", () => {
+    const url = buildSearchUrl("", "101020100");
+    expect(url).not.toContain("query=");
+  });
+});
+
+describe("idFromHref / urlFromHref", () => {
+  test("extracts the id from a relative job_detail href", () => {
+    expect(idFromHref("/job_detail/cf386d859ead4dc40nF92NS0FVNX.html")).toBe(
+      "cf386d859ead4dc40nF92NS0FVNX",
+    );
+  });
+
+  test("handles ids containing a hyphen", () => {
+    expect(idFromHref("/job_detail/0d52d083a8216edb0nF-39u5FlZY.html")).toBe(
+      "0d52d083a8216edb0nF-39u5FlZY",
+    );
+  });
+
+  test("returns null for a non-matching href", () => {
+    expect(idFromHref("/gongsi/whatever.html")).toBeNull();
+    expect(idFromHref(null)).toBeNull();
+  });
+
+  test("urlFromHref prefixes relative hrefs with the base URL", () => {
+    expect(urlFromHref("/job_detail/abc.html")).toBe("https://www.zhipin.com/job_detail/abc.html");
+  });
+
+  test("urlFromHref leaves absolute URLs untouched", () => {
+    expect(urlFromHref("https://www.zhipin.com/job_detail/abc.html")).toBe(
+      "https://www.zhipin.com/job_detail/abc.html",
+    );
+  });
+});
+
+describe("realSalary", () => {
+  test("treats the masked list-view placeholder as missing data", () => {
+    expect(realSalary("-K")).toBeNull();
+    expect(realSalary("-K·薪")).toBeNull();
+  });
+
+  test("passes through a real salary string", () => {
+    expect(realSalary("25-40K")).toBe("25-40K");
+    expect(realSalary("20-40K·16薪")).toBe("20-40K·16薪");
+  });
+
+  test("null in is null out", () => {
+    expect(realSalary(null)).toBeNull();
+  });
+});
+
+describe("companyFromTitle", () => {
+  test("extracts the company name from the detail page <title>", () => {
+    expect(companyFromTitle("「安全运营工程师招聘」_NIO蔚来招聘-BOSS直聘")).toBe("NIO蔚来");
+  });
+
+  test("returns null when the title doesn't match the expected shape", () => {
+    expect(companyFromTitle("BOSS直聘")).toBeNull();
+  });
+});
+
+describe("normalizeUrl (detail)", () => {
+  test("passes an absolute URL through unchanged", () => {
+    expect(normalizeUrl("https://www.zhipin.com/job_detail/abc.html")).toBe(
+      "https://www.zhipin.com/job_detail/abc.html",
+    );
+  });
+
+  test("builds a job_detail URL from a bare id (including hyphens/tildes)", () => {
+    expect(normalizeUrl("0d52d083a8216edb0nF-39u5FlZY")).toBe(
+      "https://www.zhipin.com/job_detail/0d52d083a8216edb0nF-39u5FlZY.html",
+    );
+  });
+
+  test("rejects an id with disallowed characters", () => {
+    expect(normalizeUrl("not a valid id!!")).toBeNull();
+  });
+});
+
+describe("shapeResults", () => {
+  function card(overrides: Partial<RawCard> = {}): RawCard {
+    return {
+      href: "/job_detail/abc123.html",
+      title: "安全运营工程师",
+      company: "NIO蔚来",
+      companyHref: "/gongsi/xyz.html",
+      location: "上海·嘉定区·安亭",
+      salaryRaw: "-K",
+      experience: "1-3年",
+      education: "本科",
+      ...overrides,
+    };
+  }
+
+  test("maps a raw card to the documented JobCard shape", () => {
+    const [result] = shapeResults([card()]);
+    expect(result).toMatchObject({
+      id: "abc123",
+      title: "安全运营工程师",
+      company: "NIO蔚来",
+      location: "上海·嘉定区·安亭",
+      date: null,
+      url: "https://www.zhipin.com/job_detail/abc123.html",
+      salary: null, // masked placeholder -> null
+      experience: "1-3年",
+      education: "本科",
+    });
+  });
+
+  test("drops cards with no extractable id or title", () => {
+    const results = shapeResults([card({ href: null }), card({ title: null })]);
+    expect(results).toHaveLength(0);
+  });
+
+  test("respects the limit", () => {
+    const results = shapeResults([card(), card({ href: "/job_detail/def456.html" })], 1);
+    expect(results).toHaveLength(1);
+  });
+
+  test("passes through a real (unmasked) salary if the page ever stops masking it", () => {
+    const [result] = shapeResults([card({ salaryRaw: "25-40K" })]);
+    expect(result.salary).toBe("25-40K");
+  });
+});
+
+describe("shouldStopScrolling", () => {
+  test("stops once the card count reaches the target", () => {
+    expect(
+      shouldStopScrolling({ count: 45, target: 45, noGrowthStreak: 0, steps: 3 }),
+    ).toBe(true);
+  });
+
+  test("stops after the no-growth streak crosses the threshold", () => {
+    expect(
+      shouldStopScrolling({
+        count: 15,
+        target: 90,
+        noGrowthStreak: NO_GROWTH_STOP_THRESHOLD,
+        steps: 2,
+      }),
+    ).toBe(true);
+  });
+
+  test("stops once the safety ceiling of scroll steps is hit", () => {
+    expect(
+      shouldStopScrolling({ count: 30, target: 90, noGrowthStreak: 0, steps: MAX_SCROLL_STEPS }),
+    ).toBe(true);
+  });
+
+  test("keeps scrolling when none of the stop conditions are met", () => {
+    expect(
+      shouldStopScrolling({ count: 15, target: 45, noGrowthStreak: 1, steps: 2 }),
+    ).toBe(false);
+  });
+});
+
+describe("shapeDetail", () => {
+  function detail(overrides: Partial<RawDetail> = {}): RawDetail {
+    return {
+      title: "安全运营工程师",
+      salary: "25-40K",
+      city: "上海",
+      experience: "1-3年",
+      education: "本科",
+      address: "上海嘉定区蔚来汽车",
+      company: "NIO蔚来",
+      description: "职位描述...",
+      pageTitle: "「安全运营工程师招聘」_NIO蔚来招聘-BOSS直聘",
+      ...overrides,
+    };
+  }
+
+  const URL = "https://www.zhipin.com/job_detail/abc123.html";
+
+  test("maps raw detail data to the documented JobDetail shape", () => {
+    const job = shapeDetail(detail(), URL);
+    expect(job).toMatchObject({
+      id: "abc123",
+      title: "安全运营工程师",
+      company: "NIO蔚来",
+      location: "上海嘉定区蔚来汽车",
+      salary: "25-40K",
+      experience: "1-3年",
+      education: "本科",
+      description: "职位描述...",
+      url: URL,
+    });
+  });
+
+  test("falls back to the page-title company when the sidebar selector is empty", () => {
+    const job = shapeDetail(detail({ company: null }), URL);
+    expect(job?.company).toBe("NIO蔚来");
+  });
+
+  test("falls back to city when no full address is present", () => {
+    const job = shapeDetail(detail({ address: null }), URL);
+    expect(job?.location).toBe("上海");
+  });
+
+  test("returns null when the page didn't render (no title)", () => {
+    expect(shapeDetail(detail({ title: null }), URL)).toBeNull();
+  });
+});

--- a/.agents/skills/zhipin-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/zhipin-search/cli/tests/parsing.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   shapeResults,
   shouldStopScrolling,
+  buildBrowserScript,
   NO_GROWTH_STOP_THRESHOLD,
   MAX_SCROLL_STEPS,
   type RawCard,
@@ -197,6 +198,21 @@ describe("shouldStopScrolling", () => {
     expect(
       shouldStopScrolling({ count: 15, target: 45, noGrowthStreak: 1, steps: 2 }),
     ).toBe(false);
+  });
+});
+
+describe("buildBrowserScript", () => {
+  test("embeds the scroll target and step parameters in the generated script", () => {
+    const script = buildBrowserScript(
+      "https://www.zhipin.com/web/geek/job?query=FDE&city=101020100",
+      45,
+    );
+    expect(script).toContain("scrollBy(1400)");
+    expect(script).toContain("wait(1.2)");
+    expect(script).toContain("count < 45");
+    expect(script).toContain(`steps < ${MAX_SCROLL_STEPS}`);
+    expect(script).toContain(`noGrowthStreak < ${NO_GROWTH_STOP_THRESHOLD}`);
+    expect(script).toContain("cliLog(JSON.stringify(results))");
   });
 });
 

--- a/.agents/skills/zhipin-search/cli/tsconfig.json
+++ b/.agents/skills/zhipin-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun", "node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/zhipin-search/url-reference.md
+++ b/.agents/skills/zhipin-search/url-reference.md
@@ -1,0 +1,187 @@
+# BOSS直聘 (zhipin.com) Reference
+
+> Personal use only. See the "Access model" section below before extending this skill —
+> the access pattern here (authenticated browser automation, not a stateless HTTP client)
+> exists because plain `fetch`/`curl` genuinely cannot retrieve this data, not as a
+> convenience choice.
+
+## Access model
+
+zhipin.com's `/web/geek/job` (and `/web/geek/jobs`) search page is a fully client-rendered
+Vue SPA (`zhipin-geek-spa`). An unauthenticated `curl`/`fetch` request to the search URL
+returns only:
+
+```html
+<div id="app">
+  <div class="page-loading">...加载中，请稍候...</div>
+</div>
+```
+
+followed by ~15 `<script defer>` bundle references. There is no server-rendered HTML with
+job data, and no discovered public JSON API backing the search — the bundles call internal
+endpoints that were not identified as stable/documented enough to hit directly (and doing so
+would face the same robots.txt/ToS issue below regardless).
+
+Real listings only appear after the JS bundle executes inside a **logged-in** session — the
+page prioritizes loading a `boss-login-*.js`/`boss-login-*.css` bundle first, and in practice
+listings only populated during investigation when driven through `ego-browser`, which reuses
+the user's own authenticated Chrome profile.
+
+**Consequence for this CLI**: every command shells out to the `ego-browser` CLI instead of
+`fetch`. This is real browser automation of the user's own logged-in account — not a stealth
+scraper impersonating a browser. Keep usage at the volume a human would generate manually.
+
+## robots.txt
+
+```
+User-agent: *
+Disallow: /*?query=*
+Disallow: *?city=*
+...
+Disallow: /*?*        <- catch-all: any URL with a query string, for any crawler
+```
+
+This explicitly disallows the exact query parameters (`?query=`, `?city=`) this skill's
+search needs, on top of a blanket `/*?*` disallow. Documented here per repo policy for
+ToS/robots-restricted portals — this is why the SKILL.md carries a prominent personal-use
+warning.
+
+## Search
+
+```
+https://www.zhipin.com/web/geek/job?query=<url-encoded text>&city=<9-digit city code>
+```
+
+(Redirects to `/web/geek/jobs?query=...&city=...` — same params.)
+
+### Verified city codes
+
+Confirmed by running a live search and checking that result locations actually matched the
+requested city (not just accepted without error):
+
+| City | Code | Alias accepted by CLI |
+|------|------|------------------------|
+| 上海 (Shanghai) | `101020100` | `上海`, `shanghai` |
+| 北京 (Beijing) | `101010100` | `北京`, `beijing` |
+| 杭州 (Hangzhou) | `101210100` | `杭州`, `hangzhou` |
+| 苏州 (Suzhou) | `101190400` | `苏州`, `suzhou` |
+
+**Finding more city codes**: do not guess or reuse codes copied from other sites' "BOSS直聘
+city code" tables floating around online without verifying — verify by running a search with
+the candidate code and checking that the returned `.company-location` text actually contains
+the expected city name, e.g.:
+
+```js
+await gotoAndWait(`https://www.zhipin.com/web/geek/jobs?query=安全&city=<candidate-code>`, { timeout: 25, settle: 2 })
+await wait(1)
+await js(`[...document.querySelectorAll('li.job-card-box .company-location')].slice(0,3).map(e=>e.innerText)`)
+```
+
+Add the verified code to `CITY_CODES` in `cli/src/helpers.ts` once confirmed.
+
+### Result DOM (verified against a live page dump, 2026-07)
+
+Each result is `li.job-card-box`:
+
+```html
+<li class="job-card-box">
+  <div class="job-info">
+    <div class="job-title clearfix">
+      <a href="/job_detail/<id>.html" class="job-name">安全运营工程师</a>
+      <span class="job-salary">-K</span>          <!-- MASKED, see below -->
+    </div>
+    <ul class="tag-list">
+      <li>1-3年</li>                               <!-- experience -->
+      <li>本科</li>                                 <!-- education -->
+    </ul>
+  </div>
+  <div class="job-card-footer">
+    <a href="/gongsi/<hash>.html" class="boss-info">
+      <span class="boss-name">NIO蔚来</span>
+    </a>
+    <span class="company-location"> 上海·嘉定区·安亭 </span>
+  </div>
+</li>
+```
+
+**Salary is masked in the list view.** `.job-salary`'s text is a literal placeholder like
+`-K` regardless of the real range shown visually elsewhere on the page (BOSS直聘 renders the
+real figure as a canvas overlay, not as this DOM node's text) — treat any value with no
+digits as missing data (`realSalary()` in `helpers.ts` does this). Only the detail page shows
+the real salary.
+
+**No posting date is shown anywhere in the list UI** — there's nothing to map `--jobage` to.
+
+**No pagination controls were observed** beyond the first result batch (and `?page=` is
+separately robots.txt-disallowed as a URL param anyway) — `--page` is accepted for
+CLI-contract compatibility but currently has no effect.
+
+## Detail
+
+```
+https://www.zhipin.com/job_detail/<id>.html
+```
+
+`<id>` is an opaque alphanumeric hash (may contain `-` and `~`), not a sequential number.
+
+### Result DOM (verified against a live page dump, 2026-07)
+
+```html
+<div class="info-primary">
+  <div class="name">
+    <h1 title="安全运营工程师">安全运营工程师</h1>
+    <span class="salary">25-40K</span>              <!-- REAL, unmasked here -->
+  </div>
+  <p>
+    <a class="text-desc text-city" href="/shanghai/">上海</a>
+    <span class="text-desc text-experiece">1-3年</span>   <!-- sic: "experiece" typo in the site's own class name -->
+    <span class="text-desc text-degree">本科</span>
+  </p>
+</div>
+...
+<div class="location-address">上海嘉定区蔚来汽车</div>
+...
+<div class="sider-company">
+  <div class="company-info">
+    <a title="NIO蔚来" href="/gongsi/<hash>.html">...</a>
+  </div>
+</div>
+...
+<div class="job-sec-text">职位描述...</div>          <!-- see anti-scraping note below -->
+```
+
+Company name fallback: `document.title` is `「<job title>招聘」_<company>招聘-BOSS直聘` —
+parsed by `companyFromTitle()` when the sidebar selector comes up empty.
+
+### Anti-scraping text injection in the description (important)
+
+The raw HTML of `.job-sec-text` contains invisible watermark spans injected **mid-word**,
+e.g. the literal DOM is `职位描<span class="zpsWpGDSH">BOSS直聘</span>述` for what a user sees
+as just "职位描述". These spans are not visible on the rendered page (some CSS
+visibility/size trick hides them) but **are** present in `.textContent`/raw HTML/regex
+matches against the page source.
+
+**Always read description text via `el.innerText`, never `el.textContent` or regex on raw
+HTML.** `.innerText` is CSS-visibility-aware and returns what a human actually sees, which
+correctly excludes this injected noise. This is the main reason a static-HTML regex parser
+(the pattern `linkedin-search` uses) would not work cleanly here even if the login-wall
+problem didn't already rule it out — the anti-scraping layer specifically targets raw-HTML
+extraction.
+
+Even with `.innerText`, at least one posting during investigation still showed a garbled
+fragment in the middle of its requirements list (reordered/interleaved characters, a
+different obfuscation from the mid-word injection above) — treat `description` as
+"generally clean, occasionally locally garbled," and sanity-check anything you're about to
+act on (e.g. quoting a JD verbatim) against the live page.
+
+## Notes / quirks
+
+- **First navigation to a search URL sometimes renders job cards as empty `<canvas>`
+  skeleton placeholders** instead of the real DOM described above, if the SPA hasn't
+  finished hydrating. Always use `gotoAndWait(url, { timeout: 25, settle: 2 })` plus one
+  extra `await wait(1)` before extracting; if you still see `<canvas>` where `li.job-card-box`
+  should be, reload once more.
+- Salary masking (list) and description watermarking (detail) both appear to be deliberate
+  anti-scraping measures, not rendering bugs — expect BOSS直聘 to keep iterating on these; if
+  extraction starts returning garbage, re-verify the selectors against a fresh live page dump
+  before assuming the parsing code is wrong.

--- a/docs/superpowers/plans/2026-07-14-zhipin-search-scroll-pagination.md
+++ b/docs/superpowers/plans/2026-07-14-zhipin-search-scroll-pagination.md
@@ -1,0 +1,627 @@
+# zhipin-search Scroll Pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `zhipin-search`'s `search` command scroll to load more than the first screenful of BOSS直聘 results, and remove the dead `--page` flag it currently ships with.
+
+**Architecture:** `buildBrowserScript` (in `search.ts`) currently emits a single `gotoAndWait` + one-shot DOM scrape. It grows a bounded scroll loop (raw `scrollBy` + `wait` + card-count check, generated as JS source text since the script runs inside `ego-browser`'s sandboxed runtime, not this process) before the existing scrape. The loop's stop decision (target reached / no-growth streak / safety ceiling) is mirrored as a standalone pure TypeScript function (`shouldStopScrolling`) so its logic is unit-testable even though the actual loop that runs live is generated JS text.
+
+**Tech Stack:** bun + TypeScript, zero new npm runtime dependencies. `ego-browser` CLI (external, already required) drives the real scroll/DOM interaction.
+
+## Global Constraints
+
+- Zero new npm runtime dependencies (`bun` + `node:child_process` only — unchanged).
+- No new user-facing CLI flags beyond removing `--page`. `--limit` gains a second meaning (also drives how far scrolling goes) but keeps its existing name and default (`undefined` = use the built-in default target).
+- Scroll parameters are fixed internal constants, not flags: step `1400`px, wait `1.2`s between steps, stop after `3` consecutive no-growth steps, hard safety ceiling `12` steps, default target (when `--limit` omitted) `45`.
+- Don't touch `detail.ts`/the `detail` command, and don't touch any sibling `.agents/skills/*-search` directory.
+- Follow this repo's existing test convention: pure-function tests live in `cli/tests/parsing.test.ts`; CLI-process integration tests live in `cli/tests/cli-flag-validation.test.ts`.
+
+---
+
+### Task 1: Add the scroll stop-decision logic (pure, unit-tested)
+
+**Files:**
+- Modify: `.agents/skills/zhipin-search/cli/src/commands/search.ts` (insert after line 31, the end of the `RawCard` interface)
+- Modify: `.agents/skills/zhipin-search/cli/tests/parsing.test.ts` (import line 10; new `describe` block)
+
+**Interfaces:**
+- Produces (consumed by Task 2): `ScrollState` interface `{ count: number; target: number; noGrowthStreak: number; steps: number }`, `shouldStopScrolling(state: ScrollState): boolean`, and exported constants `DEFAULT_TARGET_RESULTS = 45`, `MAX_SCROLL_STEPS = 12`, `NO_GROWTH_STOP_THRESHOLD = 3`, `SCROLL_STEP_PX = 1400`, `SCROLL_WAIT_SECONDS = 1.2` — all from `search.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `.agents/skills/zhipin-search/cli/tests/parsing.test.ts`, change line 10 from:
+
+```ts
+import { shapeResults, type RawCard } from "../src/commands/search";
+```
+
+to:
+
+```ts
+import {
+  shapeResults,
+  shouldStopScrolling,
+  NO_GROWTH_STOP_THRESHOLD,
+  MAX_SCROLL_STEPS,
+  type RawCard,
+} from "../src/commands/search";
+```
+
+Then add this new `describe` block anywhere after the existing `describe("shapeResults", ...)` block (i.e. after line 164, before `describe("shapeDetail", ...)`):
+
+```ts
+describe("shouldStopScrolling", () => {
+  test("stops once the card count reaches the target", () => {
+    expect(
+      shouldStopScrolling({ count: 45, target: 45, noGrowthStreak: 0, steps: 3 }),
+    ).toBe(true);
+  });
+
+  test("stops after the no-growth streak crosses the threshold", () => {
+    expect(
+      shouldStopScrolling({
+        count: 15,
+        target: 90,
+        noGrowthStreak: NO_GROWTH_STOP_THRESHOLD,
+        steps: 2,
+      }),
+    ).toBe(true);
+  });
+
+  test("stops once the safety ceiling of scroll steps is hit", () => {
+    expect(
+      shouldStopScrolling({ count: 30, target: 90, noGrowthStreak: 0, steps: MAX_SCROLL_STEPS }),
+    ).toBe(true);
+  });
+
+  test("keeps scrolling when none of the stop conditions are met", () => {
+    expect(
+      shouldStopScrolling({ count: 15, target: 45, noGrowthStreak: 1, steps: 2 }),
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun test tests/parsing.test.ts
+```
+
+Expected: FAIL — `shouldStopScrolling`, `NO_GROWTH_STOP_THRESHOLD`, `MAX_SCROLL_STEPS` are not exported from `../src/commands/search` (module has no such exports / TypeScript error).
+
+- [ ] **Step 3: Implement the minimal code to make the test pass**
+
+In `.agents/skills/zhipin-search/cli/src/commands/search.ts`, change:
+
+```ts
+export interface RawCard {
+  href: string | null
+  title: string | null
+  company: string | null
+  companyHref: string | null
+  location: string | null
+  salaryRaw: string | null
+  experience: string | null
+  education: string | null
+}
+
+// Verified selectors (li.job-card-box) — see url-reference.md for how these were
+```
+
+to:
+
+```ts
+export interface RawCard {
+  href: string | null
+  title: string | null
+  company: string | null
+  companyHref: string | null
+  location: string | null
+  salaryRaw: string | null
+  experience: string | null
+  education: string | null
+}
+
+// Scroll-loop tuning. BOSS直聘's result list loads in fixed +15-card batches;
+// live spike testing (see docs/superpowers/specs/2026-07-14-zhipin-search-scroll-pagination-design.md)
+// found real growth never produces more than 1 consecutive flat step, so 3 is a
+// safe margin for "genuinely done." Kept as fixed constants (not flags) — this
+// tool is personal, low-volume use only, not meant to become a deep crawler.
+export const DEFAULT_TARGET_RESULTS = 45
+export const MAX_SCROLL_STEPS = 12
+export const NO_GROWTH_STOP_THRESHOLD = 3
+export const SCROLL_STEP_PX = 1400
+export const SCROLL_WAIT_SECONDS = 1.2
+
+export interface ScrollState {
+  count: number
+  target: number
+  noGrowthStreak: number
+  steps: number
+}
+
+/** Pure: decide whether the scroll loop should stop after observing this step's card count. */
+export function shouldStopScrolling(state: ScrollState): boolean {
+  if (state.count >= state.target) return true
+  if (state.noGrowthStreak >= NO_GROWTH_STOP_THRESHOLD) return true
+  if (state.steps >= MAX_SCROLL_STEPS) return true
+  return false
+}
+
+// Verified selectors (li.job-card-box) — see url-reference.md for how these were
+```
+
+(the trailing comment line is unchanged — reproduced only so the edit's anchor stays contiguous with the untouched code that follows it)
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun test tests/parsing.test.ts
+```
+
+Expected: PASS — all 4 new `shouldStopScrolling` tests green, plus all pre-existing tests in the file still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .agents/skills/zhipin-search/cli/src/commands/search.ts .agents/skills/zhipin-search/cli/tests/parsing.test.ts
+git commit -m "feat(zhipin-search): add pure shouldStopScrolling decision function"
+```
+
+---
+
+### Task 2: Wire the scroll loop into buildBrowserScript, and remove the dead --page flag
+
+**Files:**
+- Modify: `.agents/skills/zhipin-search/cli/src/commands/search.ts:13-19` (`SearchOpts`), `:58-65` (`buildBrowserScript`), `:114-150` (`runSearch`)
+- Modify: `.agents/skills/zhipin-search/cli/src/cli.ts:44-78` (`HELP`), `:103-132` (flag parsing / `SearchOpts` construction)
+- Modify: `.agents/skills/zhipin-search/cli/tests/parsing.test.ts` (new `buildBrowserScript` test)
+- Modify: `.agents/skills/zhipin-search/cli/tests/cli-flag-validation.test.ts:38-67` (`--page` tests)
+
+**Interfaces:**
+- Consumes (from Task 1): `shouldStopScrolling`, `ScrollState`, `DEFAULT_TARGET_RESULTS`, `MAX_SCROLL_STEPS`, `NO_GROWTH_STOP_THRESHOLD`, `SCROLL_STEP_PX`, `SCROLL_WAIT_SECONDS` — the loop generated as JS text mirrors the same threshold values (they're interpolated as literals into the generated script, not re-derived, so both stay in sync by construction).
+- Produces (consumed by Task 3 docs, Task 4 verification): `buildBrowserScript(searchUrl: string, target: number): string`; `SearchOpts` without `page`; CLI no longer accepts `--page`.
+
+- [ ] **Step 1: Write the failing test for `buildBrowserScript`**
+
+In `.agents/skills/zhipin-search/cli/tests/parsing.test.ts`, extend the import from Task 1 to also pull in `buildBrowserScript`:
+
+```ts
+import {
+  shapeResults,
+  shouldStopScrolling,
+  buildBrowserScript,
+  NO_GROWTH_STOP_THRESHOLD,
+  MAX_SCROLL_STEPS,
+  type RawCard,
+} from "../src/commands/search";
+```
+
+Add this `describe` block near the `shouldStopScrolling` block added in Task 1:
+
+```ts
+describe("buildBrowserScript", () => {
+  test("embeds the scroll target and step parameters in the generated script", () => {
+    const script = buildBrowserScript(
+      "https://www.zhipin.com/web/geek/job?query=FDE&city=101020100",
+      45,
+    );
+    expect(script).toContain("scrollBy(1400)");
+    expect(script).toContain("wait(1.2)");
+    expect(script).toContain("count < 45");
+    expect(script).toContain(`steps < ${MAX_SCROLL_STEPS}`);
+    expect(script).toContain(`noGrowthStreak < ${NO_GROWTH_STOP_THRESHOLD}`);
+    expect(script).toContain("cliLog(JSON.stringify(results))");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun test tests/parsing.test.ts
+```
+
+Expected: FAIL — `buildBrowserScript("<url>", 45)` still only takes one argument and doesn't emit a scroll loop, so `toContain("count < 45")` etc. fail.
+
+- [ ] **Step 3: Implement — update `buildBrowserScript` and `SearchOpts` in search.ts**
+
+In `.agents/skills/zhipin-search/cli/src/commands/search.ts`, change the `SearchOpts` interface (current lines 13-19) from:
+
+```ts
+export interface SearchOpts {
+  query?: string
+  location: string
+  page: number
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+```
+
+to:
+
+```ts
+export interface SearchOpts {
+  query?: string
+  location: string
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+```
+
+Then replace the existing `buildBrowserScript` function (current lines 58-65):
+
+```ts
+export function buildBrowserScript(searchUrl: string): string {
+  return [
+    `await gotoAndWait(${JSON.stringify(searchUrl)}, { timeout: 25, settle: 2 })`,
+    `await wait(1)`,
+    `const results = await js(${JSON.stringify(DOM_SCRIPT)})`,
+    `cliLog(JSON.stringify(results))`,
+  ].join("\n")
+}
+```
+
+with:
+
+```ts
+const COUNT_CARDS_SCRIPT = `document.querySelectorAll('li.job-card-box').length`
+
+export function buildBrowserScript(searchUrl: string, target: number): string {
+  return [
+    `await gotoAndWait(${JSON.stringify(searchUrl)}, { timeout: 25, settle: 2 })`,
+    `await wait(1)`,
+    `let count = await js(${JSON.stringify(COUNT_CARDS_SCRIPT)})`,
+    `let noGrowthStreak = 0`,
+    `let steps = 0`,
+    `while (count < ${target} && noGrowthStreak < ${NO_GROWTH_STOP_THRESHOLD} && steps < ${MAX_SCROLL_STEPS}) {`,
+    `  await scrollBy(${SCROLL_STEP_PX})`,
+    `  await wait(${SCROLL_WAIT_SECONDS})`,
+    `  const newCount = await js(${JSON.stringify(COUNT_CARDS_SCRIPT)})`,
+    `  noGrowthStreak = newCount > count ? 0 : noGrowthStreak + 1`,
+    `  count = newCount`,
+    `  steps++`,
+    `}`,
+    `const results = await js(${JSON.stringify(DOM_SCRIPT)})`,
+    `cliLog(JSON.stringify(results))`,
+  ].join("\n")
+}
+```
+
+Then in `runSearch` (current lines 114-150), change:
+
+```ts
+  try {
+    const url = buildSearchUrl(opts.query || "", cityCode)
+    const stdout = await runEgoBrowser(buildBrowserScript(url))
+    const raw = lastJson<RawCard[]>(stdout)
+    const cards = shapeResults(raw, opts.limit)
+```
+
+to:
+
+```ts
+  try {
+    const url = buildSearchUrl(opts.query || "", cityCode)
+    const target = opts.limit ?? DEFAULT_TARGET_RESULTS
+    const stdout = await runEgoBrowser(buildBrowserScript(url, target))
+    const raw = lastJson<RawCard[]>(stdout)
+    const cards = shapeResults(raw, opts.limit)
+```
+
+And change the JSON-format output branch from:
+
+```ts
+    } else {
+      process.stdout.write(
+        JSON.stringify({ meta: { count: cards.length, page: opts.page }, results: cards }, null, 2) + "\n",
+      )
+    }
+```
+
+to:
+
+```ts
+    } else {
+      process.stdout.write(
+        JSON.stringify({ meta: { count: cards.length }, results: cards }, null, 2) + "\n",
+      )
+    }
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun test tests/parsing.test.ts
+```
+
+Expected: PASS for the new `buildBrowserScript` test. The rest of the suite (including `cli-flag-validation.test.ts`) will still FAIL at this point — `cli.ts` still references `flags.page`/`opts.page` against a `SearchOpts` that no longer has `page`. That's expected; fixed in the next steps.
+
+- [ ] **Step 5: Update the flag-validation tests for `--page` removal**
+
+In `.agents/skills/zhipin-search/cli/tests/cli-flag-validation.test.ts`, delete this whole block (current lines 38-46):
+
+```ts
+  describe("--page NaN validation", () => {
+    test("non-numeric string exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--page", "abc"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/page/);
+    });
+  });
+
+```
+
+And change the "valid flags" test (current lines 58-67) from:
+
+```ts
+  describe("valid flags", () => {
+    test("known city name + numeric page/limit produce no BAD_ARG/BAD_LOCATION", async () => {
+      const result = await runCLI([
+        "search", "-l", LOCATION, "--page", "1", "--limit", "5",
+      ]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("BAD_ARG");
+      expect(err.code).not.toBe("BAD_LOCATION");
+      expect(err.code).not.toBe("NO_LOCATION");
+    });
+  });
+```
+
+to:
+
+```ts
+  describe("valid flags", () => {
+    test("known city name + numeric limit produce no BAD_ARG/BAD_LOCATION", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--limit", "5"]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("BAD_ARG");
+      expect(err.code).not.toBe("BAD_LOCATION");
+      expect(err.code).not.toBe("NO_LOCATION");
+    });
+  });
+```
+
+- [ ] **Step 6: Implement — remove `--page` from cli.ts**
+
+In `.agents/skills/zhipin-search/cli/src/cli.ts`, change the `HELP` text block from:
+
+```ts
+  --query, -q <text>      Keywords (job title, skill, or role). Recommended.
+  --page <n>              1-indexed page. Default 1. NOTE: not yet wired up — the
+                          geek search list showed no visible pagination beyond the
+                          first result batch during investigation. Accepted for
+                          contract-compatibility; currently has no effect.
+  --limit, -n <n>         Cap results emitted (client-side).
+```
+
+to:
+
+```ts
+  --query, -q <text>      Keywords (job title, skill, or role). Recommended.
+  --limit, -n <n>         Cap results emitted, and how far \`search\` scrolls to
+                          find them: it scrolls the results list until at least
+                          this many cards have loaded (bounded by a low, fixed
+                          safety ceiling). Omit to use a conservative default
+                          scroll target (45 cards) instead of just the first
+                          screenful.
+```
+
+Then remove the page-parsing block. Change:
+
+```ts
+    if (flags.page !== undefined) {
+      const v = parseIntFlag("page", flags.page)
+      if (v === null) return 1
+      flags.page = String(v)
+    }
+    if (flags.limit !== undefined) {
+      const v = parseIntFlag("limit", flags.limit)
+      if (v === null) return 1
+      flags.limit = String(v)
+    }
+
+    const opts: SearchOpts = {
+      query: typeof flags.query === "string" ? flags.query : undefined,
+      location,
+      page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
+      limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+```
+
+to:
+
+```ts
+    if (flags.limit !== undefined) {
+      const v = parseIntFlag("limit", flags.limit)
+      if (v === null) return 1
+      flags.limit = String(v)
+    }
+
+    const opts: SearchOpts = {
+      query: typeof flags.query === "string" ? flags.query : undefined,
+      location,
+      limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+```
+
+- [ ] **Step 7: Run the full test suite and verify it passes**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun test
+```
+
+Expected: PASS — every test in `parsing.test.ts` and `cli-flag-validation.test.ts` green, no TypeScript errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .agents/skills/zhipin-search/cli/src/commands/search.ts .agents/skills/zhipin-search/cli/src/cli.ts .agents/skills/zhipin-search/cli/tests/parsing.test.ts .agents/skills/zhipin-search/cli/tests/cli-flag-validation.test.ts
+git commit -m "feat(zhipin-search): scroll for more results, remove dead --page flag"
+```
+
+---
+
+### Task 3: Update SKILL.md and cli/README.md
+
+**Files:**
+- Modify: `.agents/skills/zhipin-search/SKILL.md` (Key flags list, "Not supported" line)
+- Modify: `.agents/skills/zhipin-search/cli/README.md` (Search flags table)
+
+**Interfaces:**
+- Consumes: the finalized `--limit`/scroll behavior and constants from Task 2 (target 45 default, scroll ceiling 12 steps) — purely descriptive, no code interface.
+
+This task is documentation only — no test to write/run. Verify by rereading the changed sections after editing.
+
+- [ ] **Step 1: Update SKILL.md**
+
+In `.agents/skills/zhipin-search/SKILL.md`, change:
+
+```markdown
+Key flags:
+- `--location <city>` / `-l <city>` — **required.** A verified city name/alias (上海,
+  北京, 杭州, 苏州, or `shanghai`/`beijing`/`hangzhou`/`suzhou`) or a raw 9-digit
+  BOSS直聘 city code. See `url-reference.md` for how to verify and add a new one.
+- `--query <text>` / `-q <text>` — keyword search (title, skill, role). Recommended.
+- `--limit <n>` / `-n <n>` — cap total results emitted (client-side).
+- `--format json|table|plain` — default `json`.
+
+**Salary is not available from `search`** — BOSS直聘 masks it in the list view
+(returns `null`); use `detail` for the real figure. Not supported: `--jobage`
+(no posting-date filter/field exists on this portal), `--page` (accepted but not
+wired up — no pagination was observed in the geek search list).
+```
+
+to:
+
+```markdown
+Key flags:
+- `--location <city>` / `-l <city>` — **required.** A verified city name/alias (上海,
+  北京, 杭州, 苏州, or `shanghai`/`beijing`/`hangzhou`/`suzhou`) or a raw 9-digit
+  BOSS直聘 city code. See `url-reference.md` for how to verify and add a new one.
+- `--query <text>` / `-q <text>` — keyword search (title, skill, role). Recommended.
+- `--limit <n>` / `-n <n>` — cap total results emitted, **and how far `search` scrolls to find them**: it
+  scrolls the results list until at least this many cards have loaded, up to a fixed safety ceiling. Omit to
+  use a conservative default scroll target (45 cards) instead of just the first screenful.
+- `--format json|table|plain` — default `json`.
+
+**Salary is not available from `search`** — BOSS直聘 masks it in the list view
+(returns `null`); use `detail` for the real figure. Not supported: `--jobage`
+(no posting-date filter/field exists on this portal).
+
+**Pagination is scroll-driven, not a flag.** BOSS直聘's result list is infinite-scroll, not
+page-numbered — an earlier `--page` flag never did anything and has been removed. `search` now
+scrolls automatically (bounded — a handful of steps, not a deep crawl, matching this skill's
+personal-use-only posture) before scraping.
+```
+
+- [ ] **Step 2: Update cli/README.md**
+
+In `.agents/skills/zhipin-search/cli/README.md`, change the "Search flags" table from:
+
+```markdown
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--location` | `-l` | **Required.** A verified city name/alias (上海, 北京, 杭州, 苏州, or shanghai/beijing/hangzhou/suzhou) or a raw 9-digit city code. |
+| `--query` | `-q` | Keywords (title / skill / role). Recommended. |
+| `--page` | | Accepted, not yet wired up (no pagination observed in the geek search list). |
+| `--limit` | `-n` | Cap results emitted. |
+| `--format` | | `json` \| `table` \| `plain`. |
+
+Not supported: `--jobage` (no posting-date filter or field exists in this portal's UI),
+`--remote` (no workplace-type filter observed).
+```
+
+to:
+
+```markdown
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--location` | `-l` | **Required.** A verified city name/alias (上海, 北京, 杭州, 苏州, or shanghai/beijing/hangzhou/suzhou) or a raw 9-digit BOSS直聘 city code. |
+| `--query` | `-q` | Keywords (title / skill / role). Recommended. |
+| `--limit` | `-n` | Cap results emitted, and how far `search` scrolls to find them (see below). |
+| `--format` | | `json` \| `table` \| `plain`. |
+
+Not supported: `--jobage` (no posting-date filter or field exists in this portal's UI),
+`--remote` (no workplace-type filter observed).
+
+**Scroll-driven pagination.** BOSS直聘's result list is infinite-scroll, not page-numbered
+(an earlier `--page` flag never worked and has been removed). `search` scrolls the page,
+in bounded steps, until either `--limit` cards have loaded, the list stops growing, or a
+low fixed step ceiling is hit — never an unbounded crawl, matching this skill's
+personal, low-volume use only posture. Omit `--limit` to use a default scroll target of
+45 cards.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .agents/skills/zhipin-search/SKILL.md .agents/skills/zhipin-search/cli/README.md
+git commit -m "docs(zhipin-search): describe scroll-driven pagination, drop --page mentions"
+```
+
+---
+
+### Task 4: Install, run the full suite, and verify live against zhipin.com
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+- Produces: a verified, working `search` command — the deliverable of this whole plan.
+
+- [ ] **Step 1: Install dependencies**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun install
+```
+
+Expected: completes without error (installs TypeScript dev types only, per this skill's zero-npm-runtime-deps design — `node_modules` is gitignored, this is regenerating it in the worktree).
+
+- [ ] **Step 2: Run the full automated test suite**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun test
+```
+
+Expected: PASS — every test across `parsing.test.ts` and `cli-flag-validation.test.ts` green.
+
+- [ ] **Step 3: Live end-to-end verification — default target**
+
+Requires Chrome running with an active, logged-in BOSS直聘 session (already the case in this environment).
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun run src/cli.ts search -q "FDE" -l "上海" --format table
+```
+
+Expected: more than 15 rows in the output table — the documented baseline before this fix was exactly 15; the default scroll target is 45, so expect somewhere around 45 results (it may land a little under if the query's real ceiling is below 45, or stop early at a batch boundary at/above 45 — either is correct; what must NOT happen is exactly 15).
+
+- [ ] **Step 4: Live end-to-end verification — explicit `--limit` drives further scrolling**
+
+```bash
+cd .agents/skills/zhipin-search/cli
+bun run src/cli.ts search -q "FDE" -l "上海" --limit 60 --format table
+```
+
+Expected: more results than Step 3's run (targeting 60 instead of the default 45), demonstrating `--limit` actually changes how far the tool scrolls — not just how many of an already-fixed set it slices.
+
+- [ ] **Step 5: Report results**
+
+No commit for this task (verification only). Summarize in your final report to the user: automated test pass/fail, and the exact row counts from Steps 3 and 4 compared against the 15-row baseline.

--- a/docs/superpowers/specs/2026-07-14-zhipin-search-scroll-pagination-design.md
+++ b/docs/superpowers/specs/2026-07-14-zhipin-search-scroll-pagination-design.md
@@ -1,0 +1,93 @@
+# zhipin-search: scroll-triggered pagination
+
+## Problem
+
+`.agents/skills/zhipin-search/cli/src/commands/search.ts` scrapes BOSS直聘 search
+results with a single `gotoAndWait` + `wait(1)` + one-shot DOM scrape of
+`li.job-card-box`. BOSS直聘's result list is an infinite-scroll SPA, so this only
+ever captures the first screenful. Verified live: `-q "FDE" -l "上海"` always
+returns exactly 15 results, regardless of how many actually exist.
+
+The CLI also has a `--page` flag (`cli.ts`, `SearchOpts.page`) that has never done
+anything — `buildSearchUrl(query, cityCode)` in `helpers.ts` takes no page
+parameter and BOSS直聘 doesn't paginate by URL; it's scroll-based. `SKILL.md` and
+`cli/README.md` already document this honestly as "not yet wired up."
+
+## Empirical findings (spike, live against zhipin.com)
+
+Tested via raw `ego-browser` heredocs against `-q "FDE" -l "上海"` before writing
+any code:
+
+- Initial render: 15 cards.
+- Each additional batch is **exactly +15 cards**, and a raw `scrollBy(1200-1400)` +
+  `wait(1-1.2s)` step only triggers a new batch **every other call** — one step
+  advances the viewport without yet reaching the new lazy-load trigger point, the
+  next step crosses it. So a naive "did the count grow after *this* step" check
+  is not a safe stop signal by itself.
+- The list plateaued at **90 cards** and stayed there through 15 more scroll
+  attempts — a real ceiling exists per query, and once reached it's stable (no
+  flapping).
+- The SDK's own `scrollToBottomUntil(predicate, {step, wait, maxSteps})` helper
+  was tried with two parameter sets (step 900/wait 1, step 1400/wait 1.2) and in
+  both cases exited after exactly 3 internal steps while still at the 15-card
+  baseline — it appears to have its own "stuck" heuristic that doesn't tolerate
+  this site's every-other-step load pattern. Not used in the implementation for
+  that reason.
+
+## Design
+
+### 1. Manual scroll loop (replaces one-shot scrape)
+
+In `buildBrowserScript`, after the existing `gotoAndWait` + initial `wait(1)`,
+loop:
+
+```
+scrollBy(1400) -> wait(1.2) -> count `li.job-card-box`
+```
+
+Stop when the first of these is true:
+- **Target reached**: card count ≥ target (see below).
+- **Real end-of-list**: 3 consecutive steps with no count increase (empirically,
+  genuine growth never produces more than 1 consecutive flat step; 3 is a safe
+  margin above that).
+- **Safety ceiling**: 12 scroll steps taken (≈6 batches ≈ up to ~105 cards) — a
+  hard stop regardless of the above, so a pathological page can't loop forever.
+
+Then run the existing one-shot `DOM_SCRIPT` scrape as today (now over a DOM that
+has more cards loaded into it).
+
+### 2. Target count = combination of `--limit` and a conservative default
+
+- If the caller passed `--limit N`, target = N (stop scrolling as soon as enough
+  cards are loaded — avoids scrolling further than needed, keeping this tool's
+  "handful of searches, not a crawl" posture).
+- If `--limit` was not passed (today this means "return everything visible"),
+  target defaults to **45** (3 batches) — noticeably more than the current
+  hard-capped-at-15 behavior, but well short of scrolling every query to its
+  true ceiling by default. This is an internal constant, not a new flag.
+
+### 3. Remove `--page`
+
+Delete it from `cli.ts` (`SearchOpts.page`, parsing, help text), and from any
+test that references it. Update `SKILL.md` and `cli/README.md` to describe the
+real scroll behavior in place of the "not yet wired up" note.
+
+### 4. Testing
+
+- Extract the stop-decision as a pure function, e.g.
+  `shouldStopScrolling({ count, target, noGrowthStreak, steps, maxSteps })  boolean`,
+  and unit test it directly (no browser needed) — covers target-reached,
+  3-flat-steps, and safety-ceiling branches.
+- Update `cli-flag-validation.test.ts` / `parsing.test.ts` for `--page` removal.
+- Live verification (manual, not part of the automated suite): re-run
+  `-q "FDE" -l "上海"` through the modified CLI and confirm the result count
+  moves from the old baseline of 15 to ~45 (default target), and that
+  `--limit 60` pulls further (up to the 90-card real ceiling) without exceeding
+  the safety ceiling.
+
+### Out of scope
+
+- `detail` command — untouched.
+- Sibling portal skills (`linkedin-search`, `jobbank-search`, etc.) — untouched.
+- No new npm runtime dependencies (`bun` + `node:child_process` only, unchanged).
+- No new user-facing CLI flags beyond removing `--page`.


### PR DESCRIPTION
## Summary
- `zhipin-search`'s `search` command only ever scraped the first screenful of BOSS直聘's infinite-scroll results (a fixed, undocumented cap of exactly 15). It now scrolls in bounded steps (step 1400px, wait 1.2s, stop after 3 consecutive no-growth checks or a 12-step safety ceiling) before scraping.
- `--limit` now drives both how many results are returned **and** how far the tool scrolls to find them (target = `--limit`, or a default of 45 when omitted). The previously dead `--page` flag (never wired up — BOSS直聘 has no URL-based pagination) has been removed entirely.
- Design and implementation were spiked empirically against the live site first (see `docs/superpowers/specs/2026-07-14-zhipin-search-scroll-pagination-design.md`) rather than guessed — the +15-per-batch load pattern and the every-other-scroll-step trigger quirk were both measured before writing the stopping-condition logic.

## Test plan
- [x] `bun test` — 42/42 passing
- [x] Live verification in a fresh browser context: scroll count grows 15→15→30→30→45, matching the empirical spike
- [x] Per-task spec-compliance + code-quality review (3 tasks, all approved)
- [x] Final whole-branch review: caught and fixed one Critical issue (six pre-existing supporting files — `helpers.ts`, `detail.ts`, test helpers, configs — were never `git add`ed by any task since this skill directory was previously untracked; fixed in a follow-up commit and reverified with a clean `bun test` run)

Full implementation plan: `docs/superpowers/plans/2026-07-14-zhipin-search-scroll-pagination.md`