### PR TITLE
fix(cover-letter-template): use \huge instead of \Huge for title name

### DIFF
--- a/.claude/skills/job-application-assistant/06-cover-letter-templates.md
+++ b/.claude/skills/job-application-assistant/06-cover-letter-templates.md
@@ -72,7 +72,7 @@ The font wrapper is mandatory — if you just move `\begin{itemize}` outside `\l
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %     TITLE NAME
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\namesection{}{\Huge{[YOUR_NAME]}}{  \href{mailto:[YOUR_EMAIL]}{[YOUR_EMAIL]} | [YOUR_PHONE] |  \urlstyle{same}\href{[YOUR_LINKEDIN_URL]}{LinkedIn}
+\namesection{}{\huge{[YOUR_NAME]}}{  \href{mailto:[YOUR_EMAIL]}{[YOUR_EMAIL]} | [YOUR_PHONE] |  \urlstyle{same}\href{[YOUR_LINKEDIN_URL]}{LinkedIn}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
## Summary
- The cover letter template's `\namesection` title name was rendered at `\Huge` (~24.9pt); switches to `\huge` (~20.7pt), matching the size already applied to the Sopra Steria cover letter.

## Test plan
- [x] Verified the equivalent change compiles to a clean 1-page PDF for the Sopra Steria cover letter (visually inspected).
- [ ] Generate a new cover letter from the template and visually confirm the smaller title renders correctly.