### PR TITLE
docs(readme): make install loops failure-isolated per iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ PowerShell:
 ```powershell
 $tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search")
 foreach ($tool in $tools) {
-  Set-Location ".agents/skills/$tool/cli"
+  Push-Location ".agents/skills/$tool/cli"
   bun install
-  Set-Location "..\..\..\.."
+  Pop-Location
 }
 ```
 
@@ -93,7 +93,7 @@ Bash / zsh / Git Bash:
 
 ```bash
 for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search; do
-  cd .agents/skills/$tool/cli && bun install && cd ../../../..
+  (cd .agents/skills/$tool/cli && bun install)
 done
 ```
 


### PR DESCRIPTION
## Failing case

In both Quick start install loops (PowerShell and bash), a failed iteration skips the `cd` back to the repo root, so every remaining tool's `cd` fails in cascade and the shell ends up stranded deep in `.agents/skills/` with nothing else installed.

Reproduced on Linux with the original bash block and `bun` absent from `PATH`:

```
bash: line 2: bun: command not found
bash: line 2: cd: .agents/skills/jobdanmark-search/cli: No such file or directory
bash: line 2: cd: .agents/skills/jobindex-search/cli: No such file or directory
bash: line 2: cd: .agents/skills/jobnet-search/cli: No such file or directory
bash: line 2: cd: .agents/skills/linkedin-search/cli: No such file or directory
bash: line 2: cd: .agents/skills/freehire-search/cli: No such file or directory
PWD after loop: .agents/skills/jobbank-search/cli
```

One `bun` failure turns into five misleading `cd` errors, and a user who fixes bun and re-runs the loop from that directory gets six more.

## Fix

- **bash:** run each iteration in a subshell — `(cd ... && bun install)` — so the directory change dies with the subshell and there is no `cd` back to get skipped.
- **PowerShell:** `Push-Location` / `Pop-Location` instead of `Set-Location` with a hand-counted `"..\..\..\.."`.

No behavior change on the happy path.

## Verification

- Failure mode (bun absent): six independent `bun: command not found` errors, no cascade, loop ends at the repo root.
- Happy path (Linux, bun 1.3.14): all six CLIs install, `node_modules` present in each, loop ends at the repo root, working tree clean afterwards.
- The PowerShell block was not executed (no `pwsh` on the test machine); it mirrors the subshell semantics with the standard location stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EQ2xeixvVdnvbihce3aSt