### PR TITLE
fix(templates): correct 06 structure-block antipattern and 05 needspace scope

### DIFF
--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -1,5 +1,5 @@
 ---
-framework_version: 1.1.0
+framework_version: 1.1.1
 ---
 
 # CV Templates and Tailoring Guide
@@ -170,6 +170,8 @@ Add `\needspace{5\baselineskip}` immediately before the problematic `\cventry`:
 \item{\cventry{YEAR--YEAR}{Role Title}{Organization}{Location}{}{...}}
 ```
 Include `\usepackage{needspace}` in the preamble.
+
+**Caveat - use `\needspace` before entries, never before `\section` headings.** A section-level `\needspace` pushes the entire section (heading plus content) to the next page whenever the request does not fit, stranding empty space above and typically *adding* a page instead of saving one. Apply it only to the individual `\cventry` that actually orphans, and only after a compile shows the orphan.
 
 **Problem: one trailing section spills to page 3 (e.g., References alone on page 3)**
 Add `\enlargethispage{2-3\baselineskip}` before a late section (e.g., before `\section{Honors and Awards}`) to stretch page 2 by a few lines. This is the standard LaTeX rescue for near-miss overflows.

--- a/.claude/skills/job-application-assistant/06-cover-letter-templates.md
+++ b/.claude/skills/job-application-assistant/06-cover-letter-templates.md
@@ -1,5 +1,5 @@
 ---
-framework_version: 1.0.0
+framework_version: 1.0.1
 ---
 
 # Cover Letter Templates and Tailoring Guide
@@ -88,15 +88,16 @@ The font wrapper is mandatory — if you just move `\begin{itemize}` outside `\l
 
 \lettercontent{[Opening paragraph - role, connection to background, 2-3 sentences]}
 
-\lettercontent{[Body paragraph - most relevant experience, then bullet list]
+\lettercontent{[Body paragraph - most relevant experience, introducing the bullet list]}
 
+{\raggedright\fontspec[Path = OpenFonts/fonts/raleway/]{Raleway-Medium}\fontsize{11pt}{13pt}\selectfont
 \begin{itemize}
     \item [Concrete achievement/skill 1]
     \item [Concrete achievement/skill 2]
     \item [Concrete achievement/skill 3]
-\end{itemize}
+\end{itemize}\par}
 
-[Connection to company - why this role, why this company specifically]}
+\lettercontent{[Connection to company - why this role, why this company specifically]}
 
 \lettercontent{[Personal fit paragraph - behavioral strengths, team contribution, 2-3 sentences]}
 


### PR DESCRIPTION
Two template bugs found by running the full /apply pipeline end-to-end against real postings (a private output-quality benchmark):

- **06-cover-letter-templates.md**: the Document Structure block still demonstrated `itemize` wrapped inside `\lettercontent{}` - the exact antipattern the file's own "Known template pitfall" section forbids (it breaks compilation with "There's no line here to end"). A drafter following the structure block verbatim ships a broken letter; I nearly did. Block now matches the documented correct pattern (list outside, Raleway font wrapper).
- **05-cv-templates.md**: added a caveat scoping `\needspace` to individual `\cventry` items - applied at `\section` level (a natural misreading of the guidance) it pushed an entire Education block to a new page, adding a page instead of saving one. Reproduced during the benchmark run; took the compile loop from a 1-line spill to a full-page spill.

`framework_version`: 05 → 1.1.1, 06 → 1.0.1.

Verification: lint, version guard, security guards, 119 tests pass; personal-data scan of diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)