### PR TITLE
feat(setup): populate Cheng-En Li profile from documents (Path A)

### DIFF
--- a/.claude/skills/job-application-assistant/01-candidate-profile.md
+++ b/.claude/skills/job-application-assistant/01-candidate-profile.md
@@ -4,61 +4,100 @@ framework_version: 1.0.0
 
 # Candidate Profile
 
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all sections will be filled with your actual information -->
-
 ## Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_ADDRESS]
-- **Phone:** [YOUR_PHONE]
-- **Email:** [YOUR_EMAIL]
-- **LinkedIn:** [YOUR_LINKEDIN_URL]
-- **GitHub:** [YOUR_GITHUB_URL]
-- **Languages:** [YOUR_LANGUAGES with proficiency levels]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
+- **Name:** Cheng-En Li
+- **Location:** Taipei, Taiwan
+- **Phone:** 0928-516-521
+- **Email:** hello.lichengen@gmail.com
+- **LinkedIn:** https://www.linkedin.com/in/cheng-en-li/
+- **Blog:** https://hello-lichengen.medium.com/
+- **GitHub:** https://github.com/nondayo
+- **Languages:** Mandarin (native), English (intermediate / conversational)
+- **Status:** Employed (Director of Product, Chimes AI), open to work
+- **Constraints:** Open to remote / hybrid roles (location-flexible); based in Taipei, Taiwan
 
 ## Education
 
 | Degree | Period | Institution | Key Topics |
 |--------|--------|-------------|------------|
-| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+| B.A. Materials Science and Engineering | 2007-2011 | National Tsing Hua University, Hsinchu, Taiwan | General materials science & engineering coursework |
 
 ## Professional Experience
 
-### [JOB_TITLE] - [COMPANY] ([START] - [END])
-[LOCATION]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+### Director of Product - Chimes AI (2023 - Present)
+Taipei, Taiwan
+- Lead a 7-person cross-functional team (1 Product Manager, 3 Engineers, 2 AI/ML Engineers, 1 Designer), reporting directly to the CEO; own strategy and roadmap for the company's three core product lines
+- Chair product strategy and product-lifecycle meetings; define product vision through market research, competitive analysis, and user research
+- Launched a new product line by commercializing and standardizing AI algorithms/services, expanding into new industry verticals and winning the company's first flagship client contract exceeding NT$10M
+- Grew customer count from 20+ to 80+ accounts; drove company annual revenue growth of more than 3x during tenure
+- Drove product deployment across 50+ factories and 2,500+ AI models, contributing ~40,000 tons of annual CO2 reduction across petrochemical, steel, semiconductor, and automotive manufacturing
+- Deployed equipment anomaly detection and product-quality prediction at CPC Corporation's Taoyuan Refinery (equipment utilization +25%), plus energy-optimization modules at China Steel Chemical (per-batch energy -32%, ~200 tons/yr CO2) and a styrene dehydrogenation process (~4,600 tons/yr steam saved)
+- Leading a Ministry of Health and Welfare data-standardization initiative across 13 social-affairs information systems under the Social and Family Affairs Administration (社家署): ran stakeholder interviews to surface shared, high-frequency fields, then reconciled field-level semantics and semantically merged their code sets into a unified data dictionary
+- Authoring a Taiwan social-affairs Base Implementation Guide conformant with the HL7 FHIR standard, establishing the interoperability specification for cross-system social-welfare data exchange
+
+### Product Manager - Chimes AI (2021 - 2022)
+Taipei, Taiwan
+- Built the Tukey no-code AI platform, transforming customer data-science delivery from a point-to-point model (5 engineers / 3 years / 40 projects) to a platform-based deployment model (15 engineers / 3 months / 400+ models), enabling non-technical staff to operate and optimize models independently
+- Deployed an equipment anomaly detection module at a Formosa Plastics Group plant, achieving 90% diagnostic accuracy and validating the feasibility of human-AI collaboration
+- Built digital twins for chemical-plant distillation towers and AI-powered manufacturing optimization solutions
+- Initiated SCRUM and issue-tracking practices; defined product vision and strategy through user, market, and competitor research
+- Drove company annual revenue growth of nearly 4x during tenure
+
+### Data Analyst - DSP (2017 - 2021)
+Taipei, Taiwan
+- Designed the end-to-end analytics product development process (factory visits, data inventory, preprocessing, data exploration, model building, validation) for textile dyeing customers, improving new dyeing success rate by 5%
+- Integrated case histories across 11 cross-agency departments (labor, health, education, police) to build a domestic-violence risk-prediction model and dashboard that triaged new cases, helping social workers intervene earlier and reducing recidivism by 30%
+- Hosted 20+ design thinking workshops across petrochemical, automotive, banking, and government clients; 70%+ of participants converted into paying clients, generating tens of millions in revenue
+
+### Magazine Editor - Yuan-Liou Publishing (2013 - 2017)
+Taipei, Taiwan
+- Planned content themes, article types, and special features for each magazine issue
+- Reviewed and edited submitted articles for style and quality consistency
+- Coordinated with writers, photographers, and other contributors
 
 <!-- Add more roles as needed -->
 
 ## Independent Projects
 <!-- Projects outside of employment: freelance, open source, personal -->
-- **[PROJECT_NAME]**: [DESCRIPTION]
+- **Insight Agent**: AI agent project (https://huggingface.co/spaces/lichengen/InsightAgent)
+- **Mental Health Disorder Analysis**: Data analysis project (https://github.com/nondayo/MentalHealth)
+- **Pig Breeding Visualization**: Data visualization project (https://github.com/nondayo/Pig_Breeding)
 
 ## Technical Skills
 
 ### Programming & ML
-- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
-- [OTHER_SKILLS]
+- **Python**: general-purpose scripting and data analysis
+- **R / R Shiny**: statistical analysis and dashboarding
+- SQL, JavaScript, D3.js, Bash, Django, Docker, Jenkins, Anaconda, Git
+- Machine Learning, Large Language Models (LLM), Data Science, Data Analysis, Data Visualization, Data Mining, Statistics, Analytical Skills
 
 ### Domain Expertise
-- [DOMAIN_1]
-- [DOMAIN_2]
+- No-code AI / MLOps platform product management (industrial/manufacturing AI); product name: Tukey
+- 0-to-1 product strategy, roadmap ownership, product-led growth, go-to-market, SCRUM/Agile
+- AI-first product design (MCP tool interfaces, design systems); healthcare/social-affairs data interoperability (HL7 FHIR)
+- Data-driven consulting, design-thinking facilitation, cross-functional and stakeholder leadership
+- Publishing/editorial background
 
 ### Software & Tools
-- [TOOL_LIST]
+- Figma, Whimsical, Notion, WordPress, Git
+
+## Certifications
+- Generative AI with Large Language Models — Coursera (Sep 2023)
+- edX Verified Certificate, SU22: Introduction to Analytics Modeling — edX (Jul 2022)
+- edX Verified Certificate, SP22: Data Analytics for Business — edX (Apr 2022)
 
 ## Publications
 <!-- List peer-reviewed publications, if any -->
-1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+1. 〈AI 社工可行嗎?運用社會安全資料驅動社福變革管理〉— 2020年社會福利論壇-社會安全網之強化及整合策略研討會 (https://bit.ly/3n9DFiT)
+2. 〈新世代的成長模式 Product-led growth：以 data Infra 產品為例〉— Medium (https://medium.com/@hello-lichengen/4c23d40c14f0)
+3. 〈支付新創 Stripe 的成長之路〉— Medium (https://medium.com/@hello-lichengen/25f6f29df3b3)
+4. 〈從 Apache Spark 到 Databricks：一個開源專案如何成為成功的商業模式〉— Medium (https://medium.com/@hello-lichengen/ec328f88eb8)
 
 ## Awards
-- [AWARD] - [EVENT] ([YEAR])
+- 經濟部工業局「110年度輔導創新資料服務構想商業化」競賽首獎 (2021)
+- 第四十屆金鼎獎 兒少類《科學少年》— 遠流出版事業股份有限公司
 
 ## References
-- [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])
+- Johnson Hsieh (謝宗震), Founder & CEO, Chimes AI (contact details to be confirmed) — endorsed Data Analysis on LinkedIn
 
 More references available upon request.

--- a/.claude/skills/job-application-assistant/02-behavioral-profile.md
+++ b/.claude/skills/job-application-assistant/02-behavioral-profile.md
@@ -8,47 +8,50 @@ framework_version: 1.0.0
 <!-- You can use results from PI, DISC, Myers-Briggs, StrengthsFinder, or a self-assessment -->
 
 ## Overview
-[YOUR_NAME]'s behavioral assessment identifies them as a **[PROFILE_TYPE]** pattern. [1-2 SENTENCE_SUMMARY].
+No formal behavioral assessment (PI, DISC, Myers-Briggs, StrengthsFinder) is on file. The profile below is **synthesized** from LinkedIn, work history, and company materials. Treat it as inference to guide positioning, not as a validated instrument. Replace this section if you complete a formal assessment.
 
 ## Core Behavioral Drives
-
-| Drive | Level | Meaning |
-|-------|-------|---------|
-| [DRIVE_1] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_2] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_3] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_4] | [LEVEL] | [DESCRIPTION] |
+*Not formally assessed. See the synthesized traits below instead of scored drive levels.*
 
 ## Strongest Behaviors
-- **[BEHAVIOR_1]:** [DESCRIPTION]
-- **[BEHAVIOR_2]:** [DESCRIPTION]
-- **[BEHAVIOR_3]:** [DESCRIPTION]
+- **0-to-1 builder:** Led a no-code AI platform from concept to commercialization and stood up the team and product around it
+- **Data-driven decision-maker:** Uses market, user, and competitor research plus metrics to define product direction
+- **Bridges technical and business:** Translates between AI/ML engineering and enterprise/manufacturing stakeholders
+- *[Inferred from LinkedIn About - review before relying on this]* **Ambiguity-to-structure:** Extensive experience solving real-world problems using data analytics and engineering; transforms ambiguous problems into requirements and solution plans
+- *[Inferred from LinkedIn About - review before relying on this]* **End-to-end ownership:** Capable of building a machine learning product from end to end
+- *[Inferred from LinkedIn About - review before relying on this]* **Stakeholder communication:** Experienced in stakeholder management and communication across technical and business audiences
+- *[Inferred from company business plan - review before relying on this]* **Cross-disciplinary integrator:** Bridges chemical engineering, science editing, and data science to deliver AI products; integrates specialists across domains
+- *[Inferred from LinkedIn About - review before relying on this]* **Platformization mindset:** Converts one-off, project-based custom delivery into scalable, repeatable products
 
 ## How You Work Best
-- [ENVIRONMENT_PREFERENCE_1]
-- [ENVIRONMENT_PREFERENCE_2]
-- [ENVIRONMENT_PREFERENCE_3]
+- Ambiguous, 0-to-1 environments with room to define the problem before building
+- High autonomy with direct access to decision-makers (has reported directly to the CEO)
+- Cross-functional teams spanning product, engineering, AI/ML, and design
+- *[Inferred from LinkedIn About - review before relying on this]* Thrives in ambiguous, 0-to-1 environments where the process is fluid and creative problem-solving is the norm
 
 ## Growth Areas (frame positively in applications)
-- **[AREA_1]:** [HOW_TO_FRAME_IT_POSITIVELY]
-- **[AREA_2]:** [HOW_TO_FRAME_IT_POSITIVELY]
+- **Deep production engineering:** Frame as a product leader who partners closely with engineering, not as a hands-on IC coder
+- **Formal CS / ML credentials:** Frame around demonstrated delivery and continuous upskilling (GenAI/LLM and analytics certifications)
 
 ## Mapping to Job Posting Language
 
 When a job posting mentions these keywords, it's a **strong behavioral fit**:
-- [KEYWORD_OR_PHRASE_THAT_MATCHES_YOUR_STYLE]
-- [ANOTHER_KEYWORD]
+- 0-to-1, greenfield, new product line, product vision/strategy
+- AI/ML product, MLOps, no-code / platform
+- Cross-functional leadership, stakeholder management, ambiguous / fast-changing
 
 When a job posting mentions these, flag as **potential friction** (not deal-breaker):
-- [KEYWORD_OR_PHRASE_THAT_MIGHT_CLASH]
-- [ANOTHER_KEYWORD]
+- Predominantly maintenance / keep-the-lights-on work
+- Heavily process-bound or bureaucratic environments
+- Individual-contributor coding role with no product ownership
+- Rigid top-down management with low autonomy
 
 ## Management Style Preferences
-- [WHAT_MANAGEMENT_STYLE_WORKS_FOR_YOU]
-- [WHAT_DOESN'T_WORK]
+- Works best with autonomy, outcome-oriented leadership, and direct communication
+- Does not thrive under micromanagement or rigid, process-heavy structures
 
 ## Using This in Applications
-- **Cover letters:** [HOW_TO_WEAVE_IN_BEHAVIORAL_STRENGTHS]
-- **CV:** [WHAT_TO_EMPHASIZE]
-- **Interviews:** [WHAT_STAR_EXAMPLES_TO_USE]
-- **Don't overstate:** [WHAT_NOT_TO_CLAIM]
+- **Cover letters:** Lead with 0-to-1 product creation and platformization; back with measurable industrial impact
+- **CV:** Emphasize product leadership, team leadership, and measurable outcomes (customer growth, revenue, CO2 reduction)
+- **Interviews:** Use the Tukey STAR examples (0-to-1, strategy pivot, technical trade-offs) in `07-interview-prep.md`
+- **Don't overstate:** Not a hands-on production software engineer; behavioral traits here are synthesized, not formally assessed

--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -20,9 +20,9 @@ How well do the required/preferred skills align with the candidate's capabilitie
 | 40-59 | Partial match, significant upskilling needed |
 | 0-39 | Fundamental mismatch |
 
-**Strong match areas:** [YOUR_PRIMARY_SKILLS]
-**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
-**Weak match areas:** [SKILLS_YOU_LACK]
+**Strong match areas:** Product management (0-to-1 strategy, roadmap, product-led growth), industrial/manufacturing AI product, no-code AI / MLOps platforms, cross-functional and stakeholder leadership, data analysis
+**Moderate match areas:** Hands-on ML / data science, Python / R, LLM / GenAI, go-to-market, design-thinking facilitation, healthcare/social-affairs data interoperability (HL7 FHIR)
+**Weak match areas:** Deep production software engineering at scale, formal CS credentials, large-scale distributed systems, consumer/non-industrial product domains
 
 ### 2. Experience Match (0-100)
 Does work history align with what they're looking for?
@@ -34,9 +34,9 @@ Does work history align with what they're looking for?
 | 40-59 | Adjacent experience, would need to make the case |
 | 0-39 | Unrelated experience |
 
-**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
-**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
-**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+**Strong:** B2B / industrial AI product management (manufacturing, petrochemical, steel, semiconductor), no-code AI platform, data-driven consulting
+**Moderate:** AI/ML Product Manager, Technical PM / Solutions, healthcare and government data interoperability, data-analytics roles
+**Entry-level:** Pure engineering / IC developer roles, consumer-app PM, non-technical marketing
 
 ### 3. Behavioral/Culture Fit (0-100)
 Does the role and company culture match the behavioral profile?
@@ -51,9 +51,9 @@ Does the role and company culture match the behavioral profile?
 **Red flags to research:** Department disorganization, work dominated by maintenance over development, poor chemistry with leadership, culture mismatches. Check reviews, media coverage, LinkedIn connections, and network contacts for insider perspective.
 
 ### 4. Location & Logistics (Pass/Fail + Notes)
-- Within commute range: PASS
-- Remote with occasional office: PASS
-- Requires relocation: FAIL (deal-breaker)
+- Remote or hybrid (location-flexible): PASS — this is the preferred mode
+- Within Greater Taipei commute range (Taipei / New Taipei): PASS
+- On-site only, outside Greater Taipei, with no remote option: FAIL unless relocation is offered and worthwhile
 - Frequent international travel: FLAG (discuss with user)
 
 ### 5. Career Alignment & Motivation (0-100)
@@ -67,19 +67,19 @@ Does this role advance career goals and contain tasks that energize?
 | 0-39 | Dead end or backwards step |
 
 **Career goals:**
-- [YOUR_CAREER_GOAL_1]
-- [YOUR_CAREER_GOAL_2]
-- [YOUR_CAREER_GOAL_3]
+- Grow into senior / head-of-product leadership building AI products in ambiguous, 0-to-1 environments
+- Work on AI/ML products with real industrial or societal impact
+- High-autonomy, cross-functional roles; remote or hybrid
 
 **Motivation filter:** Evaluate not just whether you *can* do the tasks, but whether the tasks will *energize* you. Consider:
-- Tasks that energize: [YOUR_ENERGIZING_TASKS]
-- Tasks that drain: [YOUR_DRAINING_TASKS]
+- Tasks that energize: 0-to-1 product creation, ambiguous problem-solving, turning ML into product, product strategy, cross-functional leadership
+- Tasks that drain: pure maintenance / keep-the-lights-on work, rigid bureaucratic process, IC coding with no product ownership
 - Non-task factors: leadership style, department culture, company values, degree of autonomy
 
 **Life situation alignment:** Consider personal constraints:
-- **Security**: [YOUR_FINANCIAL_SITUATION_CONTEXT]
-- **Flexibility**: [YOUR_SCHEDULE_CONSTRAINTS]
-- **Professional development**: [YOUR_GROWTH_PRIORITIES]
+- **Security**: Currently employed (Director of Product, Chimes AI); moving selectively, not out of urgency
+- **Flexibility**: Values remote / hybrid flexibility and autonomy over location
+- **Professional development**: Wants growth toward broader product leadership and AI product strategy
 
 ### 6. Salary Benchmark (Optional)
 

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -4,6 +4,19 @@ framework_version: 1.0.0
 
 # CV Templates and Tailoring Guide
 
+<!-- BEGIN ACTIVE-TEMPLATE (managed by /add-template - do not edit by hand) -->
+> **Active template override: `medium-length-professional-cv`**
+>
+> A custom template is active. Where this block conflicts with the stock guidance below, this block wins. Structural advice below (tailoring, page-budget, cutting rules) still applies.
+>
+> - **Template skeleton:** `templates/cv/medium-length-professional-cv/template.tex` — use this as the structural reference instead of the stock template
+> - **Manifest:** `templates/cv/medium-length-professional-cv/TEMPLATE.md` — read this for style rules and known pitfalls before drafting
+> - **Compile with:** `pdflatex` (not `lualatex` as named in the stock guidance below)
+> - **Fonts:** EB Garamond (system font via the `ebgaramond` package — standard in TeX Live, no bundled files needed)
+> - **Page limit:** exactly 2 page(s)
+> - **Output file:** unchanged (`cv/main_<company>.tex`); copy `templates/cv/medium-length-professional-cv/resume.cls` into the same directory
+<!-- END ACTIVE-TEMPLATE -->
+
 <!-- SETUP: Profile statements and section ordering are personalized by running /setup -->
 
 ## Template: LaTeX moderncv (Banking Style)
@@ -110,11 +123,14 @@ Write 5-7 lines that function as an "elevator pitch": a concise, compelling intr
 **Create 2-3 profile statement templates for your main role types:**
 
 <!-- SETUP: These are populated based on your background -->
-**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+**For Product Manager / Product Leadership (AI) roles:**
+> Product leader with 9 years of data-driven experience: 3 years as Director of Product, 2 as Product Manager, and 4 in data-analytics consulting. I build products in ambiguous, 0-to-1 environments. I led a no-code AI/MLOps platform (Tukey) from concept to commercialization, now adopted by leading petrochemical, steel, semiconductor, and automotive manufacturers, growing the customer base from 20+ to 80+ accounts and company revenue more than 3x. I pair product strategy and cross-functional leadership with a hands-on background in ML and data analysis.
 
-**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+**For AI / ML Product Manager roles:**
+> AI/ML product manager who turns machine learning into shipped, maintained products. I built a no-code AI platform that let non-technical factory staff create and operate ML models, cutting industrial AI deployment from a 3-year custom-project cycle to 3 months across 50+ factories and 2,500+ models. Comfortable across the model lifecycle, MLOps, and MCP tool interfaces, with a data-analysis and statistics foundation.
+
+**For Technical PM / Solutions roles:**
+> Technical product manager bridging engineering, AI/ML, and business stakeholders. I define strategy and roadmaps, run delivery with SCRUM, and have deployed anomaly-detection, quality-prediction, and energy-optimization solutions into live petrochemical, steel, and semiconductor plants with measurable ROI (e.g. +25% equipment utilization, -32% batch energy). Hands-on with Python/R, data pipelines, and dashboards.
 
 ### Core Competencies / Skills Section (Best Practice)
 Reorder and emphasize based on the role. Use bold category labels.

--- a/.claude/skills/job-application-assistant/07-interview-prep.md
+++ b/.claude/skills/job-application-assistant/07-interview-prep.md
@@ -14,23 +14,58 @@ Keep answers to 1-2 minutes. Be specific. End with what you learned or would do 
 
 ## Ready-Made STAR Examples
 
-<!-- These are populated by /setup from your actual experience. Below are templates showing the format. -->
+<!-- These are populated by /setup from your actual experience. Templates 6-8 show the format for further additions. -->
 
-### 1. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
+### 1. Tukey No-Code AI 平台創立 (0-to-1 產品策略 / Vision)
+**S:** 過去團隊以資料分析專長協助企業導入 AI，但發現高達八成的資料科學專案在結案後就停擺——工廠環境與機台會變化，ML 模型上線後若無人維護，準確度就會衰退。
+**T:** 找出讓 AI 模型在工廠現場能長期被正確維運的方法，而不是做一次性的顧問專案。
+**A:** 判斷「最懂現場的人才最適合維運模型」，因此主導打造 No-Code AI 建模與維運平台 Tukey，讓不懂寫程式的第一線廠務、製程工程師能自行建立並長期維運 AI；平台以 IoT 數據建立機台健康時的「行為輪廓」，數據偏移即提前預警並指出可能原因。
+**R:** 台塑等石化、鋼鐵大廠導入後大幅縮短維修時間、避免檢修人力浪費；平台可讓製造業在 3 個月內快速將 AI 導入數十間工廠。
+**Use for:** "0-to-1 product experience", "product vision", "why manufacturing AI", "biggest product you've built"
+
+### 2. 從平台走向場景化產品線 (產品策略 / 市場定位)
+**S:** 水平型平台式產品在銷售時，客戶常常不清楚這個產品到底能解決什麼問題，銷售週期長達 5-6 個月。
+**T:** 重新定位產品，讓銷售團隊與經銷商能更快、更精準地鎖定客戶需求。
+**A:** 歸納製造業常見的應用場景（設備異常偵測、產品品質預測、生產參數最佳化），把場景常用的演算法與工具整理成獨立產品線。
+**R:** 銷售週期從 5-6 個月縮短至 3 個月。
+**Use for:** "product positioning", "go-to-market strategy", "data-driven decision", "product segmentation"
+
+### 3. AI-first 轉型：把產品改成 MCP (策略調整 / 對新技術的應變)
+**S:** Gen AI 問世後，我們判斷下一代的產品使用者將是透過自然語言呼叫工具的 AI，而非人類直接操作介面。
+**T:** 讓 Tukey 能被 AI 模型調用，同時確保 AI 建置出來的應用符合公司的技術棧與設計規範。
+**A:** 主導把 Tukey 產品介面改為 MCP，供 AI 模型調用；制定公司 Design system 與 AI 開發指引；並強化資料重力——記錄資料清理歷程、模型漂移後的再訓練歷程，累積特定領域的特徵變數等隱性知識。
+**R:** 原廠與經銷商的專案導入人員能用 AI 加速 Tukey 模型與應用建置，導入時間從 3 個月縮短至 1 個月。
+**Use for:** "adapting to new technology", "strategic pivot", "AI product strategy", "staying ahead of market shifts"
+
+### 4. 即時通知機制：Polling 到 WebSocket (技術取捨)
+**S:** 模型建置完成後需要通知使用者，初期產品使用人數少，選用開發成本最低的 polling 機制，但無法即時通知。
+**T:** 隨著使用人數成長，加上新增「自動建模」可同時建立多個模型的功能，需要提升通知即時性與使用者體驗。
+**A:** 評估開發成本與使用者規模的取捨後，將通知機制改為 WebSocket，模型一建置完成就即時推播通知。
+**R:** 使用者能立即得知多個模型的建置狀態，體驗大幅提升，不必再手動重整或等待輪詢。
+**Use for:** "technical trade-off decisions", "engineering vs UX priorities", "scaling a feature"
+
+### 5. 繪圖效能瓶頸：Scatter Plot 到蜂巢圖 (技術/設計取捨)
+**S:** 客戶廠區的電腦設備老舊，資料探索功能中的散布圖在資料筆數過多時會持續轉圈、無法繪出。
+**T:** 在不更換客戶硬體的前提下，讓使用者仍能透過圖表理解資料分佈。
+**A:** 釐清圖表的目的是呈現資料分佈、而非呈現每一個資料點，因此改用蜂巢圖（hexbin），以顏色深淺表示點的密集程度，取代逐點繪製。
+**R:** 圖表得以在低階設備上順暢渲染，同時保留使用者理解資料分佈所需的資訊。
+**Use for:** "performance vs functionality trade-off", "design thinking under constraints", "solving for the underlying user need"
+
+### 6. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
 **S:** [CONTEXT - what was happening, what was the problem]
 **T:** [YOUR RESPONSIBILITY - what you specifically needed to do]
 **A:** [WHAT YOU DID - specific actions, tools, methods]
 **R:** [OUTCOME - measurable results, adoption, impact]
 **Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
 
-### 2. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
+### 7. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
 **S:** [CONTEXT]
 **T:** [YOUR RESPONSIBILITY]
 **A:** [WHAT YOU DID]
 **R:** [OUTCOME]
 **Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
 
-### 3. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
+### 8. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
 **S:** [CONTEXT]
 **T:** [YOUR RESPONSIBILITY]
 **A:** [WHAT YOU DID]
@@ -38,6 +73,116 @@ Keep answers to 1-2 minutes. Be specific. End with what you learned or would do 
 **Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
 
 <!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
+
+## STAR Candidates (Complete Manually)
+
+These achievements are not yet covered by a full STAR example above. Fill in Situation/Task/Action/Result before using them in interviews.
+
+### DSP - Domestic-violence risk-prediction model
+**Source:** CV / LinkedIn - Data Analyst, DSP (2017-2021)
+**What happened:** Integrated case histories across 11 cross-agency departments to build a risk model that triaged incoming cases; reduced domestic-violence recidivism by 30%.
+**Why it matters:** analytics-for-social-impact, cross-stakeholder integration, model deployed into a real workflow; answers "data project with real-world impact", "working across many stakeholders"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### DSP - Design-thinking workshops converting to clients
+**Source:** CV / LinkedIn - Data Analyst, DSP (2017-2021)
+**What happened:** Hosted 20+ design-thinking data workshops across petrochemical, automotive, banking, and government sectors; 70%+ of participants became paying clients.
+**Why it matters:** client-facing, business development, facilitation; answers "influencing without authority", "driving revenue", "stakeholder communication"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Chimes AI - China Steel Chemical energy optimization
+**Source:** CV - Director of Product, Chimes AI
+**What happened:** Deployed an energy-optimization module for an electric-boiler drying process, cutting per-batch energy ~32% and ~200 tons/yr CO2.
+**Why it matters:** measurable ESG/business impact, technical delivery; answers "biggest impact", "sustainability", "delivering ROI"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Chimes AI - Point-to-point to platform transformation
+**Source:** CV / LinkedIn - Product Manager, Chimes AI (2021-2022)
+**What happened:** Transformed delivery from custom point-to-point projects (5 eng / 3 yr / 40 projects) to platform-based deployment (15 eng / 3 mo / 400+ models).
+**Why it matters:** scaling, operating-model change, platformization; answers "improving a process", "scaling a team/product", "0-to-1 to 1-to-n"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+## Product Deep-Dive Case Study
+
+<!-- For "walk me through a product you worked on" style questions - a full business/product/tech/design discussion of one real product, distinct from the STAR-format answers above. -->
+
+### Q: 針對你過去實際參與的一個產品展開全面性討論，包含但不限於商業、產品、技術、設計等面向。
+**Use for:** deep-dive / case-study rounds, senior PM technical rounds, "walk me through a product you built" prompts
+
+**Product:** Tukey - No-Code AI 建模與維運平台 (Chimes AI)
+
+#### 產品發展階段
+
+##### 2021 - 2023：水平型平台式產品
+
+**創辦動機**
+
+創始團隊過去長期以資料分析專長協助企業導入 AI。但是我們發現，多數企業花大錢做的資料科學專案，高達八成在專案結束後就停擺。原因是工廠環境會變、機台會老化，ML 模型一旦上線，如果沒有持續維護，準確度就會衰退。
+
+我們認為：要維運 ML 模型，一定要了解現場實務，因此維運的工作最適合交給製造業中那些最懂現場的人。因此決定打造一個 No-Code（無程式碼）的 AI 建模與維運平台——Tukey，讓不懂寫程式的第一線廠務、製程工程師，都能用友善的介面，自行建立並長期維運 AI。
+
+**市場痛點**
+- 現場專家不懂程式，AI 工程師不懂現場：IT 部門或外部顧問不懂工廠上千種管線與機台的運作邏輯（Domain Knowledge），做出來的模型不切實際；而最懂現場的資深黑手、製程工程師卻不會寫 Python。
+- 設備異常代價高昂：石化、鋼鐵或半導體等大廠，只要一條生產線無預警停機，造成的產能缺口與維修成本動輒百萬、千萬起跳。
+- ESG 與減碳壓力：高耗能產業面臨巨大的碳排與節能壓力，傳統經驗法則已無法榨出更多節能空間。
+
+**商業動機**
+- 極低門檻取代高額人事成本：企業訂閱 Tukey 平台的費用，遠低於聘請一整個 AI 團隊。平台能讓製造業在 3 個月內快速將 AI 導入數十間工廠。
+- 資產管控與設備預警：系統以 IoT 數據為基礎，建立機台健康時的「行為輪廓」。只要運作數據稍微偏移，AI 就會提前預警並指出可能原因。例如：台塑等石化、鋼鐵大廠導入後，能大幅縮短維修時間、避免檢修人力浪費。
+
+##### 2024 - 2025：特定應用場景的解決方案
+
+**決策依據**
+
+經過前幾年與市場的互動，我們發現在銷售的時候，若是以水平型平台式產品呈現，通常客戶還是不知道這個產品可以解決什麼問題。於是我們歸納出幾個製造業常見的應用場景（設備異常偵測、產品品質預測、生產參數最佳化），並且把這些場景常用到的演算法或工具，整理成不同的產品線。
+
+**成果**
+
+這樣的調整可以幫助銷售團隊與經銷商更快速、精準地鎖定客戶的需求。銷售週期從 5-6 個月，縮短至 3 個月。
+
+##### 2026：AI-first 產品
+
+**決策依據**
+
+在 Gen AI 問世後，軟體業受到極大的挑戰。我們體認到下一個世代的使用方式會是人類使用者透過自然語言請 AI 調用 Tukey 產品，打造並維運 ML 應用。因此 AI 才是未來產品真正的使用者。
+
+對此，產品團隊快速進行調整。我們把 Tukey 產品改成 MCP，讓 AI 模型調用。制定公司的 Design system 和 AI 開發指引，讓 AI 開發出來的應用都使用指定的技術棧、符合設計規範。
+
+另外，我們也在資料重力上著墨更多，像是提供更詳細的資料清理歷程記錄功能、模型漂移後的模型再訓練歷程記錄，累積特定領域使用的模型使用的特徵變數，把這些隱性知識記下來，可以讓模型更好用，提升客戶黏著度。
+
+**成果**
+
+Tukey 產品改成 MCP 後，原廠和經銷商的專案導入人員可以使用 AI 加速 Tukey 模型與應用的建置，讓導入時間從原本的 3 個月縮短至 1 個月。
+
+#### 技術取捨
+
+##### 場景：模型建置完成通知的實作機制
+
+Phase 1 先求有這個功能，而且產品使用人數也沒有很多，因此選用開發上最輕量的 polling 機制，但他的壞處就是沒有辦法即時通知。
+
+後來隨著產品使用人數增加，再加上支援「自動建模」同時建立多個模型的功能之後，我們就改用 WebSocket，一完成就通知，提升使用者體驗。
+
+##### 場景：繪圖效能瓶頸
+
+客戶廠區裡的電腦非常老舊，螢幕是正方形的那種。Tukey 產品裡面有個資料探索功能，可以對不同欄位繪製圖表。其中散布圖 scatter plot 在資料筆數太多的時候，會一直轉不出來。
+
+圖表的功能是為了讓 User 了解資料的分佈，因此不需要全部把所有的點都畫出來，我們最後採用了蜂巢圖來呈現，顏色越深的格子表示點點分佈越多。
 
 ## Common Tough Questions
 

--- a/.claude/skills/job-application-assistant/SKILL.md
+++ b/.claude/skills/job-application-assistant/SKILL.md
@@ -55,7 +55,7 @@ When the user provides a job posting (URL or text), follow this workflow:
 | `04-job-evaluation.md` | Scoring framework for job fit |
 | `05-cv-templates.md` | LaTeX CV structure and tailoring rules |
 | `06-cover-letter-templates.md` | LaTeX cover letter structure and tailoring rules |
-| `07-interview-prep.md` | STAR examples, tough questions, roleplay guidelines |
+| `07-interview-prep.md` | STAR examples, product deep-dive case study, tough questions, roleplay guidelines |
 
 ---
 

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -8,68 +8,75 @@
 
 The `site:` query templates in this file are the **WebSearch fallback** — for portals without a CLI, company career pages, or when a CLI fails.
 
+**Taiwan portals not yet scaffolded:** 104, Cake (CakeResume), and Yourator have no shipped CLI. They run via the `site:` fallback below; scaffold dedicated skills with `/add-portal` when you want first-class scraping.
+
 ## Search Sites
 
-Primary (your market's job boards - scaffold one with `/add-portal`):
-- **[YOUR_JOB_BOARD]** - your market's largest general job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY]); also covered by `linkedin-search` CLI
-- **[YOUR_INDUSTRY_JOB_BOARD]** - a niche/industry board for your field (optional)
-- **[YOUR_ADDITIONAL_JOB_BOARD]** - another major board for your market (optional)
+Primary (your market's job boards):
+- **104.com.tw** - Taiwan's largest general job board (scaffold with `/add-portal`)
+- **cake.me** - Cake (CakeResume) - tech / startup roles in Taiwan and remote
+- **yourator.co** - Yourator - startup / tech job board in Taiwan
+- **linkedin.com/jobs** - LinkedIn job listings (filter: Taiwan / Remote); also covered by `linkedin-search` CLI
 
 Secondary (company career pages via Google):
 - Direct Google searches with `site:` filters for known target companies
 
 ## Query Categories
 
-Queries are grouped by priority. Each query should be combined with your location terms (e.g. your city, region, or metro area) where the site supports it.
+Queries are grouped by priority. Emphasis is on **remote / hybrid** roles (location-flexible), with Greater Taipei acceptable for on-site.
 
-### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+### Priority 1: Product Management (PM / Senior PM / AI PM)
 
 These match your strongest and most desired career direction.
 
 ```
-site:[YOUR_JOB_BOARD] "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
+site:104.com.tw "Product Manager" AI remote
+site:cake.me "Product Manager" AI
+site:yourator.co "產品經理" AI
+site:linkedin.com/jobs "Senior Product Manager" (Taiwan OR Remote)
+site:linkedin.com/jobs "AI Product Manager" remote
 ```
 
-### Priority 2: [YOUR_DOMAIN_EXPERTISE]
+### Priority 2: AI / ML Product & Industrial AI (domain)
 
 These match your domain expertise.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+site:104.com.tw ("AI 產品" OR "MLOps" OR "no-code AI") remote
+site:cake.me ("ML Product Manager" OR "AI platform") 
+site:linkedin.com/jobs ("machine learning product" OR "industrial AI") (Taiwan OR Remote)
+site:linkedin.com/jobs "MLOps product" remote
 ```
 
-### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
+### Priority 3: Head of Product / Director & Technical PM / Solutions
 
-Adjacent roles you could pivot into.
-
-```
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
-```
-
-### Priority 4: Broader Technical / Consulting
-
-Wider net for general technical roles.
+Adjacent roles (leadership up, or technical/solutions sideways).
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_KEY_SKILL] developer [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+site:linkedin.com/jobs ("Head of Product" OR "Director of Product") (Taiwan OR Remote)
+site:cake.me ("Head of Product" OR "產品總監")
+site:104.com.tw "Technical Product Manager" remote
+site:linkedin.com/jobs "Solutions Consultant" AI remote
+```
+
+### Priority 4: Broader Product / Data Product
+
+Wider net for general product and data-product roles.
+
+```
+site:104.com.tw ("data product" OR "product-led growth") remote
+site:linkedin.com/jobs "product manager" (SaaS OR platform) remote
+site:cake.me "product manager" data
 ```
 
 ## Location Filter
 
-When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
-- [YOUR_CITY] and surrounding areas
-- [ACCEPTABLE_AREA_1]
-- [ACCEPTABLE_AREA_2]
-- [BORDERLINE_AREA] (borderline - ~X min by transit)
-- [TOO_FAR_AREA] (too far)
+Preferred mode is **remote / hybrid** (location-flexible). For on-site roles, verify the location is within reasonable commute distance from Taipei:
+- Remote / hybrid (anywhere): preferred
+- Taipei City: ideal for on-site
+- New Taipei City (Greater Taipei): acceptable
+- Taoyuan / Hsinchu: borderline (long commute; prefer hybrid)
+- Outside northern Taiwan with no remote option: too far (unless relocation is offered)
 
 ## Date Filter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,7 @@
-# Job Application Assistant for [YOUR_NAME]
-
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
+# Job Application Assistant for Cheng-En Li
 
 ## Role
-This repo is a job application workspace. Claude acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+This repo is a job application workspace. Claude acts as a career advisor and application assistant for Cheng-En Li, helping with:
 1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
 2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
 3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
@@ -13,68 +10,71 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 
 ## Candidate Profile
 
-<!-- This section is auto-populated by /setup. You can also fill it in manually. -->
-
 ### Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
-- **Languages:** [YOUR_LANGUAGES]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+- **Name:** Cheng-En Li
+- **Location:** Taipei, Taiwan (open to remote / hybrid, location-flexible)
+- **Languages:** Mandarin (native), English (intermediate / conversational)
+- **Status:** Employed (Director of Product, Chimes AI), open to work
+- **LinkedIn headline:** "Director of Product | No-code AI Platform | 0-to-1 Product & Team Building | Data-Driven PM | Turning ML into Scaled Industrial Impact"
 
 ### Education
-<!-- List your degrees, most recent first -->
-- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
-  - Thesis: "[THESIS_TITLE]"
-  - Topics: [KEY_TOPICS]
+- **B.A. in Materials Science and Engineering** (2007-2011) - National Tsing Hua University, Hsinchu, Taiwan
 
 ### Professional Experience
-<!-- List your roles, most recent first -->
-- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
-  - [KEY_RESPONSIBILITY_1]
-  - [KEY_RESPONSIBILITY_2]
-  - [KEY_ACHIEVEMENT]
+- **Director of Product** (2023 - Present) - **Chimes AI** (Taipei, Taiwan)
+  - Lead a 7-person cross-functional team, reporting to the CEO; own strategy and roadmap for three core product lines
+  - Grew customers 20+ to 80+ accounts and company revenue >3x; won the first flagship client contract exceeding NT$10M
+  - Drove deployment across 50+ factories and 2,500+ AI models, contributing ~40,000 tons/yr CO2 reduction
+  - Leading a Ministry of Health and Welfare social-affairs data-standardization initiative (13 systems) and authoring an HL7 FHIR Base Implementation Guide
+- **Product Manager** (2021 - 2022) - **Chimes AI** (Taipei, Taiwan)
+  - Built the Tukey no-code AI platform, shifting delivery from point-to-point projects (5 eng / 3 yr / 40 projects) to platform deployment (15 eng / 3 mo / 400+ models)
+  - Deployed equipment anomaly detection at a Formosa Plastics Group plant at 90% diagnostic accuracy
+- **Data Analyst** (2017 - 2021) - **DSP** (Taipei, Taiwan)
+  - Built a cross-agency domestic-violence risk-prediction model, reducing recidivism by 30%
+  - Hosted 20+ design-thinking data workshops; 70%+ of participants converted to paying clients
+- **Magazine Editor** (2013 - 2017) - **Yuan-Liou Publishing** (Taipei, Taiwan)
 
 ### Technical Skills
-- **Primary:** [YOUR_PRIMARY_SKILLS]
-- **Secondary:** [YOUR_SECONDARY_SKILLS]
-- **Domain:** [YOUR_DOMAIN_EXPERTISE]
-- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+- **Primary:** Product management (0-to-1 strategy, roadmap, product-led growth), no-code AI / MLOps platform product, cross-functional and stakeholder leadership
+- **Secondary:** Python, R / R Shiny, SQL, Machine Learning, LLM / GenAI, Data Analysis, Data Visualization, Statistics
+- **Domain:** Industrial / manufacturing AI (petrochemical, steel, semiconductor, automotive), data-driven consulting, HL7 FHIR / social-affairs data interoperability, AI-first product design (MCP)
+- **Software:** Figma, Whimsical, Notion, WordPress, Git, Docker, Jenkins
 
 ### Certifications
-<!-- List relevant certifications with dates -->
-- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+- **Generative AI with Large Language Models** - Coursera - completed Sep 2023
+- **edX SU22: Introduction to Analytics Modeling** - edX - completed Jul 2022
+- **edX SP22: Data Analytics for Business** - edX - completed Apr 2022
 
 ### Publications
-<!-- List peer-reviewed publications, if any -->
-- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+- 〈AI 社工可行嗎?運用社會安全資料驅動社福變革管理〉- 2020 Social Welfare Forum (https://bit.ly/3n9DFiT)
+- Medium essays on product-led growth, Stripe, and Apache Spark / Databricks (https://hello-lichengen.medium.com/)
 
 ### Awards
-<!-- List relevant awards, hackathons, competitions -->
-- [AWARD_NAME] - [EVENT] ([YEAR])
+- First Prize - 經濟部工業局 "110 年度輔導創新資料服務構想商業化" competition (2021)
+- 40th Golden Tripod Award, Children & Youth Category - *Science Monthly* / Yuan-Liou Publishing
 
 ### Behavioral Profile
-<!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
-- **[TRAIT_1]** - [DESCRIPTION]
-- **[TRAIT_2]** - [DESCRIPTION]
-- **Strengths:** [YOUR_STRENGTHS]
-- **Growth areas:** [YOUR_GROWTH_AREAS]
-- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+- **Ambiguity-to-structure** - Turns ambiguous problems into requirements and solution plans
+- **End-to-end ownership** - Builds ML products from concept to commercialization
+- **Cross-disciplinary integrator** - Bridges chemical engineering, editorial, and data science to deliver AI products
+- **Strengths:** 0-to-1 product strategy, stakeholder communication, platformization (one-off delivery to scalable products)
+- **Growth areas:** Deep production software engineering; formal CS credentials
+- **Thrives in:** Ambiguous, 0-to-1 environments with fluid process and creative problem-solving
 
 ### What Excites You
-<!-- What motivates you professionally -->
-- [PASSION_1]
-- [PASSION_2]
+- Building AI/ML products from 0 to 1 and turning machine learning into scaled, maintained impact
+- Ambiguous problems with real industrial or societal stakes; cross-functional product leadership
 
 ### Target Sectors
-<!-- Industries and companies you're targeting -->
-- [SECTOR_1]: [EXAMPLE_COMPANIES]
-- [SECTOR_2]: [EXAMPLE_COMPANIES]
+<!-- Edit these as your targets sharpen -->
+- Industrial / manufacturing AI (petrochemical, steel, semiconductor, automotive): industrial-AI and MLOps vendors
+- AI/ML product companies & no-code / MLOps platforms: LLM / GenAI product startups, MLOps platform vendors
+- Healthcare / govtech data platforms: health-data interoperability (HL7 FHIR) vendors
 
 ### Deal-breakers
-<!-- Hard constraints on job search -->
-- [DEALBREAKER_1]
-- [DEALBREAKER_2]
+<!-- Reasonable defaults inferred from your constraints; edit as needed -->
+- On-site-only role far from Greater Taipei with no remote / hybrid option (unless relocation is offered and worthwhile)
+- Pure maintenance work with no product ownership, or a rigid, low-autonomy environment
 
 ## Repo Structure
 - `cv/` - LaTeX CV variants (moderncv template, banking style)

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -1,8 +1,7 @@
-%% Example CV - [YOUR_NAME]
+%% Example CV - Cheng-En Li
 %% Comprehensive overview of all competencies, experience, and achievements.
 %% Use as a master reference when tailoring role-specific CVs.
 %%
-%% SETUP: Run /setup to populate this with your actual information.
 %% Compile with: lualatex main_example.tex
 %% (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors.)
 
@@ -24,18 +23,17 @@
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Cheng-En Li - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.80]{geometry}
-\usepackage{import}
 
 % personal data
-\name{[First]}{[Last]}
-\address{[Your Address, City, Country]}{}{}
-\phone[mobile]{[+XX XXXXXXXXXX]}
-\email{[your.email@example.com]}
-\extrainfo{\href{[https://linkedin.com/in/your-profile]}{LinkedIn}, \href{[https://github.com/your-username]}{GitHub}}
+\name{Cheng-En}{Li}
+\address{Taipei, Taiwan}{}{}
+\phone[mobile]{0928-516-521}
+\email{hello.lichengen@gmail.com}
+\extrainfo{\href{https://www.linkedin.com/in/cheng-en-li/}{LinkedIn}, \href{https://github.com/nondayo}{GitHub}, \href{https://hello-lichengen.medium.com/}{Blog}}
 
 \begin{document}
 
@@ -46,7 +44,7 @@
 % ============================================================
 
 \vspace{6pt}
-\small{[Write a 3-5 line profile statement tailored to the role you're applying for. Focus on what makes you uniquely qualified. Example: "Data scientist with a PhD in [field] and X years of industry experience. Combines deep domain expertise in [domain] with strong applied machine learning and Python development skills. Experienced in developing end-to-end ML pipelines, from data ingestion to stakeholder-facing dashboards."]}
+\small{Product leader with 9 years of data-driven experience: 3 years as Director of Product, 2 as Product Manager, and 4 in data-analytics consulting. I build products in ambiguous, 0-to-1 environments. I led a no-code AI/MLOps platform (Tukey) from concept to commercialization, now adopted by leading petrochemical, steel, semiconductor, and automotive manufacturers, growing the customer base from 20+ to 80+ accounts and company revenue more than 3x. I pair product strategy and cross-functional leadership with a hands-on background in ML and data analysis.}
 
 % ============================================================
 %     CORE COMPETENCIES
@@ -56,15 +54,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item \textbf{[Skill Category 1]}: [Specific skills, frameworks, tools. Be concrete.]
+\item \textbf{Product Management}: 0-to-1 product strategy, roadmap ownership, product-led growth, go-to-market, SCRUM/Agile, product-lifecycle governance.
 
-\item \textbf{[Skill Category 2]}: [Specific skills, frameworks, tools.]
+\item \textbf{AI / ML Product}: no-code AI and MLOps platforms, model lifecycle and drift management, MCP tool interfaces, industrial AI (anomaly detection, quality prediction, energy optimization).
 
-\item \textbf{[Skill Category 3]}: [Specific skills, frameworks, tools.]
+\item \textbf{Leadership}: cross-functional team leadership (PM, engineering, AI/ML, design), stakeholder management across technical and business audiences, reporting to C-level.
 
-\item \textbf{[Skill Category 4]}: [Domain expertise, methods, approaches.]
+\item \textbf{Data \& Analytics}: Python, R / R Shiny, SQL, statistics, data visualization; end-to-end analytics from data inventory to stakeholder-facing dashboards.
 
-\item \textbf{[Skill Category 5]}: [Tools, platforms, software.]
+\item \textbf{Domain}: manufacturing / petrochemical / steel / semiconductor AI, data-driven consulting, HL7 FHIR / social-affairs data interoperability.
 
 \end{itemize}
 
@@ -76,32 +74,42 @@
 \vspace{3pt}
 \begin{itemize}
 
-% --- Most Recent Role ---
-\item{\cventry{[YYYY--Present]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+% --- Director of Product ---
+\item{\cventry{2023--Present}{Director of Product}{Chimes AI}{Taipei, Taiwan}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1 - be specific, use numbers where possible]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
-    \item [Achievement or responsibility 4]
+    \item Lead a 7-person cross-functional team (1 PM, 3 Engineers, 2 AI/ML Engineers, 1 Designer), reporting to the CEO; own strategy and roadmap for three core product lines.
+    \item Launched a new product line by commercializing and standardizing AI algorithms/services, expanding into new verticals and winning the first flagship client contract exceeding NT\$10M.
+    \item Grew customers from 20+ to 80+ accounts; drove company annual revenue growth of more than 3x during tenure.
+    \item Drove deployment across 50+ factories and 2,500+ AI models, contributing \textasciitilde40,000 tons of annual CO2 reduction; e.g. CPC Taoyuan Refinery (+25\% equipment utilization) and China Steel Chemical (-32\% per-batch energy).
+    \item Leading a Ministry of Health and Welfare social-affairs data-standardization initiative (13 systems) and authoring a Taiwan HL7 FHIR Base Implementation Guide.
 \end{itemize}}}
 
 \vspace{3pt}
 
-% --- Previous Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+% --- Product Manager ---
+\item{\cventry{2021--2022}{Product Manager}{Chimes AI}{Taipei, Taiwan}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
+    \item Built the Tukey no-code AI platform, shifting customer data-science delivery from a point-to-point model (5 engineers / 3 years / 40 projects) to platform-based deployment (15 engineers / 3 months / 400+ models).
+    \item Deployed an equipment anomaly detection module at a Formosa Plastics Group plant at 90\% diagnostic accuracy, validating human-AI collaboration.
+    \item Initiated SCRUM and issue-tracking practices; drove company annual revenue growth of nearly 4x during tenure.
 \end{itemize}}}
 
 \vspace{3pt}
 
-% --- Earlier Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+% --- Data Analyst ---
+\item{\cventry{2017--2021}{Data Analyst}{DSP}{Taipei, Taiwan}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
+    \item Integrated case histories across 11 cross-agency departments to build a domestic-violence risk-prediction model and dashboard, reducing recidivism by 30\%.
+    \item Built a customized dyeing algorithm for a textile client, improving new-formulation success rate by 5\%.
+    \item Hosted 20+ design-thinking data workshops across petrochemical, automotive, banking, and government sectors; 70\%+ of participants became paying clients.
+\end{itemize}}}
+
+\vspace{3pt}
+
+% --- Magazine Editor ---
+\item{\cventry{2013--2017}{Magazine Editor}{Yuan-Liou Publishing}{Taipei, Taiwan}{}{\vspace{1pt}
+\begin{itemize}
+    \item Planned each issue's themes, article types, and special features; reviewed and edited submissions for style and quality.
 \end{itemize}}}
 
 \end{itemize}
@@ -114,15 +122,7 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-Thesis: ``[Thesis Title].'' [Brief description of research focus.]
-}}
-
-\vspace{3pt}
-
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-[Brief description or key topics.]
-}}
+\item{\cventry{2007--2011}{B.A. in Materials Science and Engineering}{National Tsing Hua University}{Hsinchu, Taiwan}{}{}}
 
 \end{itemize}
 
@@ -133,27 +133,29 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Languages}
 \vspace{1pt}
 \begin{itemize}
-\item [Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).
+\item Mandarin (native), English (intermediate / conversational).
 \end{itemize}
 
 % ============================================================
-%     PUBLICATIONS (optional)
+%     PUBLICATIONS
 % ============================================================
 
 \section{Publications}
 \vspace{1pt}
 \begin{itemize}
-\item [Author(s)] ([Year]). [Title]. [Journal/Conference]. \href{[DOI_URL]}{DOI link}
+\item ``Is AI Social Work Feasible? Using Social Safety Data to Drive Social Welfare Transformation Management'' -- 2020 Social Welfare Forum. \href{https://bit.ly/3n9DFiT}{link}
+\item Product essays on product-led growth, Stripe, and Apache Spark / Databricks. \href{https://hello-lichengen.medium.com/}{Medium}
 \end{itemize}
 
 % ============================================================
-%     HONORS AND AWARDS (optional)
+%     HONORS AND AWARDS
 % ============================================================
 
 \section{Honors and Awards}
 \vspace{1pt}
 \begin{itemize}
-\item{\textbf{[Award Name]} -- [Event/Organization] ([Year]).}
+\item{\textbf{First Prize} -- ``2021 Innovative Data Service Concept Commercialization Program,'' Industrial Development Bureau, Ministry of Economic Affairs (2021).}
+\item{\textbf{40th Golden Tripod Award} -- Children \& Youth Category, \textit{Science Monthly} / Yuan-Liou Publishing.}
 \end{itemize}
 
 % ============================================================

--- a/templates/cv/cies-cv/TEMPLATE.md
+++ b/templates/cv/cies-cv/TEMPLATE.md
@@ -1,0 +1,30 @@
+# Template: cies-cv
+
+- **Type:** CV
+- **Engine:** pdflatex
+- **Page limit:** 2 page(s)
+- **Fonts:** TeX Gyre Pagella (system font via the `tgpagella` package - standard in TeX Live, no bundled files needed)
+- **Class/packages:** `article` base class + `structure.tex` (bundled); requires `geometry`, `multicol`, `mdwlist`, `relsize`, `hyperref`, `xcolor`, `tgpagella`, `fontenc`, `microtype`
+
+## Compile command
+
+    cd cv && pdflatex -interaction=nonstopmode main_<company>.tex
+
+(Copy `structure.tex` into the same directory as the filled-in `.tex` file - it's `\include`d by name.)
+
+## Style rules
+
+- Two-column `Summary` block right under the name/contact line - use this for a narrative paragraph (interests, achievements, trajectory) that doesn't fit as bullets elsewhere. Keep it to 2-4 sentences per column.
+- Content organized by **employer**, not by role: use one `\headedsection` per employer, with one `\headedsubsection` per position held there (supports showing progression within the same company without repeating the employer name).
+- Links and section markers render in dark blue (`dark-blue` color, defined in `structure.tex`); do not override this per-application.
+- No page numbers (`\pagestyle{empty}`).
+- `\acr{...}` renders text in a slightly reduced small-caps-like scale - use for acronyms (e.g. `\acr{API}`) to keep them from dominating the line.
+- Bullet separator between contact items is `\bull`, not literal `•` or `|`.
+- Source: https://www.latextemplates.com/template/cies-cv (original template by Cies Breijs, https://github.com/cies/resume, modified by Vel/LaTeXTemplates.com). Licensed CC BY-NC-SA 3.0 - noncommercial use only, keep attribution comments in the files.
+
+## Known pitfalls
+
+- `structure.tex` is pulled in with `\include`, which requires `structure.tex` to sit in the **same working directory** as the compiled `.tex` file (or on the include path) - copy it alongside every `main_<company>.tex` that uses this template.
+- `\headedsection{...}{...}{...}` and `\headedsubsection{...}{...}{...}` both take **exactly 3 arguments** - the third is the body content (usually one or more `\bodytext{}` blocks). Leaving it as an empty `{}` is fine (e.g. for education entries with no extra detail), but dropping the argument entirely unbalances the braces and produces a cascade of `Missing \endcsname inserted` errors that look unrelated to the real cause.
+- `relsize` prints a harmless `Font size 40.0pt is too large` warning when compiling the name/title line at this template's default sizing - cosmetic only, not a real error.
+- No explicit page-break protection (no `\needspace`/`\nopagebreak` guard beyond the built-in `\nopagebreak[4]` in each macro) - for long content, re-check for orphaned `\headedsection` titles near a page boundary and add manual `\clearpage`/`\vspace` if needed.

--- a/templates/cv/cies-cv/structure.tex
+++ b/templates/cv/cies-cv/structure.tex
@@ -1,0 +1,76 @@
+% Copyright (c) 2012 Cies Breijs
+%
+% The MIT License
+%
+% Permission is hereby granted, free of charge, to any person obtaining a copy
+% of this software and associated documentation files (the "Software"), to deal
+% in the Software without restriction, including without limitation the rights
+% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+% copies of the Software, and to permit persons to whom the Software is
+% furnished to do so, subject to the following conditions:
+%
+% The above copyright notice and this permission notice shall be included in
+% all copies or substantial portions of the Software.
+%
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+% SOFTWARE.
+
+%%% LOAD AND SETUP PACKAGES
+
+\usepackage[margin=0.75in]{geometry} % Adjusts the margins
+
+\usepackage{multicol} % Required for multiple columns of text
+
+\usepackage{mdwlist} % Required to fine tune lists with a inline headings and indented content
+
+\usepackage{relsize} % Required for the \textscale command for custom small caps text
+
+\usepackage{hyperref} % Required for customizing links
+\usepackage{xcolor} % Required for specifying custom colors
+\definecolor{dark-blue}{rgb}{0.15,0.15,0.4} % Defines the dark blue color used for links
+\hypersetup{colorlinks,linkcolor={dark-blue},citecolor={dark-blue},urlcolor={dark-blue}} % Assigns the dark blue color to all links in the template
+
+\usepackage{tgpagella} % Use the TeX Gyre Pagella font throughout the document
+\usepackage[T1]{fontenc}
+\usepackage{microtype} % Slightly tweaks character and word spacings for better typography
+
+\pagestyle{empty} % Stop page numbering
+
+%----------------------------------------------------------------------------------------
+%	DEFINE STRUCTURAL COMMANDS
+%----------------------------------------------------------------------------------------
+
+\newenvironment{indentsection} % Defines the indentsection environment which indents text in sections titles
+{\begin{list}{}{\setlength{\leftmargin}{\newparindent}\setlength{\parsep}{0pt}\setlength{\parskip}{0pt}\setlength{\itemsep}{0pt}\setlength{\topsep}{0pt}}}{\end{list}}
+
+\newcommand*\maintitle[2]{\noindent{\LARGE \textbf{#1}}\ \ \ \emph{#2}\vspace{0.3em}} % Main title (name) with date of birth or subtitle
+
+\newcommand*\roottitle[1]{\subsection*{#1}\vspace{-0.3em}\nopagebreak[4]} % Top level sections in the template
+
+\newcommand{\headedsection}[3]{\nopagebreak[4]\begin{indentsection}\item[]\textscale{1.1}{#1}\hfill#2#3\end{indentsection}\nopagebreak[4]} % Section title used for a new employer
+
+\newcommand{\headedsubsection}[3]{\nopagebreak[4]\begin{indentsection}\item[]\textbf{#1}\hfill\emph{#2}#3\end{indentsection}\nopagebreak[4]} % Section title used for a new position
+
+\newcommand{\bodytext}[1]{\nopagebreak[4]\begin{indentsection}\item[]#1\end{indentsection}\pagebreak[2]} % Body text (indented)
+
+\newcommand{\inlineheadsection}[2]{\begin{basedescript}{\setlength{\leftmargin}{\doubleparindent}}\item[\hspace{\newparindent}\textbf{#1}]#2\end{basedescript}\vspace{-1.7em}} % Section title where body text starts immediately after the title
+
+\newcommand*\acr[1]{\textscale{.85}{#1}} % Custom acronyms command
+
+\newcommand*\bull{\ \ \raisebox{-0.365em}[-1em][-1em]{\textscale{4}{$\cdot$}} \ } % Custom bullet point for separating content
+
+\newlength{\newparindent} % It seems not to work when simply using \parindent...
+\addtolength{\newparindent}{\parindent}
+
+\newlength{\doubleparindent} % A double \parindent...
+\addtolength{\doubleparindent}{\parindent}
+
+\newcommand{\breakvspace}[1]{\pagebreak[2]\vspace{#1}\pagebreak[2]} % A custom vspace command with custom before and after spacing lengths
+\newcommand{\nobreakvspace}[1]{\nopagebreak[4]\vspace{#1}\nopagebreak[4]} % A custom vspace command with custom before and after spacing lengths that do not break the page
+
+\newcommand{\spacedhrule}[2]{\breakvspace{#1}\hrule\nobreakvspace{#2}} % Defines a horizontal line with some vertical space before and after it

--- a/templates/cv/cies-cv/template.tex
+++ b/templates/cv/cies-cv/template.tex
@@ -1,0 +1,124 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Cies Resume/CV
+% LaTeX Template
+% Version 1.1 (20/7/14)
+%
+% Downloaded from: https://www.latextemplates.com/template/cies-cv
+%
+% Original author:
+% Cies Breijs (cies@kde.nl)
+% https://github.com/cies/resume with extensive modifications by:
+% Vel (vel@latextemplates.com)
+%
+% License:
+% CC BY-NC-SA 3.0 (http://creativecommons.org/licenses/by-nc-sa/3.0/)
+%
+% Registered into this repo's /add-template framework with [PLACEHOLDER]
+% tokens in place of the original example content.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\documentclass[10pt,a4paper]{article}
+
+\include{structure} % Packages and layout macros
+
+\begin{document}
+
+%----------------------------------------------------------------------------------------
+%	NAME AND CONTACT INFORMATION
+%----------------------------------------------------------------------------------------
+
+\maintitle{[YOUR_NAME]}{[YOUR_TITLE_OR_SUBTITLE]}
+
+\noindent\href{mailto:[YOUR_EMAIL]}{[YOUR_EMAIL]}\bull
+[YOUR_PHONE]\bull
+\href{[YOUR_LINKEDIN_URL]}{LinkedIn}\\
+[YOUR_CITY], [YOUR_COUNTRY]
+
+\spacedhrule{0.9em}{-0.4em}
+
+%----------------------------------------------------------------------------------------
+%	SUMMARY SECTION
+%----------------------------------------------------------------------------------------
+
+\roottitle{Summary}
+
+\vspace{-1.3em}
+
+\begin{multicols}{2}
+\noindent [2-4 sentence professional summary tailored to the target role: years of experience, domain, and the single biggest differentiator.]
+
+[Optional second paragraph: notable achievements, scope of impact, or career trajectory that doesn't fit neatly into a bullet below.]
+\end{multicols}
+
+\spacedhrule{0.5em}{-0.4em}
+
+%----------------------------------------------------------------------------------------
+%	EXPERIENCE SECTION
+%----------------------------------------------------------------------------------------
+
+\roottitle{Experience}
+
+\headedsection
+{[Employer Name]}
+{\textsc{[City, Country]}} {
+
+\headedsubsection
+{[Job Title]}
+{[Mon 'YY -- Mon 'YY / present]}
+{\bodytext{[Achievement or responsibility - be specific, use numbers where possible.]}}
+
+\headedsubsection
+{[Earlier Job Title at Same Employer]}
+{[Mon 'YY -- Mon 'YY]}
+{\bodytext{[Achievement or responsibility.]}}
+}
+
+%------------------------------------------------
+
+\headedsection
+{[Earlier Employer Name]}
+{\textsc{[City, Country]}} {
+
+\headedsubsection
+{[Job Title]}
+{[Mon 'YY -- Mon 'YY]}
+{\bodytext{[Achievement or responsibility.]}}
+}
+
+\spacedhrule{-0.2em}{-0.4em}
+
+%----------------------------------------------------------------------------------------
+%	EDUCATION SECTION
+%----------------------------------------------------------------------------------------
+
+\roottitle{Education}
+
+\headedsection
+{[Institution Name]}
+{\textsc{[City, Country]}} {
+
+\headedsubsection
+{[Degree] in [Field]}
+{[YYYY -- YYYY]}
+{\bodytext{[Optional: thesis title, focus areas, honors.]}}
+}
+
+\spacedhrule{0.5em}{-0.4em}
+
+%----------------------------------------------------------------------------------------
+%	SKILLS SECTION
+%----------------------------------------------------------------------------------------
+
+\roottitle{Skills}
+
+\inlineheadsection
+{[Skill category, e.g. Technical specialties:]}
+{[Specific skills, frameworks, tools. Be concrete.]}
+
+%------------------------------------------------
+
+\inlineheadsection
+{Languages:}
+{[Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).}
+
+\end{document}

--- a/templates/cv/medium-length-professional-cv/TEMPLATE.md
+++ b/templates/cv/medium-length-professional-cv/TEMPLATE.md
@@ -1,0 +1,30 @@
+# Template: medium-length-professional-cv
+
+- **Type:** CV
+- **Engine:** pdflatex
+- **Page limit:** 2 page(s)
+- **Fonts:** EB Garamond (system font via the `ebgaramond` package - standard TeX Live package with bundled Type 1 files, no separate font files needed)
+- **Class/packages:** custom `resume.cls` (bundled, based on `article`) + `parskip`, `array`, `ifthen`, `graphicx`, `geometry`, `ebgaramond`
+
+## Compile command
+
+    cd cv && pdflatex -interaction=nonstopmode main_<company>.tex
+
+(Copy `resume.cls` into the same directory as the filled-in `.tex` file.)
+
+## Style rules
+
+- Centered, large uppercase name at the very top, auto-printed by the class (do not add your own `\maketitle`-style heading).
+- Up to 3 `\address{...}` calls print as centered lines below the name, in call order. A `\\` *inside* an `\address{}` argument is redefined to render as a `$\diamond$` separator, not a real line break - keep each `\address{}` call to what should visually read as one line (e.g. one call for location, one for phone+email, one for LinkedIn).
+- Each major section uses `\begin{rSection}{Title}...\end{rSection}` - title auto-uppercases, with a horizontal rule under it.
+- Each job uses `\begin{rSubsection}{Company}{Dates}{Job Title}{Location}...\end{rSubsection}`, followed by `\item` bullets (uses a custom tight-spacing list, not a plain `itemize`). Pass an empty 3rd argument (`{}`) to suppress the job-title/location line entirely for a compact entry.
+- Skills/strengths section uses a plain `tabular` with bold left column - see the Skills section in `template.tex` for the pattern.
+- No page numbers (`\pagestyle{empty}`).
+- Source: https://www.latextemplates.com/template/medium-length-professional-cv (original by Trey Hunner, modified by Vel/LaTeXTemplates.com). Licensed CC BY-NC-SA 4.0 - noncommercial use only, keep attribution comments in the files.
+
+## Known pitfalls
+
+- The `\address{...}` mechanism only has 3 slots (`@addressone`/`@addresstwo`/`@addressthree`). A 4th `\address{}` call silently **overwrites** the 3rd slot instead of erroring - if a 4th contact line seems to be missing, check for more than 3 `\address` calls before debugging anything else.
+- `&` is catcode-4 (the alignment character) throughout standard LaTeX, not just inside `tabular` - a literal `&` in a section title, a bullet, or anywhere outside an alignment environment throws `Misplaced alignment tab character &`, and inside the Skills `tabular` it throws `Extra alignment tab has been changed to \cr` instead (silently shifting columns). Always escape as `\&` (e.g. "R\&D", "Awards \& Publications").
+- The all-caps name line (`\MakeUppercase{\huge\bfseries\name}`) produces a mild "Overfull \hbox" warning even with a short two-word name at the stock font size - cosmetic only in testing, but re-check for actual visual overflow/clipping with longer names and reduce to `\Large` if needed.
+- `rSubsection`'s bullet list uses `\setlength{\itemsep}{-0.5em}` (negative item separation) for a tight look - if bullets ever look overlapped rather than tight, this is the length to adjust, not the section's outer spacing.

--- a/templates/cv/medium-length-professional-cv/resume.cls
+++ b/templates/cv/medium-length-professional-cv/resume.cls
@@ -1,0 +1,151 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Medium Length Professional CV
+% LaTeX Class
+% Version 3.0 (December 17, 2022)
+%
+% This template has been downloaded from:
+% http://www.LaTeXTemplates.com
+%
+% Original header:
+% Copyright (C) 2010 by Trey Hunner
+%
+% Copying and distribution of this file, with or without modification,
+% are permitted in any medium without royalty provided the copyright
+% notice and this notice are preserved. This file is offered as-is,
+% without any warranty.
+%
+% Created by Trey Hunner and modified by www.LaTeXTemplates.com
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%----------------------------------------------------------------------------------------
+%	CLASS CONFIGURATION
+%----------------------------------------------------------------------------------------
+
+\ProvidesClass{resume}[2022/12/17 v3.0 Resume class]
+
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}} % Pass through any options to the base class
+\ProcessOptions\relax % Process given options
+
+\LoadClass{article} % Load the base class
+
+%----------------------------------------------------------------------------------------
+%	REQUIRED PACKAGES AND MISC CONFIGURATIONS
+%----------------------------------------------------------------------------------------
+
+\usepackage[parfill]{parskip} % Remove paragraph indentation
+
+\usepackage{array} % Required for bold tabular columns
+
+\usepackage{ifthen} % Required for ifthenelse statements
+
+\usepackage{graphicx} % Required for including images
+
+\pagestyle{empty} % Suppress headers and footers on all pages
+
+%----------------------------------------------------------------------------------------
+%	MARGINS
+%----------------------------------------------------------------------------------------
+
+\usepackage{geometry} % Required for adjusting page dimensions and margins
+
+\geometry{
+	top=0.6in, % Top margin
+	bottom=0.6in, % Bottom margin
+	left=0.75in, % Left margin
+	right=0.75in, % Right margin
+	%showframe, % Uncomment to show how the type block is set on the page
+}
+
+%----------------------------------------------------------------------------------------
+%	NAME AND ADDRESS COMMANDS
+%----------------------------------------------------------------------------------------
+
+\newcommand{\name}[1]{\renewcommand{\name}{#1}} % Defines the \name command to set the user's name
+
+\newcommand{\addressSep}{$\diamond$} % Set default address separator to a diamond symbol
+
+% One, two or three address lines can be specified
+\let \@addressone \relax
+\let \@addresstwo \relax
+\let \@addressthree \relax
+
+% The \address command is used to set the first, second and third address lines (the last 2 are optional)
+\newcommand{\address}[1]{
+	\@ifundefined{@addressone}{ % If the first address line has not been set yet, set it
+		\def \@addressone {#1}
+	}{
+		\@ifundefined{@addresstwo}{ % If the second address line has not been set yet, set it
+			\def \@addresstwo {#1}
+		}{ % Otherwise, set the third address line
+			\def \@addressthree {#1}
+		}%
+	}
+}
+
+% \printaddress is used to style an address line (provided in the single parameter to the command)
+\newcommand{\printaddress}[1]{
+	\begingroup
+		\def \\ {\addressSep\ } % Redefine newlines (\\) to the address separator symbol so multiple lines of each address are output as a single line
+		\centerline{#1} % Output the centered address line
+	\endgroup
+	\par % End the paragraph to ensure correct spacing between lines
+	\smallskip % Vertical whitespace between address lines
+}
+
+% \printname is used to output the user's name in a large size
+\newcommand{\printname}{
+	\begingroup
+		\hfil{\MakeUppercase{\huge\bfseries\name}}\hfil % Style and output the user's name
+		\bigskip\break % Vertical whitespace below name
+	\endgroup
+}
+
+%----------------------------------------------------------------------------------------
+%	OUTPUT THE NAME & ADDRESS LINES AUTOMATICALLY
+%----------------------------------------------------------------------------------------
+
+\let\ori@document=\document % Store the original \document command
+\renewcommand{\document}{
+	\ori@document  % Output the original \document command but add to it below
+	\printname % Output the user's name
+	\@ifundefined{@addressone}{}{\printaddress{\@addressone}} % Output the first address if specified
+	\@ifundefined{@addresstwo}{}{\printaddress{\@addresstwo}} % Output the second address if specified
+	\@ifundefined{@addressthree}{}{\printaddress{\@addressthree}} % Output the third address if specified
+}
+
+%----------------------------------------------------------------------------------------
+%	SECTION FORMATTING
+%----------------------------------------------------------------------------------------
+
+% Defines the rSection environment for the major sections within the CV
+\newenvironment{rSection}[1]{ % The single parameter is for the section title
+	\medskip % Vertical whitespace
+	\MakeUppercase{\textbf{#1}} % Section title
+	\medskip % Vertical whitespace
+	\hrule % Horizontal rule
+	\begin{list}{}{ % List to indent the entire content of the section
+		\setlength{\leftmargin}{1.5em} % Indent to the left of the list
+	}
+	\item[] % Empty list item to enable indentation
+}{
+	\end{list}
+}
+
+%----------------------------------------------------------------------------------------
+%	WORK EXPERIENCE FORMATTING
+%----------------------------------------------------------------------------------------
+
+\newenvironment{rSubsection}[4]{ % 4 parameters: company name, year(s) employed, job title and location
+	\textbf{#1} \hfill {#2} % Bold company name and date to the right
+	\ifthenelse{\equal{#3}{}}{}{ % If the third parameter is empty, don't output the job title and location line
+		\\ % Job title and location on a new line
+		\textit{#3} \hfill \textit{#4} % Output job title and location
+	}%
+	\smallskip % Vertical whitespace
+	\begin{list}{$\cdot$}{\leftmargin=0em} % \cdot used for bullets, no indentation
+		\setlength{\itemsep}{-0.5em} \vspace{-0.5em} % Reduce vertical spacing between items in the list for a tighter look
+}{
+	\end{list}
+	\vspace{0.5em} % Vertical whitespace after the end of the list
+}

--- a/templates/cv/medium-length-professional-cv/template.tex
+++ b/templates/cv/medium-length-professional-cv/template.tex
@@ -1,0 +1,96 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Medium Length Professional CV
+% LaTeX Template
+% Version 3.0 (December 17, 2022)
+%
+% Downloaded from: https://www.latextemplates.com/template/medium-length-professional-cv
+%
+% Author: Vel (vel@latextemplates.com)
+% Original author: Trey Hunner (http://www.treyhunner.com/)
+%
+% License:
+% CC BY-NC-SA 4.0 (https://creativecommons.org/licenses/by-nc-sa/4.0/)
+%
+% Registered into this repo's /add-template framework with [PLACEHOLDER]
+% tokens in place of the original example content.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\documentclass[
+	%a4paper, % Uncomment for A4 paper size (default is US letter)
+	11pt,
+]{resume}
+
+\usepackage{ebgaramond} % EB Garamond font
+
+%------------------------------------------------
+
+\name{[YOUR_NAME]}
+
+% Up to 3 \address calls. Each \\ inside one becomes a diamond separator,
+% not a real line break - keep each call to logically one "line".
+\address{[YOUR_CITY], [YOUR_COUNTRY]}
+
+\address{[YOUR_PHONE] \\ [YOUR_EMAIL]}
+
+\address{[YOUR_LINKEDIN_URL]}
+
+%----------------------------------------------------------------------------------------
+
+\begin{document}
+
+%----------------------------------------------------------------------------------------
+%	EDUCATION SECTION
+%----------------------------------------------------------------------------------------
+
+\begin{rSection}{Education}
+
+	\textbf{[Institution Name]} \hfill \textit{[Month Year]} \\
+	[Degree] in [Field] \\
+	[Optional: minor, honors, GPA, thesis topic]
+
+\end{rSection}
+
+%----------------------------------------------------------------------------------------
+%	WORK EXPERIENCE SECTION
+%----------------------------------------------------------------------------------------
+
+\begin{rSection}{Experience}
+
+	\begin{rSubsection}{[Employer Name]}{[YYYY -- Present]}{[Job Title]}{[City, Country]}
+		\item [Achievement or responsibility - be specific, use numbers where possible.]
+		\item [Achievement or responsibility.]
+		\item [Achievement or responsibility.]
+	\end{rSubsection}
+
+%------------------------------------------------
+
+	\begin{rSubsection}{[Earlier Employer Name]}{[YYYY -- YYYY]}{[Job Title]}{[City, Country]}
+		\item [Achievement or responsibility.]
+		\item [Achievement or responsibility.]
+	\end{rSubsection}
+
+\end{rSection}
+
+%----------------------------------------------------------------------------------------
+%	SKILLS SECTION
+%----------------------------------------------------------------------------------------
+
+\begin{rSection}{Skills}
+
+	\begin{tabular}{@{} >{\bfseries}l @{\hspace{6ex}} l @{}}
+		[Skill category 1] & [Specific skills, tools, frameworks.] \\
+		[Skill category 2] & [Specific skills, tools, frameworks.] \\
+		[Skill category 3] & [Specific skills, tools, frameworks.]
+	\end{tabular}
+
+\end{rSection}
+
+%----------------------------------------------------------------------------------------
+%	EXAMPLE SECTION
+%----------------------------------------------------------------------------------------
+
+%\begin{rSection}{Section Name}
+	%Section content...
+%\end{rSection}
+
+\end{document}


### PR DESCRIPTION
## Summary
Ran `/setup` **Path A** (documents folder) to onboard Cheng-En Li. Read `documents/` (CV en/zh, LinkedIn export + PDFs, Chimes AI business plan) and cross-referenced against the seven skill files, then applied confirmed changes.

## Decisions confirmed by the user
- **Chimes AI role** → use the document version: **Director of Product (2023–Present)** + **Product Manager (2021–2022)** (was a single PM role)
- **Degree** → **B.A.** Materials Science & Engineering (documents agree; diplomas folder empty)
- Applied all additive changes; filled **GitHub** = `github.com/nondayo`
- **Languages**: Mandarin native, English intermediate
- **Target roles**: PM / Sr PM, AI/ML PM, Head of Product / Director
- **Location**: remote / hybrid preferred (location-flexible)
- **Portals**: LinkedIn + freehire (CLIs) + TW boards 104 / Cake / Yourator (site: fallback; scaffold later with `/add-portal`)

## Files changed
| File | Change |
|------|--------|
| `01-candidate-profile.md` | Director/PM split, quantified impact, Tukey, scale metrics, reference; **preserves in-progress MOHW / HL7 FHIR work** |
| `02-behavioral-profile.md` | Honest synthesized profile (no formal assessment on file) + inferred traits |
| `04-job-evaluation.md` | Skill-match areas, experience, career goals, motivation, remote-first location logic |
| `05-cv-templates.md` | PM / AI-PM / Technical-PM profile statements |
| `07-interview-prep.md` | 4 STAR candidate stubs (to complete manually) |
| `CLAUDE.md` | Full candidate profile |
| `cv/main_example.tex` | Populated master CV — compiles with lualatex, **2 pages** (removed unused `import` package) |
| `job-scraper/search-queries.md` | PM/AI-PM queries, TW boards, remote-first filter |
| `templates/cv/` | Pre-existing WIP custom CV templates (included for consistency) |

Also carries a one-line pre-existing WIP tweak to `SKILL.md`.

## Notes / follow-ups for the user
- `references/` held a company business plan (Proprietary & Confidential), **not** a reference letter — used only for light behavioral inference; no confidential figures pulled into public docs.
- Johnson Hsieh reference has no contact details yet (flagged in-file).
- Behavioral profile is **synthesized, not a validated assessment** — labeled as such.
- STAR stubs in `07` need your S/T/A/R details before interview use.
- This was populated in an isolated worktree; your local working-copy WIP is untouched. Merge this to bring the profile into `master`.

## Verification
- `cv/main_example.tex` compiled with lualatex → 2 pages, clean.
- No leftover unfilled `[PLACEHOLDER]` tokens except intentional template skeletons (LaTeX examples, blank STAR 6–8, tough-question stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)