### PR TITLE
feat(apply): make CV language a profile setting, defaulting to English

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -65,7 +65,7 @@ Also read the most recent existing CV and cover letter files for concrete struct
 - Read any existing `cover_letters/cover_*.tex` or `cover_letters/Cover_*.tex` file as a template reference
 
 ### CV (`cv/main_<company>_<role>.tex`)
-- Always in **English**
+- In the **CV language from the profile** (the `CV language:` line in CLAUDE.md's Identity section). When the profile does not set one, default to **English**. Never switch language per posting - the CV language is a profile-level choice, so all CVs stay consistent and reusable
 - Follow the moderncv/banking format from `05-cv-templates.md`
 - Tailor the profile statement and experience bullets to the specific role
 - Reframe skills and achievements to match job requirements
@@ -245,7 +245,7 @@ Read the `.txt` file.
 
 Failures here are template-level problems: fix them in the `.tex` (e.g. print the email as text rather than icon-only), then re-run 5a–5c and re-extract. If a custom template's layout fundamentally scrambles extraction order, tell the user prominently — they may be trading ATS compatibility for looks.
 
-**3. Keyword coverage.** Reuse the required/preferred keyword list you extracted in Step 1 — do not re-derive it. Match each keyword against the extracted text, **in the posting's language** (a Danish posting's keywords are matched in Danish even though the CV is in English — where the CV legitimately covers the concept in English, count it as synonym-only and note the language difference). Report a table:
+**3. Keyword coverage.** Reuse the required/preferred keyword list you extracted in Step 1 — do not re-derive it. Match each keyword against the extracted text, **in the posting's language** (when the posting's language differs from the CV language — e.g. a Danish posting against an English CV — a concept the CV legitimately covers in its own language counts as synonym-only; note the language difference). Report a table:
 
 | Keyword | Priority | Status | Note |
 |---------|----------|--------|------|

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -314,6 +314,7 @@ Ask about:
 - **Target companies (optional):** "Are there specific companies you'd like to monitor for openings?"
 - **Geographic scope:** "Which cities or regions should I search in? How far are you willing to commute?" Use this to define the location filter tiers (ideal, acceptable, borderline, too far).
 - **Job portals:** "The framework ships country-agnostic search CLIs (`linkedin-search`, `freehire-search`) plus Danish portal demos (Jobindex, Jobbank, Jobdanmark, Jobnet). `/scrape` auto-discovers whatever portal skills are installed under `.agents/skills/`. Which of these fit your market, and do you use other job boards?" If the user needs a local board that is not shipped, guide them to `/add-portal` (market-specific skills live in their fork). WebSearch/`site:` queries remain the fallback for portals without a CLI skill.
+- **CV language:** "Should your CVs be written in English (the default, accepted in most markets), or in your market's language?" Record the answer as a `CV language: <language>` line in CLAUDE.md's Identity section. Cover letters always match each posting's language automatically; this setting governs the CV only. If the user is unsure, keep English and note they can re-run `/setup --section search` to change it.
 
 **Important:** Also suggest role types the user may not have considered, based on their skill profile. For example:
 - If they have strong Python + domain expertise: "Have you considered roles like 'Technical Consultant' or 'Solutions Engineer' in your domain?"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 - **Name:** [YOUR_NAME]
 - **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
 - **Languages:** [YOUR_LANGUAGES]
+- **CV language:** [YOUR_CV_LANGUAGE] <!-- English unless your market expects otherwise; /setup asks -->
+
 - **Status:** [YOUR_EMPLOYMENT_STATUS]
 - **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
 


### PR DESCRIPTION
From the quality audit: `apply.md` hardcoded the CV as 'Always in English' - a baked-in assumption from the demonstration profile that actively hurts output quality for fork users in markets expecting local-language applications (the fork map now spans DACH, Poland, Brazil, Spain, China, Vietnam). Cover letters already match the posting's language; the CV had no equivalent flexibility.

**Changes (+5/-2):**
- `setup.md`: one search-config question - CV in English (default) or the market's language - recorded as a `CV language:` line in CLAUDE.md's Identity section
- `apply.md`: CV drafts in the profile's CV language, **defaulting to English when unset** - zero behavior change for every existing user and fork; explicitly stays a profile-level choice (never per-posting) so CVs remain consistent
- `apply.md` ATS keyword rule: reworded language-neutrally (was 'even though the CV is in English')
- `CLAUDE.md`: `[YOUR_CV_LANGUAGE]` placeholder slot in Identity

Verification: lint, version guard, 119 tests green; personal-data scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)