### PR TITLE
feat(portals): German market integration — arbeitsagentur-search and arbeitnow-search skills

### DIFF
--- a/.agents/skills/arbeitnow-search/SKILL.md
+++ b/.agents/skills/arbeitnow-search/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: arbeitnow-search
+version: 1.0.0
+description: >
+  Use this skill when the user wants to search tech, startup, or English-speaking
+  jobs in Germany, remote jobs in Germany, or jobs with visa sponsorship — via the
+  free Arbeitnow job board API. Good complement to arbeitsagentur-search: Arbeitnow
+  skews towards IT/startup/international roles, while the Arbeitsagentur covers the
+  whole market. Trigger phrases include: arbeitnow, english speaking jobs germany,
+  jobs with visa sponsorship germany, remote jobs germany, startup jobs berlin,
+  tech jobs germany, developer jobs germany english, IT jobs für englischsprachige,
+  remote stelle deutschland, homeoffice job tech, international jobs germany.
+context: fork
+allowed-tools: Bash(bun run .agents/skills/arbeitnow-search/cli/src/cli.ts *)
+---
+
+# Arbeitnow Search Skill
+
+Search job listings from the free Arbeitnow job board API — **no API key, no
+registration, zero runtime dependencies**. Focus: jobs in Germany with a
+tech/startup/English-speaking slant, including remote and visa-sponsorship
+friendly roles.
+
+> **Important:** the API ignores server-side filter parameters, so this CLI fetches
+> pages (100 jobs each, newest first) and filters **client-side**. Use `--pages` to
+> control how deep it searches (default 3 = 300 jobs).
+
+## When to use this skill
+
+- Search tech/startup/English-speaking jobs in Germany by keyword
+- Find remote or hybrid roles in the German market
+- Complement an `arbeitsagentur-search` run with startup/international postings
+- Get the full description of a specific Arbeitnow posting
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run .agents/skills/arbeitnow-search/cli/src/cli.ts search [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q` — keyword filter, matched case-insensitively against title, tags, company, and description (client-side)
+- `--location <text>` / `-l` — filter by location substring (e.g. `Berlin`, `Munich`)
+- `--remote` — only remote jobs; `--onsite` — only non-remote jobs
+- `--jobage <days>` — only jobs posted within the last N days (client-side, from `created_at`)
+- `--pages <n>` — how many API pages to scan (100 jobs/page, default 3, max 10)
+- `--page <n>` — 1-indexed start page (default 1)
+- `--limit <n>` — cap results the CLI outputs
+- `--format json|table|plain` (default `json`)
+
+### Fetch full job detail
+
+```bash
+bun run .agents/skills/arbeitnow-search/cli/src/cli.ts detail <slug|url> [--format json|plain]
+```
+
+`slug` is the `id` from search results (e.g. `senior-developer-berlin-123456`); a full
+`arbeitnow.com/jobs/...` URL also works. Scans up to 10 pages for the slug and returns
+the full description (HTML stripped in `plain`).
+
+---
+
+## How to use effectively
+
+**Search German AND English terms.** Listings are mixed-language — try
+`-q entwickler` as well as `-q developer`.
+
+**Increase `--pages` for rare keywords.** The default scans 300 recent jobs;
+`--pages 10` scans 1000.
+
+**Run `detail` soon after `search`.** Detail scans for the slug in the same list,
+so very old postings may have rotated out.
+
+---
+
+## Usage examples
+
+### Remote developer jobs
+
+```bash
+bun run .agents/skills/arbeitnow-search/cli/src/cli.ts search \
+  -q developer --remote --format table
+```
+
+### Python jobs in Berlin, last 14 days
+
+```bash
+bun run .agents/skills/arbeitnow-search/cli/src/cli.ts search \
+  -q python -l Berlin --jobage 14 --format table
+```
+
+### Marketing roles, deep scan
+
+```bash
+bun run .agents/skills/arbeitnow-search/cli/src/cli.ts search \
+  -q marketing --pages 10 --limit 20 --format table
+```
+
+### Full details for a posting
+
+```bash
+bun run .agents/skills/arbeitnow-search/cli/src/cli.ts detail senior-developer-berlin-123456 --format plain
+```
+
+---
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing slugs to `detail` |
+| `table` | Quick human-readable overview |
+| `plain` | Reading a single job's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the
+process exits with code `1`.
+
+---
+
+## Notes
+
+- Free public API (`arbeitnow.com/api/job-board-api`), no key. The API asks not to
+  be abused — the CLI caps page scans at 10 and retries politely.
+- Server-side `search`/`remote` params are silently ignored by the API — everything
+  is filtered client-side (see `url-reference.md`).
+- `date` in results is derived from the unix `created_at` timestamp.
+- `meta.count` in JSON output is the number of matches found in the scanned pages,
+  not a global total (the API does not expose one for a filtered view).

--- a/.agents/skills/arbeitnow-search/cli/README.md
+++ b/.agents/skills/arbeitnow-search/cli/README.md
@@ -1,0 +1,23 @@
+# arbeitnow-cli
+
+CLI for the free **Arbeitnow job board API** — jobs in Germany with a
+tech/startup/English-speaking focus. No API key, no registration, **zero runtime
+dependencies** (plain `bun` + `fetch`).
+
+The API ignores server-side filter parameters, so this CLI fetches pages
+(100 jobs each) and filters client-side. See `../url-reference.md`.
+
+## Install & run
+
+```bash
+bun install        # dev types only
+bun run src/cli.ts search -q developer --remote --format table
+bun run src/cli.ts detail <slug> --format plain
+```
+
+## Test & typecheck
+
+```bash
+bun run test        # includes live smoke tests against the API
+bun run typecheck
+```

--- a/.agents/skills/arbeitnow-search/cli/package.json
+++ b/.agents/skills/arbeitnow-search/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "arbeitnow-cli",
+  "version": "1.0.0",
+  "description": "CLI for the free Arbeitnow job board API (Germany, tech/startup/English-speaking focus) — no API key, zero runtime dependencies.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "arbeitnow-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest"
+  }
+}

--- a/.agents/skills/arbeitnow-search/cli/src/cli.ts
+++ b/.agents/skills/arbeitnow-search/cli/src/cli.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env bun
+// Self-contained CLI for the free Arbeitnow job board API (Germany; tech/startup/
+// English-speaking focus). No API key, zero runtime dependencies.
+//
+// The API ignores server-side filter params (verified), so this CLI fetches pages
+// (100 jobs each, newest first) and filters client-side. Page scans are capped to
+// keep request volume low — the API asks not to be abused.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+import { MAX_PAGES } from "./helpers.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", l: "location", n: "limit" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `arbeitnow-cli — search the free Arbeitnow job board (Germany, tech/startup focus)
+
+USAGE
+  bun run src/cli.ts search [flags]
+  bun run src/cli.ts detail <slug|url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>      Keyword filter (title, tags, company, description). Client-side.
+  --location, -l <text>   Location substring filter (e.g. "Berlin", "Munich").
+  --remote                Only remote jobs.       --onsite   Only non-remote jobs.
+  --jobage <days>         Only jobs posted within the last N days.
+  --pages <n>             API pages to scan, 100 jobs each (default 3, max ${MAX_PAGES}).
+  --page <n>              1-indexed start page. Default 1.
+  --limit, -n <n>         Cap results emitted.
+  --format <fmt>          json (default) | table | plain.
+
+EXAMPLES
+  bun run src/cli.ts search -q developer --remote --format table
+  bun run src/cli.ts search -q python -l Berlin --jobage 14 --format table
+  bun run src/cli.ts search -q marketing --pages 10 --limit 20 --format table
+  bun run src/cli.ts detail senior-developer-berlin-123456 --format plain
+
+Data source: free public API (arbeitnow.com/api/job-board-api), no key. Keep volume low.
+`
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
+    const val = parseInt(raw as string, 10)
+    if (isNaN(val)) {
+      process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+      return null
+    }
+    return val
+  }
+
+  if (cmd === "search") {
+    const fmt = (flags.format as string) || "json"
+
+    if (flags.remote === true && flags.onsite === true) {
+      process.stderr.write(JSON.stringify({ error: "--remote and --onsite are mutually exclusive", code: "BAD_ARG" }) + "\n")
+      return 1
+    }
+
+    let jobage: number | undefined
+    let page = 1
+    let pages = 3
+    let limit: number | undefined
+
+    if (flags.jobage !== undefined) {
+      const v = parseIntFlag("jobage", flags.jobage)
+      if (v === null) return 1
+      jobage = Math.max(0, v)
+    }
+    if (flags.page !== undefined) {
+      const v = parseIntFlag("page", flags.page)
+      if (v === null) return 1
+      page = Math.max(1, v)
+    }
+    if (flags.pages !== undefined) {
+      const v = parseIntFlag("pages", flags.pages)
+      if (v === null) return 1
+      pages = Math.min(Math.max(1, v), MAX_PAGES)
+    }
+    if (flags.limit !== undefined) {
+      const v = parseIntFlag("limit", flags.limit)
+      if (v === null) return 1
+      limit = v
+    }
+
+    const opts: SearchOpts = {
+      query: typeof flags.query === "string" ? flags.query : undefined,
+      location: typeof flags.location === "string" ? flags.location : undefined,
+      remote: flags.remote === true ? true : flags.onsite === true ? false : undefined,
+      jobage,
+      page,
+      pages,
+      limit,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(JSON.stringify({ error: "detail requires a <slug|url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      id,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main().then((code) => process.exit(code))

--- a/.agents/skills/arbeitnow-search/cli/src/commands/detail.ts
+++ b/.agents/skills/arbeitnow-search/cli/src/commands/detail.ts
@@ -1,0 +1,60 @@
+import { fetchPage, mapJob, stripHtml, writeError, MAX_PAGES, type RawJob } from "../helpers.js"
+
+export interface DetailOpts {
+  id: string
+  format: "json" | "plain"
+}
+
+/** Accept a raw slug or an arbeitnow.com job URL. */
+export function normalizeSlug(input: string): string | null {
+  const url = input.match(/arbeitnow\.com\/jobs\/(?:companies\/[^/]+\/)?([^/?#\s]+)/)
+  if (url) return url[1]
+  if (/^[a-z0-9][a-z0-9-]*$/i.test(input)) return input
+  return null
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const slug = normalizeSlug(opts.id)
+  if (!slug) {
+    writeError(`Could not parse a slug from "${opts.id}"`, "BAD_ID")
+    return 1
+  }
+  try {
+    let found: RawJob | undefined
+    for (let p = 1; p <= MAX_PAGES; p++) {
+      const data = await fetchPage(p)
+      found = (data.data ?? []).find((j) => j.slug === slug)
+      if (found) break
+      if (!data.links?.next) break
+    }
+    if (!found) {
+      writeError(`Job "${slug}" not found in the ${MAX_PAGES * 100} most recent listings`, "NOT_FOUND")
+      return 1
+    }
+
+    const base = mapJob(found)
+    const job = { ...base, jobTypes: found.job_types ?? [], description: found.description || null }
+
+    if (opts.format === "plain") {
+      const lines = [
+        job.title,
+        `${job.company || "—"} · ${job.location || "—"}${job.remote ? " · remote" : ""}`,
+        "",
+        job.tags.length > 0 ? `Tags: ${job.tags.join(", ")}` : "",
+        job.jobTypes.length > 0 ? `Type: ${job.jobTypes.join(", ")}` : "",
+        job.date ? `Posted: ${job.date}` : "",
+        "",
+        job.description ? stripHtml(job.description) : "(no description)",
+        "",
+        `URL: ${job.url}`,
+      ].filter((l) => l !== "")
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/arbeitnow-search/cli/src/commands/search.ts
+++ b/.agents/skills/arbeitnow-search/cli/src/commands/search.ts
@@ -1,0 +1,84 @@
+import {
+  fetchPage,
+  mapJob,
+  matchesFilters,
+  writeError,
+  MAX_PAGES,
+  type FilterOpts,
+  type JobResult,
+} from "../helpers.js"
+
+export interface SearchOpts {
+  query?: string
+  location?: string
+  remote?: boolean
+  jobage?: number
+  page: number
+  pages: number
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+
+function renderTable(jobs: JobResult[]): string {
+  if (jobs.length === 0) return "No results."
+  const header =
+    "ID".padEnd(44) + " " + "TITLE".padEnd(44) + " " + "COMPANY".padEnd(24) + " " + "LOCATION".padEnd(16) + " " + "REMOTE".padEnd(6) + " DATE"
+  const rows = jobs.map((j) => {
+    const id = j.id.slice(0, 44).padEnd(44)
+    const title = j.title.slice(0, 44).padEnd(44)
+    const company = (j.company || "—").slice(0, 24).padEnd(24)
+    const loc = (j.location || "—").slice(0, 16).padEnd(16)
+    const remote = (j.remote ? "yes" : "no").padEnd(6)
+    return `${id} ${title} ${company} ${loc} ${remote} ${j.date || "—"}`
+  })
+  return [header, "-".repeat(header.length), ...rows].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  try {
+    const filters: FilterOpts = {
+      query: opts.query,
+      location: opts.location,
+      remote: opts.remote,
+      jobageDays: opts.jobage,
+    }
+    const jobs: JobResult[] = []
+    let scanned = 0
+    const lastPage = Math.min(opts.page + opts.pages - 1, opts.page + MAX_PAGES - 1)
+
+    for (let p = opts.page; p <= lastPage; p++) {
+      const data = await fetchPage(p)
+      const raws = data.data ?? []
+      scanned += raws.length
+      for (const raw of raws) {
+        if (matchesFilters(raw, filters)) jobs.push(mapJob(raw))
+        if (opts.limit !== undefined && jobs.length >= opts.limit) break
+      }
+      if (opts.limit !== undefined && jobs.length >= opts.limit) break
+      if (!data.links?.next) break
+    }
+
+    const out = opts.limit !== undefined ? jobs.slice(0, opts.limit) : jobs
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(out) + `\n\nMatches: ${out.length} (scanned ${scanned} jobs)\n`)
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        out
+          .map(
+            (j) =>
+              `${j.title}\n  ${j.company || "—"} · ${j.location || "—"} · ${j.date || "—"}${j.remote ? " · remote" : ""}\n  id: ${j.id}\n  ${j.url}`,
+          )
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify({ meta: { count: out.length, page: opts.page, scanned }, results: out }, null, 2) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/arbeitnow-search/cli/src/helpers.ts
+++ b/.agents/skills/arbeitnow-search/cli/src/helpers.ts
@@ -1,0 +1,125 @@
+export const API_URL = "https://www.arbeitnow.com/api/job-board-api"
+export const MAX_PAGES = 10
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+export interface RawJob {
+  slug: string
+  company_name?: string
+  title?: string
+  description?: string
+  remote?: boolean
+  url?: string
+  tags?: string[]
+  job_types?: string[]
+  location?: string
+  created_at?: number
+}
+
+export interface ApiPage {
+  data?: RawJob[]
+  links?: { next?: string | null }
+}
+
+export interface JobResult {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  date: string | null
+  url: string
+  remote: boolean | null
+  tags: string[]
+}
+
+export async function fetchPage(page: number): Promise<ApiPage> {
+  const url = `${API_URL}?page=${page}`
+  const maxRetries = 6
+  let delay = 500
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        "Accept": "application/json",
+        "User-Agent": "Mozilla/5.0 (compatible; arbeitnow-cli/1.0)",
+      },
+    })
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+      }
+      const jitter = Math.floor(Math.random() * 500)
+      await new Promise((resolve) => setTimeout(resolve, delay + jitter))
+      delay = Math.min(delay * 2, 5000)
+      continue
+    }
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+    }
+    return response.json() as Promise<ApiPage>
+  }
+  throw new Error("API request failed after max retries")
+}
+
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<(br|\/p|\/li|\/h[1-6])[^>]*>/gi, "\n")
+    .replace(/<li[^>]*>/gi, "- ")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+export function toIsoDate(unixSeconds?: number): string | null {
+  if (!unixSeconds) return null
+  return new Date(unixSeconds * 1000).toISOString().slice(0, 10)
+}
+
+export function mapJob(raw: RawJob): JobResult {
+  return {
+    id: raw.slug,
+    title: raw.title || "(no title)",
+    company: raw.company_name || null,
+    location: raw.location || null,
+    date: toIsoDate(raw.created_at),
+    url: raw.url || `https://www.arbeitnow.com/jobs/${raw.slug}`,
+    remote: raw.remote ?? null,
+    tags: raw.tags ?? [],
+  }
+}
+
+export interface FilterOpts {
+  query?: string
+  location?: string
+  remote?: boolean
+  jobageDays?: number
+}
+
+export function matchesFilters(raw: RawJob, f: FilterOpts): boolean {
+  if (f.remote !== undefined && (raw.remote ?? false) !== f.remote) return false
+  if (f.location) {
+    const loc = (raw.location || "").toLowerCase()
+    if (!loc.includes(f.location.toLowerCase())) return false
+  }
+  if (f.jobageDays !== undefined && raw.created_at) {
+    const ageDays = (Date.now() / 1000 - raw.created_at) / 86400
+    if (ageDays > f.jobageDays) return false
+  }
+  if (f.query) {
+    const q = f.query.toLowerCase()
+    const haystack = [raw.title, raw.company_name, raw.location, (raw.tags ?? []).join(" "), raw.description]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase()
+    if (!haystack.includes(q)) return false
+  }
+  return true
+}

--- a/.agents/skills/arbeitnow-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/arbeitnow-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { runCLI } from "./helpers"
+
+describe("flag validation", () => {
+  test("unknown command exits 1 with JSON error on stderr", async () => {
+    const result = await runCLI(["frobnicate"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_CMD")
+  })
+
+  test("non-numeric --jobage exits 1", async () => {
+    const result = await runCLI(["search", "--jobage", "soon"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ARG")
+  })
+
+  test("--remote and --onsite together exit 1", async () => {
+    const result = await runCLI(["search", "--remote", "--onsite"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ARG")
+  })
+
+  test("detail without id exits 1", async () => {
+    const result = await runCLI(["detail"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("NO_ID")
+  })
+})

--- a/.agents/skills/arbeitnow-search/cli/tests/helpers.ts
+++ b/.agents/skills/arbeitnow-search/cli/tests/helpers.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/arbeitnow-search/cli/tests/search.test.ts
+++ b/.agents/skills/arbeitnow-search/cli/tests/search.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { runCLI, parseJSON } from "./helpers"
+
+interface SearchResult {
+  meta: { count: number; page: number; scanned: number }
+  results: Array<{ id: string | null; title: string | null; url: string | null }>
+}
+
+describe("search (live)", () => {
+  test("returns at least one result with id/title/url", async () => {
+    const result = await runCLI(["search", "--limit", "3"])
+    expect(result.exitCode).toBe(0)
+    const data = parseJSON<SearchResult>(result)
+    expect(data.results.length).toBeGreaterThan(0)
+    for (const job of data.results) {
+      expect(job.id).toBeTruthy()
+      expect(job.title).toBeTruthy()
+      expect(job.url).toContain("arbeitnow.com")
+    }
+  })
+
+  test("detail returns readable content for a search hit", async () => {
+    const search = await runCLI(["search", "--limit", "1"])
+    const data = parseJSON<SearchResult>(search)
+    expect(data.results.length).toBe(1)
+    const detail = await runCLI(["detail", data.results[0].id as string, "--format", "plain"])
+    expect(detail.exitCode).toBe(0)
+    expect(detail.stdout.length).toBeGreaterThan(50)
+  })
+})

--- a/.agents/skills/arbeitnow-search/cli/tsconfig.json
+++ b/.agents/skills/arbeitnow-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/arbeitnow-search/url-reference.md
+++ b/.agents/skills/arbeitnow-search/url-reference.md
@@ -1,0 +1,38 @@
+# Arbeitnow Job Board API — URL Reference
+
+Free public API, no key, no registration: https://www.arbeitnow.com/api/job-board-api
+(docs: https://documenter.getpostman.com/view/18545278/UVJbJdKh — linked from arbeitnow.com).
+The API's own `meta.terms` string: "This is a free public API for jobs, please do not abuse."
+
+Focus: jobs in Germany, strong tech/startup/English-speaking slant, visa-sponsorship
+friendly listings.
+
+## Endpoint
+
+```
+GET https://www.arbeitnow.com/api/job-board-api?page=N
+```
+
+- Returns 100 jobs per page, newest first. `links.next` is null on the last page.
+- **Server-side filtering does NOT work** (verified 2026-07): `search`, `q`, `tag`,
+  and `remote` parameters are ignored — the response is a shared cached list, and
+  `meta.current_page_url` even echoes other clients' query strings. The CLI therefore
+  filters **client-side** and fetches multiple pages (`--pages`).
+
+## Response shape
+
+```
+{ "data": [ { slug, company_name, title, description (HTML), remote (bool),
+              url, tags[], job_types[], location, created_at (unix seconds) } ],
+  "links": { first, last, prev, next },
+  "meta":  { current_page, per_page: 100, ... } }
+```
+
+## Quirks
+
+- `description` is HTML — strip tags for plain output.
+- `created_at` is a unix timestamp (seconds).
+- No per-job detail endpoint: the full description is already in the list payload,
+  so `detail <slug>` scans pages until the slug is found (capped).
+- `job_types` is often empty; `tags` carries the useful categorisation.
+- Job page URL per job is the `url` field (arbeitnow.com/jobs/companies/...).

--- a/.agents/skills/arbeitsagentur-search/SKILL.md
+++ b/.agents/skills/arbeitsagentur-search/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: arbeitsagentur-search
+version: 1.0.0
+description: >
+  Make sure to use this skill whenever the user wants to search for jobs in Germany,
+  find German job listings, look up a specific job posting, or asks anything about
+  the German job market — even if they don't mention arbeitsagentur.de explicitly.
+  This skill covers the official German government job portal operated by the
+  Bundesagentur für Arbeit (Federal Employment Agency), Germany's largest job board
+  including private-sector postings, apprenticeships (Ausbildung), and internships.
+  Trigger phrases include: arbeitsagentur, jobbörse, jobsuche, stellenangebote,
+  stellenanzeigen, job in deutschland, arbeit finden, stellensuche, jobs berlin,
+  jobs münchen, jobs hamburg, jobs köln, jobs stuttgart, softwareentwickler job,
+  webentwickler stelle, ausbildungsplatz, ausbildung finden, praktikum finden,
+  german jobs, jobs in germany, job search germany, work in germany, hiring germany,
+  vacancies germany, developer jobs berlin, IT jobs germany, ingenieur stelle,
+  handwerker job, teilzeit job, vollzeit stelle, homeoffice job deutschland.
+context: fork
+allowed-tools: Bash(bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts *)
+---
+
+# Arbeitsagentur Search Skill
+
+Search live German job listings from the official Bundesagentur für Arbeit Jobsuche
+API. No authentication beyond a static public API key (built in), **zero runtime
+dependencies**. Germany's largest job portal: several hundred thousand active
+postings across all sectors, including apprenticeships and internships.
+
+## When to use this skill
+
+Invoke this skill when the user wants to:
+
+- Search for job openings in Germany by keyword, job title, or technology
+- Filter by city/postal code with a km radius, posting age, full/part time,
+  home office, permanent/temporary contracts
+- Find apprenticeships (Ausbildung) or internships (Praktikum)
+- Get the full description of a specific posting
+- Explore the German job market for a profession or skill set
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts search [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q` — keyword search (job title, skill, profession)
+- `--location <text>` / `-l` — city, postal code, or region (e.g. `Berlin`, `70173`)
+- `--radius <km>` — radius around `--location` (API default: 25)
+- `--jobage <days>` — posting age in days, 0–100 (e.g. `1`, `7`, `14`, `30`)
+- `--worktime <type>` — `vz` (full-time), `tz` (part-time), `snw` (shift/night/weekend), `ho` (home office), `mj` (minijob); combine with `;` e.g. `"vz;ho"`
+- `--contract <type>` — `1` (temporary/befristet) or `2` (permanent/unbefristet)
+- `--offertype <type>` — `1` job (default), `4` apprenticeship (Ausbildung/duales Studium), `34` internship/trainee
+- `--employer <text>` — filter by employer name
+- `--no-tempwork` — exclude temp-agency (Zeitarbeit) postings
+- `--page <n>` — page number (1-indexed)
+- `--size <n>` — results per page (default 20, max 100)
+- `--limit <n>` — cap results the CLI outputs (client-side)
+- `--format json|table|plain` (default `json`)
+
+### Fetch full job detail
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts detail <refnr|url> [--format json|plain]
+```
+
+`refnr` is the ID from `search` results (e.g. `12016-10004847581-S`). A full
+`arbeitsagentur.de/jobsuche/jobdetail/...` URL also works. Returns the full
+description, employer, locations, start date, salary info (if given), and contract type.
+
+---
+
+## How to use effectively
+
+**Natural workflow: `search` → `detail`.** Search first, then fetch details for
+promising `id`s.
+
+**Always pass `--location` for German results.** Without it, the API also returns
+Austrian (AMS) postings for German-language queries.
+
+**Use `--jobage 7` or `--jobage 1` for fresh listings.** Otherwise all active
+postings are returned.
+
+**Exclude recruiter noise** with `--no-tempwork` — Zeitarbeit/staffing agencies
+post high volumes; filtering them improves signal for direct positions.
+
+**Use `--format table` for scanning**, `json` for processing, `plain` for reading.
+
+---
+
+## Usage examples
+
+### Python jobs in Berlin, last 7 days
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts search \
+  -q python -l Berlin --jobage 7 --format table
+```
+
+### Full-stack developer near Stuttgart, 50 km, no temp agencies
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts search \
+  -q "full stack entwickler" -l Stuttgart --radius 50 --no-tempwork --format table
+```
+
+### Permanent full-time or home-office positions
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts search \
+  -q "devops" -l München --worktime "vz;ho" --contract 2 --format table
+```
+
+### Apprenticeships (Ausbildung) in Hamburg
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts search \
+  -q mechatroniker -l Hamburg --offertype 4 --format table
+```
+
+### Full details for a posting
+
+```bash
+bun run .agents/skills/arbeitsagentur-search/cli/src/cli.ts detail 12016-10004847581-S --format plain
+```
+
+---
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing IDs to `detail` |
+| `table` | Quick human-readable overview and scanning |
+| `plain` | Reading a single job's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the
+process exits with code `1`.
+
+---
+
+## Notes
+
+- Data source: official public API (`rest.arbeitsagentur.de`), documented at
+  https://jobsuche.api.bund.dev/ — static API key, no registration, no ToS concerns
+  for personal use.
+- Job IDs (`refnr`) are strings like `12016-10004847581-S`; the detail endpoint
+  requires them base64-encoded — the CLI handles this automatically.
+- The detail endpoint is **v3** — v1/v2 return 403 (see `url-reference.md`).
+- Postings with `externalUrl` are hosted on external boards; their `detail` data
+  can be thinner. The `externalUrl` is included in search results.
+- Human-facing URL per job: `https://www.arbeitsagentur.de/jobsuche/jobdetail/{refnr}`

--- a/.agents/skills/arbeitsagentur-search/cli/README.md
+++ b/.agents/skills/arbeitsagentur-search/cli/README.md
@@ -1,0 +1,26 @@
+# arbeitsagentur-cli
+
+CLI for the official **Bundesagentur für Arbeit Jobsuche API** — Germany's
+government job portal and largest job board. Public API with a static key
+(documented at https://jobsuche.api.bund.dev/), no registration, **zero runtime
+dependencies** (plain `bun` + `fetch`).
+
+## Install & run
+
+```bash
+bun install        # dev types only
+bun run src/cli.ts search -q python -l Berlin --jobage 7 --format table
+bun run src/cli.ts detail <refnr> --format plain
+```
+
+## Commands
+
+See `../SKILL.md` for the full flag reference and usage examples, and
+`../url-reference.md` for the API endpoint documentation.
+
+## Test & typecheck
+
+```bash
+bun run test        # includes live smoke tests against the API
+bun run typecheck
+```

--- a/.agents/skills/arbeitsagentur-search/cli/package.json
+++ b/.agents/skills/arbeitsagentur-search/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "arbeitsagentur-cli",
+  "version": "1.0.0",
+  "description": "CLI for the official Bundesagentur für Arbeit Jobsuche API (German government job portal) — no registration, zero runtime dependencies.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "arbeitsagentur-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "latest"
+  }
+}

--- a/.agents/skills/arbeitsagentur-search/cli/src/cli.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/src/cli.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+// Self-contained CLI for the official Bundesagentur für Arbeit Jobsuche API
+// (German government job portal). Public API with a static key — no registration,
+// no scraping, zero runtime dependencies.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", l: "location", n: "limit" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `arbeitsagentur-cli — search jobs on the official German government job portal
+
+USAGE
+  bun run src/cli.ts search [flags]
+  bun run src/cli.ts detail <refnr|url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>      Keywords (job title, skill, profession).
+  --location, -l <text>   City, postal code, or region (e.g. "Berlin", "70173").
+  --radius <km>           Radius around --location in km (API default 25).
+  --jobage <days>         Posted within N days (0–100).
+  --worktime <type>       vz | tz | snw | ho | mj (combine: "vz;ho").
+  --contract <type>       1 = temporary (befristet), 2 = permanent (unbefristet).
+  --offertype <type>      1 = job (default), 4 = Ausbildung, 34 = Praktikum/Trainee.
+  --employer <text>       Filter by employer name.
+  --no-tempwork           Exclude temp-agency (Zeitarbeit) postings.
+  --page <n>              1-indexed page. Default 1.
+  --size <n>              Results per page (max 100). Default 20.
+  --limit, -n <n>         Cap results emitted (client-side).
+  --format <fmt>          json (default) | table | plain.
+
+EXAMPLES
+  bun run src/cli.ts search -q python -l Berlin --jobage 7 --format table
+  bun run src/cli.ts search -q "full stack entwickler" -l Stuttgart --radius 50 --no-tempwork --format table
+  bun run src/cli.ts search -q mechatroniker -l Hamburg --offertype 4 --format table
+  bun run src/cli.ts detail 12016-10004847581-S --format plain
+
+Data source: official public API (https://jobsuche.api.bund.dev/), static key, no registration.
+`
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
+    const val = parseInt(raw as string, 10)
+    if (isNaN(val)) {
+      process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+      return null
+    }
+    return val
+  }
+
+  if (cmd === "search") {
+    const fmt = (flags.format as string) || "json"
+
+    let radius: number | undefined
+    let jobage: number | undefined
+    let page = 1
+    let size = 20
+    let limit: number | undefined
+
+    if (flags.radius !== undefined) {
+      const v = parseIntFlag("radius", flags.radius)
+      if (v === null) return 1
+      radius = v
+    }
+    if (flags.jobage !== undefined) {
+      const v = parseIntFlag("jobage", flags.jobage)
+      if (v === null) return 1
+      jobage = Math.min(Math.max(v, 0), 100)
+    }
+    if (flags.page !== undefined) {
+      const v = parseIntFlag("page", flags.page)
+      if (v === null) return 1
+      page = Math.max(1, v)
+    }
+    if (flags.size !== undefined) {
+      const v = parseIntFlag("size", flags.size)
+      if (v === null) return 1
+      size = Math.min(Math.max(1, v), 100)
+    }
+    if (flags.limit !== undefined) {
+      const v = parseIntFlag("limit", flags.limit)
+      if (v === null) return 1
+      limit = v
+    }
+
+    if (flags.contract !== undefined && !["1", "2"].includes(String(flags.contract))) {
+      process.stderr.write(JSON.stringify({ error: `--contract must be 1 (temporary) or 2 (permanent), got "${flags.contract}"`, code: "BAD_ARG" }) + "\n")
+      return 1
+    }
+
+    const opts: SearchOpts = {
+      query: typeof flags.query === "string" ? flags.query : undefined,
+      location: typeof flags.location === "string" ? flags.location : undefined,
+      radius,
+      jobage,
+      worktime: typeof flags.worktime === "string" ? flags.worktime : undefined,
+      contract: typeof flags.contract === "string" ? flags.contract : undefined,
+      offertype: typeof flags.offertype === "string" ? flags.offertype : undefined,
+      employer: typeof flags.employer === "string" ? flags.employer : undefined,
+      noTempwork: flags["no-tempwork"] === true,
+      page,
+      size,
+      limit,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(JSON.stringify({ error: "detail requires a <refnr|url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      id,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main().then((code) => process.exit(code))

--- a/.agents/skills/arbeitsagentur-search/cli/src/commands/detail.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/src/commands/detail.ts
@@ -1,0 +1,99 @@
+import { apiFetch, encodeRefnr, writeError, JOB_PAGE_URL, NotFoundError } from "../helpers.js"
+
+export interface DetailOpts {
+  id: string
+  format: "json" | "plain"
+}
+
+interface RawLokation {
+  adresse?: { plz?: string; ort?: string; region?: string; land?: string }
+}
+
+interface RawDetail {
+  stellenangebotsTitel?: string
+  firma?: string
+  stellenangebotsBeschreibung?: string
+  stellenlokationen?: RawLokation[]
+  datumErsteVeroeffentlichung?: string
+  eintrittszeitraum?: { von?: string }
+  arbeitszeitVollzeit?: boolean
+  vertragsdauer?: string
+  verguetungsangabe?: string
+  festgehalt?: number
+  hauptberuf?: string
+  allianzpartnerName?: string
+  allianzpartnerUrl?: string
+  referenznummer?: string
+}
+
+/** Accept a raw refnr (e.g. 12016-10004847581-S) or a jobdetail URL. */
+export function normalizeRefnr(input: string): string | null {
+  const url = input.match(/jobdetail\/([^/?#\s]+)/)
+  if (url) return decodeURIComponent(url[1])
+  if (/^[\w.]+-[\w-]+$/.test(input)) return input
+  return null
+}
+
+function formatLocations(lokationen?: RawLokation[]): string | null {
+  if (!lokationen || lokationen.length === 0) return null
+  return lokationen
+    .map((l) => [l.adresse?.plz, l.adresse?.ort].filter((p) => p && p !== "null").join(" "))
+    .filter((s) => s.length > 0)
+    .join("; ") || null
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const refnr = normalizeRefnr(opts.id)
+  if (!refnr) {
+    writeError(`Could not parse a refnr from "${opts.id}"`, "BAD_ID")
+    return 1
+  }
+  try {
+    const raw = await apiFetch<RawDetail>(`/pc/v3/jobdetails/${encodeRefnr(refnr)}`)
+    const job = {
+      id: raw.referenznummer || refnr,
+      title: raw.stellenangebotsTitel || null,
+      company: raw.firma || null,
+      location: formatLocations(raw.stellenlokationen),
+      date: raw.datumErsteVeroeffentlichung || null,
+      startDate: raw.eintrittszeitraum?.von || null,
+      fullTime: raw.arbeitszeitVollzeit ?? null,
+      contractDuration: raw.vertragsdauer || null,
+      salaryType: raw.verguetungsangabe || null,
+      salary: raw.festgehalt ?? null,
+      occupation: raw.hauptberuf || null,
+      partnerName: raw.allianzpartnerName || null,
+      partnerUrl: raw.allianzpartnerUrl || null,
+      description: raw.stellenangebotsBeschreibung || null,
+      url: `${JOB_PAGE_URL}/${encodeURIComponent(refnr)}`,
+    }
+
+    if (opts.format === "plain") {
+      const lines = [
+        job.title || "(ohne Titel)",
+        `${job.company || "—"} · ${job.location || "—"}`,
+        "",
+        job.occupation ? `Beruf: ${job.occupation}` : "",
+        job.startDate ? `Eintritt: ${job.startDate}` : "",
+        job.fullTime !== null ? `Arbeitszeit: ${job.fullTime ? "Vollzeit" : "Teilzeit"}` : "",
+        job.contractDuration && job.contractDuration !== "KEINE_ANGABE" ? `Vertrag: ${job.contractDuration}` : "",
+        job.salary !== null ? `Vergütung: ${job.salary} (${job.salaryType || "—"})` : "",
+        "",
+        job.description || "(keine Beschreibung)",
+        "",
+        `URL: ${job.url}`,
+      ].filter((l) => l !== "")
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      writeError(e.message, "NOT_FOUND")
+      return 1
+    }
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/arbeitsagentur-search/cli/src/commands/search.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/src/commands/search.ts
@@ -1,0 +1,78 @@
+import { apiFetch, mapJob, writeError, type JobResult, type SearchResponse } from "../helpers.js"
+
+export interface SearchOpts {
+  query?: string
+  location?: string
+  radius?: number
+  jobage?: number
+  worktime?: string
+  contract?: string
+  offertype?: string
+  employer?: string
+  noTempwork?: boolean
+  page: number
+  size: number
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+
+function buildParams(opts: SearchOpts): Record<string, string> {
+  const params: Record<string, string> = {
+    page: String(opts.page),
+    size: String(opts.size),
+  }
+  if (opts.query) params.was = opts.query
+  if (opts.location) params.wo = opts.location
+  if (opts.radius !== undefined) params.umkreis = String(opts.radius)
+  if (opts.jobage !== undefined) params.veroeffentlichtseit = String(opts.jobage)
+  if (opts.worktime) params.arbeitszeit = opts.worktime
+  if (opts.contract) params.befristung = opts.contract
+  if (opts.offertype) params.angebotsart = opts.offertype
+  if (opts.employer) params.arbeitgeber = opts.employer
+  if (opts.noTempwork) params.zeitarbeit = "false"
+  return params
+}
+
+function renderTable(jobs: JobResult[], total: number): string {
+  if (jobs.length === 0) return "No results."
+  const header =
+    "ID".padEnd(22) + " " + "TITLE".padEnd(46) + " " + "COMPANY".padEnd(28) + " " + "LOCATION".padEnd(22) + " DATE"
+  const rows = jobs.map((j) => {
+    const id = j.id.slice(0, 22).padEnd(22)
+    const title = j.title.slice(0, 46).padEnd(46)
+    const company = (j.company || "—").slice(0, 28).padEnd(28)
+    const loc = (j.location || "—").slice(0, 22).padEnd(22)
+    return `${id} ${title} ${company} ${loc} ${j.date || "—"}`
+  })
+  return [header, "-".repeat(header.length), ...rows, "", `Total matches: ${total}`].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  try {
+    const data = await apiFetch<SearchResponse>("/pc/v4/jobs", buildParams(opts))
+    let jobs = (data.stellenangebote ?? []).map(mapJob)
+    if (opts.limit !== undefined && opts.limit >= 0) jobs = jobs.slice(0, opts.limit)
+    const total = data.maxErgebnisse ?? jobs.length
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(jobs, total) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        jobs
+          .map(
+            (j) =>
+              `${j.title}\n  ${j.company || "—"} · ${j.location || "—"} · ${j.date || "—"}\n  id: ${j.id}\n  ${j.url}`,
+          )
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify({ meta: { count: total, page: opts.page }, results: jobs }, null, 2) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/arbeitsagentur-search/cli/src/helpers.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/src/helpers.ts
@@ -1,0 +1,119 @@
+export const BASE_URL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service"
+export const API_KEY = "jobboerse-jobsuche"
+export const JOB_PAGE_URL = "https://www.arbeitsagentur.de/jobsuche/jobdetail"
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+export async function apiFetch<T>(path: string, params?: Record<string, string>): Promise<T> {
+  let url = `${BASE_URL}${path}`
+  if (params && Object.keys(params).length > 0) {
+    const qs = new URLSearchParams(params)
+    url += `?${qs.toString()}`
+  }
+
+  const maxRetries = 6
+  let delay = 500
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        "X-API-Key": API_KEY,
+        "Accept": "application/json",
+        "User-Agent": "Mozilla/5.0 (compatible; arbeitsagentur-cli/1.0)",
+      },
+    })
+
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+      }
+      const jitter = Math.floor(Math.random() * 500)
+      await new Promise((resolve) => setTimeout(resolve, delay + jitter))
+      delay = Math.min(delay * 2, 5000)
+      continue
+    }
+
+    if (response.status === 404 || response.status === 403) {
+      // The v3 jobdetails endpoint answers 403/404 for unknown or externally
+      // hosted postings — surface both as "not found" rather than crashing.
+      throw new NotFoundError("Job not found (or details not available via the API)")
+    }
+
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`)
+    }
+
+    return response.json() as Promise<T>
+  }
+  throw new Error("API request failed after max retries")
+}
+
+export class NotFoundError extends Error {}
+
+export interface JobResult {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  date: string | null
+  url: string
+  startDate: string | null
+  externalUrl: string | null
+  distanceKm: string | null
+}
+
+interface RawArbeitsort {
+  plz?: string
+  ort?: string
+  region?: string
+  land?: string
+  entfernung?: string
+}
+
+export interface RawStellenangebot {
+  refnr: string
+  titel?: string
+  beruf?: string
+  arbeitgeber?: string
+  arbeitsort?: RawArbeitsort
+  aktuelleVeroeffentlichungsdatum?: string
+  eintrittsdatum?: string
+  externeUrl?: string
+}
+
+export interface SearchResponse {
+  stellenangebote?: RawStellenangebot[]
+  maxErgebnisse?: number
+  page?: number
+  size?: number
+}
+
+function formatLocation(ort?: RawArbeitsort): string | null {
+  if (!ort) return null
+  const parts = [ort.plz, ort.ort].filter((p) => p && p !== "null")
+  let s = parts.join(" ")
+  if (ort.land && ort.land !== "null" && ort.land !== "Deutschland" && ort.land !== "DEUTSCHLAND") {
+    s = s ? `${s} (${ort.land})` : ort.land
+  }
+  return s || ort.region || null
+}
+
+export function mapJob(raw: RawStellenangebot): JobResult {
+  return {
+    id: raw.refnr,
+    title: raw.titel || raw.beruf || "(ohne Titel)",
+    company: raw.arbeitgeber || null,
+    location: formatLocation(raw.arbeitsort),
+    date: raw.aktuelleVeroeffentlichungsdatum || null,
+    url: `${JOB_PAGE_URL}/${encodeURIComponent(raw.refnr)}`,
+    startDate: raw.eintrittsdatum || null,
+    externalUrl: raw.externeUrl || null,
+    distanceKm: raw.arbeitsort?.entfernung ?? null,
+  }
+}
+
+/** Encode a refnr for the v3 jobdetails endpoint (base64 of the raw refnr). */
+export function encodeRefnr(refnr: string): string {
+  return Buffer.from(refnr, "utf-8").toString("base64")
+}

--- a/.agents/skills/arbeitsagentur-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { runCLI } from "./helpers"
+
+describe("flag validation", () => {
+  test("unknown command exits 1 with JSON error on stderr", async () => {
+    const result = await runCLI(["frobnicate"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_CMD")
+  })
+
+  test("non-numeric --jobage exits 1", async () => {
+    const result = await runCLI(["search", "--jobage", "soon"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ARG")
+  })
+
+  test("invalid --contract exits 1", async () => {
+    const result = await runCLI(["search", "--contract", "5"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ARG")
+  })
+
+  test("detail without id exits 1", async () => {
+    const result = await runCLI(["detail"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("NO_ID")
+  })
+})

--- a/.agents/skills/arbeitsagentur-search/cli/tests/helpers.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/tests/helpers.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/arbeitsagentur-search/cli/tests/search.test.ts
+++ b/.agents/skills/arbeitsagentur-search/cli/tests/search.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { runCLI, parseJSON } from "./helpers"
+
+interface SearchResult {
+  meta: { count: number; page: number }
+  results: Array<{ id: string | null; title: string | null; url: string | null }>
+}
+
+describe("search (live)", () => {
+  test("returns at least one result with id/title/url", async () => {
+    const result = await runCLI(["search", "-q", "softwareentwickler", "-l", "Berlin", "--limit", "3"])
+    expect(result.exitCode).toBe(0)
+    const data = parseJSON<SearchResult>(result)
+    expect(data.results.length).toBeGreaterThan(0)
+    for (const job of data.results) {
+      expect(job.id).toBeTruthy()
+      expect(job.title).toBeTruthy()
+      expect(job.url).toContain("arbeitsagentur.de")
+    }
+  })
+
+  test("detail returns readable content for a search hit", async () => {
+    const search = await runCLI(["search", "-q", "softwareentwickler", "-l", "Berlin", "--limit", "1"])
+    const data = parseJSON<SearchResult>(search)
+    expect(data.results.length).toBe(1)
+    const detail = await runCLI(["detail", data.results[0].id as string, "--format", "plain"])
+    expect(detail.exitCode).toBe(0)
+    expect(detail.stdout.length).toBeGreaterThan(50)
+  })
+})

--- a/.agents/skills/arbeitsagentur-search/cli/tsconfig.json
+++ b/.agents/skills/arbeitsagentur-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/arbeitsagentur-search/url-reference.md
+++ b/.agents/skills/arbeitsagentur-search/url-reference.md
@@ -1,0 +1,62 @@
+# Arbeitsagentur Jobsuche API — URL Reference
+
+Official public API of the Bundesagentur für Arbeit (German Federal Employment
+Agency), documented by the bund.dev community: https://jobsuche.api.bund.dev/
+
+No registration required. All requests need the static header:
+
+```
+X-API-Key: jobboerse-jobsuche
+```
+
+## Search endpoint
+
+```
+GET https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs
+```
+
+| Parameter            | Meaning                                                        | CLI flag        |
+|----------------------|----------------------------------------------------------------|-----------------|
+| `was`                | Keyword: job title, skill, profession                          | `--query`       |
+| `wo`                 | Location: city, postal code, or region                         | `--location`    |
+| `umkreis`            | Radius in km around `wo` (API default 25)                      | `--radius`      |
+| `veroeffentlichtseit`| Posting age in days (0–100)                                    | `--jobage`      |
+| `page`               | Page number, 1-indexed                                         | `--page`        |
+| `size`               | Results per page (max 100)                                     | `--size`        |
+| `arbeitszeit`        | `vz` full-time, `tz` part-time, `snw` shift/night/weekend, `ho` home office, `mj` minijob. Multiple: semicolon-joined | `--worktime` |
+| `befristung`         | `1` temporary, `2` permanent                                   | `--contract`    |
+| `angebotsart`        | `1` job (default), `2` self-employment, `4` apprenticeship/dual study, `34` internship/trainee | `--offertype` |
+| `arbeitgeber`        | Filter by employer name                                        | `--employer`    |
+| `zeitarbeit`         | `false` excludes temp-agency (Zeitarbeit) postings             | `--no-tempwork` |
+
+Response (JSON): `stellenangebote[]` with `refnr`, `titel`, `beruf`, `arbeitgeber`,
+`arbeitsort {plz, ort, region, land, entfernung}`, `aktuelleVeroeffentlichungsdatum`,
+`eintrittsdatum`, optional `externeUrl`. Total count in `maxErgebnisse`.
+
+## Detail endpoint
+
+```
+GET https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v3/jobdetails/{BASE64(refnr)}
+```
+
+The path segment is the **base64-encoded** `refnr` from search results.
+**v3 is the working version** — v1/v2 return 403 with this API key (verified 2026-07).
+
+Response fields used: `stellenangebotsTitel`, `firma`, `stellenangebotsBeschreibung`
+(plain text), `stellenlokationen[]`, `datumErsteVeroeffentlichung`,
+`eintrittszeitraum.von`, `arbeitszeitVollzeit`, `vertragsdauer`, `verguetungsangabe`,
+`festgehalt`, `hauptberuf`, `allianzpartnerName`, `allianzpartnerUrl`, `referenznummer`.
+
+## Human-facing URLs
+
+- Job detail page: `https://www.arbeitsagentur.de/jobsuche/jobdetail/{refnr}`
+- Externally hosted postings carry `externeUrl` in search results; their detail
+  data may be thinner than BA-hosted postings.
+
+## Quirks
+
+- Search covers Germany plus some neighbouring markets (Austrian AMS postings
+  appear for German-language queries without `wo`). Pass `--location` to stay in Germany.
+- `arbeitsort.strasse` can be the literal string `"null"`.
+- `koordinaten` may be `0.0/0.0` for external postings.
+- `arbeitsort.entfernung` (km) is only present when searching with `wo`/`umkreis`.

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -10,11 +10,12 @@ The `site:` query templates in this file are the **WebSearch fallback** — for 
 
 ## Search Sites
 
-Primary (your market's job boards - scaffold one with `/add-portal`):
-- **[YOUR_JOB_BOARD]** - your market's largest general job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY]); also covered by `linkedin-search` CLI
+Primary (German market - arbeitsagentur.de is covered by the `arbeitsagentur-search` CLI):
+- **stepstone.de** - Germany's largest private general job board (WebSearch fallback, blocks direct scraping)
+- **de.indeed.com** - job aggregator for Germany (WebSearch fallback, blocks direct scraping)
+- **linkedin.com/jobs** - LinkedIn job listings (filter: Deutschland / [YOUR_CITY]); also covered by `linkedin-search` CLI
+- **xing.com/jobs** - DACH-focused professional network job board (optional)
 - **[YOUR_INDUSTRY_JOB_BOARD]** - a niche/industry board for your field (optional)
-- **[YOUR_ADDITIONAL_JOB_BOARD]** - another major board for your market (optional)
 
 Secondary (company career pages via Google):
 - Direct Google searches with `site:` filters for known target companies
@@ -28,9 +29,9 @@ Queries are grouped by priority. Each query should be combined with your locatio
 These match your strongest and most desired career direction.
 
 ```
-site:[YOUR_JOB_BOARD] "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
+site:stepstone.de OR site:de.indeed.com "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
+site:stepstone.de OR site:de.indeed.com "[YOUR_KEY_SKILL]" [YOUR_CITY]
+site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" Deutschland
 ```
 
 ### Priority 2: [YOUR_DOMAIN_EXPERTISE]
@@ -38,9 +39,9 @@ site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
 These match your domain expertise.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+site:stepstone.de OR site:de.indeed.com [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
+site:stepstone.de OR site:de.indeed.com [YOUR_DOMAIN_KEYWORD_2] Deutschland
+site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] Deutschland
 ```
 
 ### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
@@ -48,8 +49,8 @@ site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
 Adjacent roles you could pivot into.
 
 ```
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
+site:stepstone.de OR site:de.indeed.com "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
+site:stepstone.de OR site:de.indeed.com "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
 ```
 
 ### Priority 4: Broader Technical / Consulting
@@ -57,9 +58,9 @@ site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
 Wider net for general technical roles.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_KEY_SKILL] developer [YOUR_CITY]
+site:stepstone.de OR site:de.indeed.com [YOUR_KEY_SKILL] developer [YOUR_CITY]
 site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+site:stepstone.de OR site:de.indeed.com "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
 ```
 
 ## Location Filter

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -10,7 +10,7 @@ The `site:` query templates in this file are the **WebSearch fallback** — for 
 
 ## Search Sites
 
-Primary (German market - arbeitsagentur.de is covered by the `arbeitsagentur-search` CLI):
+Primary (German market - arbeitsagentur.de and arbeitnow.com are covered by the `arbeitsagentur-search` and `arbeitnow-search` CLIs):
 - **stepstone.de** - Germany's largest private general job board (WebSearch fallback, blocks direct scraping)
 - **de.indeed.com** - job aggregator for Germany (WebSearch fallback, blocks direct scraping)
 - **linkedin.com/jobs** - LinkedIn job listings (filter: Deutschland / [YOUR_CITY]); also covered by `linkedin-search` CLI


### PR DESCRIPTION
## Summary

Adds German job market support to this fork, following the portal-skill pattern
(and `/add-portal` workflow) from upstream.

### New portal skills

**`arbeitsagentur-search`** — official Bundesagentur für Arbeit Jobsuche API
- Germany's largest job portal (government-run, includes private-sector postings)
- Official public API (documented at jobsuche.api.bund.dev): static API key, no registration, no scraping
- `search` / `detail` per the portal-skill contract, zero runtime dependencies
- Filters: location + radius, posting age, work time (full/part time, home office),
  contract type, offer type (jobs / Ausbildung / internships), employer, Zeitarbeit exclusion
- Detail endpoint quirk documented in `url-reference.md`: only **v3** works (v1/v2 return 403)

**`arbeitnow-search`** — free Arbeitnow job board API
- Tech/startup/English-speaking jobs in Germany, incl. remote and visa-sponsorship roles
- No API key, zero runtime dependencies
- API ignores server-side filter params (verified live): the CLI paginates
  (100 jobs/page) and filters client-side; page scans capped at 10 per the API's fair-use terms

### Changed

- `search-queries.md`: switched WebSearch fallback to German boards
  (StepStone, Indeed.de, Xing, LinkedIn Deutschland) — these have no public
  search APIs and block scraping

## Verification

- `tsc --noEmit` clean for both CLIs
- 12/12 tests pass (incl. live smoke tests: search → detail round-trip against both APIs)
- Live queries verified: 256 matches for "softwareentwickler" in Berlin (Arbeitsagentur),
  remote developer roles found via Arbeitnow

Per upstream policy, these market-specific skills live in this fork and are not
intended for an upstream PR.