### PR TITLE
fix: clean up duplicate imports, dead code, and fill test gaps

### DIFF
--- a/.agents/skills/jobindex-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import { runCLI } from "./helpers";
+
+function parsedStderr(stderr: string): { error?: string; code?: string } {
+  try {
+    return JSON.parse(stderr);
+  } catch {
+    return {};
+  }
+}
+
+describe("Jobindex CLI flag validation", () => {
+  describe("search missing --query", () => {
+    test("search without --query exits 1 with MISSING_REQUIRED", async () => {
+      const result = await runCLI(["search"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("MISSING_REQUIRED");
+      expect(err.error).toMatch(/query/);
+    });
+  });
+
+  describe("detail missing ID", () => {
+    test("detail without an ID exits 1 with MISSING_REQUIRED", async () => {
+      const result = await runCLI(["detail"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("MISSING_REQUIRED");
+    });
+  });
+
+  describe("--page NaN validation", () => {
+    test("non-numeric string exits 1", async () => {
+      const result = await runCLI(["search", "-q", "python", "--page", "abc"]);
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+
+  describe("--limit NaN validation", () => {
+    test("non-numeric string exits 1", async () => {
+      const result = await runCLI(["search", "-q", "python", "--limit", "xyz"]);
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+
+  describe("--jobage NaN validation", () => {
+    test("non-numeric string exits 1", async () => {
+      const result = await runCLI(["search", "-q", "python", "--jobage", "foo"]);
+      expect(result.exitCode).not.toBe(0);
+    });
+  });
+
+  describe("valid flags produce no error", () => {
+    test("all valid flags pass validation", async () => {
+      const result = await runCLI([
+        "search", "-q", "python", "--page", "1", "--limit", "1", "--jobage", "7",
+      ]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("MISSING_REQUIRED");
+    });
+  });
+});

--- a/.agents/skills/jobnet-search/cli/tests/cli-contract.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/cli-contract.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+function parseError(stderr: string): { error: string; code: string } {
+  return JSON.parse(stderr);
+}
+
+describe("Jobnet CLI error contract", () => {
+  test("detail without an ID exits 1 with MISSING_REQUIRED", async () => {
+    const result = await runCLI(["detail"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(parseError(result.stderr)).toEqual({
+      error: "Job ad ID is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+
+  test("search with valid flags passes validation", async () => {
+    const result = await runCLI([
+      "search", "--search-string", "python", "--per-page", "1",
+    ]);
+    const errStr = result.stderr;
+    let err: { code?: string } = {};
+    try { err = JSON.parse(errStr); } catch {}
+    expect(err.code).not.toBe("BAD_ARG");
+  });
+
+  test("--per-page NaN exits 1", async () => {
+    const result = await runCLI(["search", "--per-page", "abc"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("--page NaN exits 1", async () => {
+    const result = await runCLI(["search", "--page", "xyz"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("--radius NaN exits 1", async () => {
+    const result = await runCLI(["search", "--postal-code", "2100", "--radius", "foo"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("--limit NaN exits 1", async () => {
+    const result = await runCLI(["search", "--limit", "bar"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/cover_letters/cover.cls
+++ b/cover_letters/cover.cls
@@ -21,19 +21,16 @@
 \renewcommand\refname{\vskip -1.5cm}
 
 % Color definitions
-\usepackage[usenames,dvipsnames]{xcolor} 
-\definecolor{date}{HTML}{666666} 
+\definecolor{date}{HTML}{666666}
 \definecolor{primary}{HTML}{2b2b2b} 
 \definecolor{headings}{HTML}{6A6A6A}
 \definecolor{subheadings}{HTML}{333333}
 
 % Set main fonts
-\usepackage{fontspec}
 \setmainfont[Color=primary, Path = OpenFonts/fonts/lato/,BoldItalicFont=Lato-RegIta,BoldFont=Lato-Reg,ItalicFont=Lato-LigIta]{Lato-Lig}
 \setsansfont[Scale=MatchLowercase,Mapping=tex-text, Path = OpenFonts/fonts/raleway/]{Raleway-ExtraLight}
 
 % Date command
-\usepackage[absolute]{textpos}
 % \usepackage[UKenglish]{isodate}
 \setlength{\TPHorizModule}{1mm}
 \setlength{\TPVertModule}{1mm}
@@ -57,7 +54,6 @@ Last Updated on \today
 }
 
 % Section seperators 
-\usepackage{titlesec}
 \titlespacing{\section}{0pt}{0pt}{0pt} 
 \titlespacing{\subsection}{0pt}{0pt}{0pt}
 \newcommand{\sectionsep}{\vspace{8pt}}

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -17,7 +17,6 @@
 \renewcommand*{\lastnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
 \renewcommand*{\sectionstyle}[1]{{\sectionfont\color{color1}#1}}
 
-\usepackage[utf8]{inputenc}
 \usepackage{hyperref}
 \hypersetup{
     colorlinks=true,

--- a/tests/test_check_upstream_updates.py
+++ b/tests/test_check_upstream_updates.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for tools/check_upstream_updates.py helper functions."""
+
+import unittest
+from tools.check_upstream_updates import (
+    get_framework_version_from_text,
+    parse_semver,
+)
+
+
+class TestGetFrameworkVersionFromText(unittest.TestCase):
+    """Tests for extracting framework_version from YAML-like frontmatter."""
+
+    def test_valid_frontmatter(self):
+        text = "---\nframework_version: 1.0.0\n---\nContent here"
+        self.assertEqual(get_framework_version_from_text(text), "1.0.0")
+
+    def test_valid_frontmatter_quoted(self):
+        text = '---\nframework_version: "1.2.3"\n---\nContent'
+        self.assertEqual(get_framework_version_from_text(text), "1.2.3")
+
+    def test_valid_frontmatter_single_quoted(self):
+        text = "---\nframework_version: '2.0.1'\n---\nContent"
+        self.assertEqual(get_framework_version_from_text(text), "2.0.1")
+
+    def test_no_frontmatter(self):
+        text = "Just some plain text without frontmatter"
+        self.assertIsNone(get_framework_version_from_text(text))
+
+    def test_empty_frontmatter(self):
+        text = "---\n---\nContent"
+        self.assertIsNone(get_framework_version_from_text(text))
+
+    def test_frontmatter_without_version(self):
+        text = "---\nother_key: value\n---\nContent"
+        self.assertIsNone(get_framework_version_from_text(text))
+
+    def test_unclosed_frontmatter(self):
+        text = "---\nframework_version: 1.0.0\nContent without closing"
+        self.assertIsNone(get_framework_version_from_text(text))
+
+    def test_version_with_whitespace(self):
+        text = "---\nframework_version:   1.5.0  \n---\nContent"
+        self.assertEqual(get_framework_version_from_text(text), "1.5.0")
+
+    def test_multiple_frontmatter_keys(self):
+        text = "---\ntitle: My Skill\nframework_version: 3.1.0\ndescription: Test\n---\nBody"
+        self.assertEqual(get_framework_version_from_text(text), "3.1.0")
+
+    def test_empty_string(self):
+        self.assertIsNone(get_framework_version_from_text(""))
+
+    def test_only_opening_fence(self):
+        text = "---\nframework_version: 1.0.0"
+        self.assertIsNone(get_framework_version_from_text(text))
+
+
+class TestParseSemver(unittest.TestCase):
+    """Tests for semver parsing."""
+
+    def test_standard_version(self):
+        self.assertEqual(parse_semver("1.0.0"), (1, 0, 0))
+
+    def test_version_with_v_prefix(self):
+        self.assertEqual(parse_semver("v2.3.4"), (2, 3, 4))
+
+    def test_large_numbers(self):
+        self.assertEqual(parse_semver("10.200.3000"), (10, 200, 3000))
+
+    def test_invalid_version_returns_zero(self):
+        self.assertEqual(parse_semver("invalid"), (0, 0, 0))
+
+    def test_empty_string(self):
+        self.assertEqual(parse_semver(""), (0, 0, 0))
+
+    def test_partial_version(self):
+        self.assertEqual(parse_semver("1.2"), (0, 0, 0))
+
+    def test_version_with_suffix(self):
+        self.assertEqual(parse_semver("1.2.3-beta"), (1, 2, 3))
+
+    def test_version_with_extra_text(self):
+        self.assertEqual(parse_semver("version 1.2.3"), (0, 0, 0))
+
+    def test_zero_version(self):
+        self.assertEqual(parse_semver("0.0.0"), (0, 0, 0))
+
+    def test_comparisonordering(self):
+        self.assertGreater(parse_semver("1.0.1"), parse_semver("1.0.0"))
+        self.assertGreater(parse_semver("2.0.0"), parse_semver("1.9.9"))
+        self.assertGreater(parse_semver("1.1.0"), parse_semver("1.0.9"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/convert_salary_excel.py
+++ b/tools/convert_salary_excel.py
@@ -89,7 +89,7 @@ def detect_column_type(header):
     return None
 
 
-def parse_sheet(ws, sheet_label=None):
+def parse_sheet(ws):
     """Parse a single worksheet into a list of company entries and detected categories."""
     # Find header row
     header_row = None
@@ -273,7 +273,7 @@ def main():
     for sheet_name in wb.sheetnames:
         print(f"  Parsing sheet: {sheet_name}")
         ws = wb[sheet_name]
-        companies = parse_sheet(ws, sheet_label=sheet_name)
+        companies = parse_sheet(ws)
         all_companies.extend(companies)
 
     wb.close()


### PR DESCRIPTION
- cover.cls: remove duplicate xcolor, fontspec, textpos, titlesec imports
- cv/main_example.tex: drop inputenc (unnecessary with lualatex)
- convert_salary_excel.py: remove unused sheet_label parameter
- Add 21 tests for check_upstream_updates.py (was untested)
- Add CLI flag validation tests for jobindex-search (7 tests)
- Add CLI contract tests for jobnet-search (5 tests)

<!-- Heads-up before you publish: if you built this in a personalized fork
     (your profile data, your market's job portals, another AI runtime),
     note that GitHub points new PRs at the UPSTREAM repo by default.
     Those adaptations live in forks - see CONTRIBUTING.md - and get
     discovered via the pinned "Community forks & adaptations" discussion (#78).
     Check the "base repository" dropdown above before you continue. -->

## What changed and why

## Failing case / reproduction (for fixes)

## Verification
<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
     python3 tools/check_framework_version.py, bun test / bun run typecheck
     in touched CLIs, python3 -m unittest discover -s tests -->
