### PR TITLE
test(cli): cover Jobindex and Jobnet contracts

### DIFF
--- a/.agents/skills/jobindex-search/cli/tests/cli-contract.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/cli-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+describe("Jobindex CLI error contract", () => {
+  test("search without a query fails with JSON on stderr", async () => {
+    const result = await runCLI(["search"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--query is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+
+  test("detail without an ID fails before making a request", async () => {
+    const result = await runCLI(["detail"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "Job ID or URL is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+
+  test("an invalid numeric option fails before making a request", async () => {
+    const result = await runCLI(["search", "--query", "test", "--page", "not-a-number"]);
+    const error = JSON.parse(result.stderr);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(error.ok).toBe(false);
+    expect(error.error.kind).toBe("validation");
+    expect(error.error.option).toBe("page");
+    expect(error.error.message).toContain("Expected number");
+  });
+});

--- a/.agents/skills/jobnet-search/cli/tests/cli-contract.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/cli-contract.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+describe("Jobnet CLI error contract", () => {
+  test("detail without an ID fails with JSON on stderr", async () => {
+    const result = await runCLI(["detail"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "Job ad ID is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+
+  test("occupations without a search string fails before making a request", async () => {
+    const result = await runCLI(["occupations"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--search-string is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+
+  test("suggestions without a query fails before making a request", async () => {
+    const result = await runCLI(["suggestions"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--query is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+
+  test("an invalid numeric option fails before making a request", async () => {
+    const result = await runCLI(["search", "--page", "not-a-number"]);
+    const error = JSON.parse(result.stderr);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(error.ok).toBe(false);
+    expect(error.error.kind).toBe("validation");
+    expect(error.error.option).toBe("page");
+    expect(error.error.message).toContain("Expected number");
+  });
+});


### PR DESCRIPTION
## What

Extends the offline CLI contract tests to the two remaining Danish portal CLIs, completing the sweep started with the Jobbank/Jobdanmark contract tests. Both CLIs implement the documented error contract (JSON errors on stderr, exit 1, fail before any network request) but had no test locking it in — `jobindex-search` shipped only `parsing.test.ts`, and `jobnet-search` only the formatting/normalization suites.

## Coverage

**jobindex-search** (3 tests):
- `search` without `--query` → `{"error": "--query is required", "code": "MISSING_REQUIRED"}` on stderr, exit 1, empty stdout
- `detail` without an ID → `MISSING_REQUIRED`, same shape
- `search --query test --page not-a-number` → bunli validation error (`kind: "validation"`, `option: "page"`) before any request

**jobnet-search** (4 tests):
- `detail` without an ID → `MISSING_REQUIRED`
- `occupations` without `--search-string` → `MISSING_REQUIRED`
- `suggestions` without `--query` → `MISSING_REQUIRED`
- `search --page not-a-number` → bunli validation error

Jobnet's `search` has no required flag (an unfiltered search is legitimate), so its offline-testable surface is the validation path; the two extra commands it ships get their own required-flag tests instead.

## Notes

- Every asserted path exits before any network call — no live portal requests, per CI policy.
- Assertions were written against observed CLI output (each error path was run and its actual stderr shape captured), not assumed shapes.
- Test style, file naming, and `runCLI` usage mirror the existing Jobbank/Jobdanmark contract tests; both `tests/helpers.ts` files already existed and are unchanged.

## Verification

- `bun test` in `jobindex-search/cli`: 9 pass / 0 fail (2 files)
- `bun test` in `jobnet-search/cli`: 9 pass / 0 fail (3 files)
- `bun run typecheck` clean in both CLIs
- `python3 tools/lint_skills.py`: OK