### PR TITLE
feat(job-scraper): per-portal enabled toggle honored by /scrape

### DIFF
--- a/.agents/skills/freehire-search/SKILL.md
+++ b/.agents/skills/freehire-search/SKILL.md
@@ -11,6 +11,7 @@ description: >
   jobs, engineering vacancies, data/ML jobs, DevOps roles, remote developer jobs,
   "are there any <tech role> jobs in <place>", look up this freehire job posting.
 context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/freehire-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobbank-search/SKILL.md
+++ b/.agents/skills/jobbank-search/SKILL.md
@@ -19,6 +19,7 @@ description: >
   jobbank søgning, find stilling, data scientist job, software developer job,
   projektleder stilling, konsulent job, data analyse job.
 context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobbank-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobdanmark-search/SKILL.md
+++ b/.agents/skills/jobdanmark-search/SKILL.md
@@ -17,6 +17,7 @@ description: >
   work in denmark, employment denmark, job denmark, jobs near me denmark,
   apprentice denmark, internship denmark, part-time denmark, full-time denmark.
 context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobdanmark-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobindex-search/SKILL.md
+++ b/.agents/skills/jobindex-search/SKILL.md
@@ -17,6 +17,7 @@ description: >
   hiring denmark, job listings denmark, python jobs denmark, grafisk designer job,
   data engineer job, softwareudvikler job, full stack developer job danmark.
 context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobindex-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobnet-search/SKILL.md
+++ b/.agents/skills/jobnet-search/SKILL.md
@@ -18,6 +18,7 @@ description: >
   social worker job denmark, occupation search denmark, esco occupation, job deadline,
   ansøgningsfrist, søg efter job, full time job denmark, part time job denmark.
 context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobnet-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/linkedin-search/SKILL.md
+++ b/.agents/skills/linkedin-search/SKILL.md
@@ -11,6 +11,7 @@ description: >
   positions open, remote jobs, "are there any X jobs in <place>", look up this
   job posting.
 context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/linkedin-search/cli/src/cli.ts *)
 ---
 

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -59,7 +59,9 @@ If this fails (bun not installed), skip to **1c (WebSearch fallback)** for all p
 
 Discover all installed portal CLI skills by reading every `SKILL.md` found under `.agents/skills/*/SKILL.md`. Each file documents that portal's exact CLI flags and usage examples. **Use each portal's own documented interface — do not guess flags.** This approach automatically includes any new portals added via `/add-portal` without requiring changes to this file.
 
-For each installed portal skill:
+**Honor the `enabled` toggle.** A portal is enabled unless its `SKILL.md` frontmatter sets `enabled: false` (a missing key means enabled — the default). Skip each disabled portal and record it for the Step 5 summary. A fork can thus keep a portal installed but sit out a run without deleting its directory.
+
+For each **enabled** portal skill:
 
 1. Read its `SKILL.md` to find the correct `bun run …` invocation and supported flags.
 2. Translate the query terms from `search-queries.md` into that portal's flag format (e.g. `--key`, `--search-string`, `--query`, filter codes — whatever the portal's SKILL.md specifies).
@@ -152,12 +154,17 @@ specific person was found; these are search links, not results.
 
 ### Step 5: Present Results
 
-Present new jobs in a table sorted by fit (high first):
+Present new jobs in a table sorted by fit (high first). When Step 1b skipped
+portals (`enabled: false`), report them with the `skipped (disabled):` line below
+so opting one out stays visible rather than silent; omit the line when nothing
+was skipped.
 
 ```
 ## New Job Matches - YYYY-MM-DD
 
 Found X new positions (Y high, Z medium, W low match).
+
+skipped (disabled): <portal-name>, <portal-name>
 
 | # | Fit | Title | Company | Location | Deadline | URL |
 |---|-----|-------|---------|----------|----------|-----|


### PR DESCRIPTION
Implements the shape approved in [discussion #93](https://github.com/MadsLorentzen/ai-job-search/discussions/93#discussioncomment-17608228).

## What

Adds a lightweight way to keep a portal skill installed but skip it in a `/scrape` run — without deleting its directory (destructive, and returns on rebase) or editing scrape logic.

- **`enabled: true|false` frontmatter field** added to each portal `SKILL.md`, defaulting to `true`. A missing key means enabled, so this is a no-op for existing installs and any portal that doesn't set it.
- **`/scrape` honors the toggle** during portal enumeration (Step 1b): a portal is skipped only when its frontmatter explicitly sets `enabled: false`. Its CLI is not run.
- **Skipped portals are reported** in the run summary (Step 5) as `skipped (disabled): <portal-name>`, so disabling a portal is a visible choice rather than silent data loss — per the maintainer's added requirement in the discussion.

No new command, no separate registry/config file: the setting travels with the skill and survives rebases, and `/scrape` already reads each `SKILL.md`.

## Scope

Market-agnostic mechanism only — this is not country-specific portal content. The field is added to the six portal skills currently in the template (`freehire`, `jobbank`, `jobdanmark`, `jobindex`, `jobnet`, `linkedin`), each set to `true` so nothing changes by default.

## Verification

- `python tools/lint_skills.py` passes (9 skills, 9 commands, settings.json)
- Each portal frontmatter parses as a proper YAML boolean (inline explanatory comment is correctly ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)