### PR TITLE
feat(agy): add root AGENTS.md thin-pointer specification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Guidelines: AI Job Search
+
+This workspace is structured to manage job search activities, scraper tools, CVs, cover letters, and interview preparation.
+
+## Thin-Pointer Design (Single Source of Truth)
+
+To prevent duplication and configuration drift across different AI agent frameworks (Claude Code, Google Antigravity, Codex, Cursor, Gemini CLI, etc.), this workspace uses a unified thin-pointer design. All agent runtimes should load the canonical specifications and candidate profiles from the files and directories below:
+
+1. **Personal Candidate Profile:**
+   - The candidate profile, contact details, education, and target preferences are defined in [CLAUDE.md](CLAUDE.md).
+2. **Canonical Workflow Specifications:**
+   - The step-by-step instructions and triggers for tasks (setup, scrape, rank, apply, upskill, interview) are defined in the [.claude/](.claude/) directory (specifically under `.claude/skills/` and `.claude/commands/`).
+   - Do not duplicate these rules or specifications. Treat `.claude/` files as the single source of truth.
+
+---
+**Framework Version:** 1.0.0


### PR DESCRIPTION
Implements the root-level AGENTS.md pointers file as discussed in #78 to support Google Antigravity, Codex, Cursor, and Gemini runtimes tool-neutrally.