### PR TITLE
docs: warn fork authors about GitHub's default PR base

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Heads-up before you publish: if you built this in a personalized fork
+     (your profile data, your market's job portals, another AI runtime),
+     note that GitHub points new PRs at the UPSTREAM repo by default.
+     Those adaptations live in forks - see CONTRIBUTING.md - and get
+     discovered via the pinned "Community forks & adaptations" discussion (#78).
+     Check the "base repository" dropdown above before you continue. -->
+
+## What changed and why
+
+## Failing case / reproduction (for fixes)
+
+## Verification
+<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
+     python3 tools/check_framework_version.py, bun test / bun run typecheck
+     in touched CLIs, python3 -m unittest discover -s tests -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,8 @@ Reviews here are empirical. Bug reports are reproduced on master before the fix 
 
 Market-specific skills are genuinely valuable - they just live in forks, where their maintainers can test them and their users can find them.
 
+One practical warning: when you open a PR from a fork, GitHub targets this upstream repo by default, not your own - three personalized-fork PRs landed here by accident in a single week ([#155], [#162], [#165]). Check the "base repository" dropdown before publishing.
+
 ## Porting to another AI runtime? Forks too
 
 Claude Code is the reference runtime: it is what the maintainer runs daily and what every methodology change is verified on. A parallel command tree for another runtime (Codex, Antigravity, Gemini CLI, ...) would ship untested on every change - CI cannot run those harnesses - and each accepted runtime makes the next one harder to refuse. It is the same arithmetic that keeps market-specific portals in forks.
@@ -93,3 +95,6 @@ Questions and proposals are welcome in [Discussions](https://github.com/MadsLore
 [#73]: https://github.com/MadsLorentzen/ai-job-search/issues/73
 [#75]: https://github.com/MadsLorentzen/ai-job-search/issues/75
 [#76]: https://github.com/MadsLorentzen/ai-job-search/issues/76
+[#155]: https://github.com/MadsLorentzen/ai-job-search/pull/155
+[#162]: https://github.com/MadsLorentzen/ai-job-search/pull/162
+[#165]: https://github.com/MadsLorentzen/ai-job-search/pull/165


### PR DESCRIPTION
Three personalized-fork PRs (#155, #162, #165) were filed against upstream by accident in a single week - GitHub targets the upstream repo by default when opening a PR from a fork, and nothing warns about it at the moment of filing (CONTRIBUTING demonstrably isn't read at that moment).

Two additions, different moments of contact:

- **`.github/PULL_REQUEST_TEMPLATE.md`** (new): the heads-up appears in the PR compose box - the only place all three authors would have seen it. The visible headings mirror what review asks for anyway (what/why, failing case, verification commands), so the template doubles as a norms nudge. The warning is an HTML comment: invisible in the rendered PR, zero cost to compliant contributors.
- **CONTRIBUTING.md**: one sentence in the fork section naming the default-base mechanism, with the three precedent PRs in the file's reference-link house style - so decline redirects that link CONTRIBUTING become fully self-explanatory.

Verification: lint (10 commands), security guards, framework version check, 114 Python tests all pass; staged diff scanned for personal data - clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)