### PR TITLE
docs: codify the runtime policy - Claude Code first, runtime forks welcome

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,20 @@ Reviews here are empirical. Bug reports are reproduced on master before the fix 
 
 Market-specific skills are genuinely valuable - they just live in forks, where their maintainers can test them and their users can find them.
 
+## Porting to another AI runtime? Forks too
+
+Claude Code is the reference runtime: it is what the maintainer runs daily and what every methodology change is verified on. A parallel command tree for another runtime (Codex, Antigravity, Gemini CLI, ...) would ship untested on every change - CI cannot run those harnesses - and each accepted runtime makes the next one harder to refuse. It is the same arithmetic that keeps market-specific portals in forks.
+
+What upstream maintains for other runtimes instead:
+
+- The portal search skills in `.agents/skills/` use the portable Agent Skills format (`SKILL.md` per portal) and are auto-discovered by Codex and Antigravity today.
+- The root `AGENTS.md` points any agent at the canonical workflow specs and the profile entry point.
+- Framework instruction files carry `framework_version` markers, so a runtime fork can track methodology changes precisely (`python3 tools/check_upstream_updates.py`).
+
+Announce your runtime fork in the pinned [Community forks & adaptations](https://github.com/MadsLorentzen/ai-job-search/discussions/78) discussion and it gets listed alongside the market adaptations. The proven shape is a thin pointer: reference the specs here instead of copying them, so upstream improvements reach your fork on rebase.
+
+This is a decision, not a dogma: if cross-runtime standards mature to the point where these specs run unmodified elsewhere, or the community's center of gravity moves to runtime forks, the trade-off gets re-evaluated. Background: the architecture thread in [Community forks & adaptations](https://github.com/MadsLorentzen/ai-job-search/discussions/78).
+
 ## Practical notes
 
 - **Portal-skill contract**: `search`/`detail` commands, `--format json|table|plain`, stderr JSON errors with exit 1, backoff on 429/5xx, zero runtime dependencies by default. See `/add-portal`'s spec and `linkedin-search` as the reference implementation.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The framework encodes career guidance best practices, including structured evalu
 
 ## Prerequisites
 
-- [Claude Code](https://claude.com/claude-code) (CLI)
+- [Claude Code](https://claude.com/claude-code) (CLI). Using a different agent tool (Codex, Antigravity, Gemini CLI)? Start at [`AGENTS.md`](AGENTS.md) - the portal search skills work there out of the box, and [community forks](https://github.com/MadsLorentzen/ai-job-search/discussions/78) adapt the full workflow.
 - Python 3.10+
 - [Bun](https://bun.sh) (for job search CLI tools)
 - LaTeX distribution with `lualatex` and `xelatex`: [TeX Live](https://tug.org/texlive/), [MacTeX](https://tug.org/mactex/), [TinyTeX](https://yihui.org/tinytex/), or [MiKTeX](https://miktex.org/). The CV compiles with `lualatex` (pdflatex often fails on modern MiKTeX installs with `fontawesome5` font-expansion errors); the cover letter compiles with `xelatex` because `cover.cls` requires `fontspec`. If using a minimal TeX install such as TinyTeX or BasicTeX, install the extra packages listed in [SETUP.md](SETUP.md#minimal-tex-install-tinytexbasictex).


### PR DESCRIPTION
Writes down the runtime-identity decision from the [architecture thread in #78](https://github.com/MadsLorentzen/ai-job-search/discussions/78) so the next runtime proposal reads it before filing, the same way the market-skills section works for portals.

- **README**: one added line in Prerequisites pointing non-Claude agent users at `AGENTS.md` and the community forks - no new section, no added scroll for the core audience.
- **CONTRIBUTING**: new "Porting to another AI runtime? Forks too" section beside the market-skills policy it mirrors - the reference-runtime rationale, what upstream maintains for other runtimes, the thin-pointer fork pattern, and the explicit revisit conditions so this reads as a reasoned decision rather than dogma.

Note: the README line links `AGENTS.md`, which lands in #159 - merge order matters or the link 404s briefly.

Verification: lint, security guards, framework version check, and all 109 Python tests pass; diff scanned for personal data (none - the only name occurrences are the repo's own public URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)