### PR TITLE
feat(apply): requirement-coverage rules and CV targeting improvements from output benchmark

### DIFF
--- a/.claude/commands/apply.md
+++ b/.claude/commands/apply.md
@@ -64,6 +64,11 @@ Also read the most recent existing CV and cover letter files for concrete struct
 - Read any existing `cv/main_*.tex` file as a LaTeX template reference
 - Read any existing `cover_letters/cover_*.tex` or `cover_letters/Cover_*.tex` file as a template reference
 
+### Requirement coverage (both documents)
+- **Every requirement the posting states gets addressed - matched or honestly gapped, never silently omitted.** A stated requirement the candidate lacks (a tool, a clearance, years of experience) is acknowledged with an honest bridge ("not in my daily toolkit yet; a natural extension of X"), because omission reads as hiding once an interviewer asks. Build the requirement list from Step 1 and check both drafts against it before Step 3.
+- **Engage nice-to-haves by name** where the profile supports honest adjacency (e.g. "conceptually aligned with <named tool>"), and use the posting's own term over a synonym wherever it is truthfully applicable - including in CV section headings (a posting hiring for "MLOps" should find a heading containing "MLOps", not only a paraphrase).
+- **Address stated logistics and prerequisites** in the cover letter where the posting raises them: security clearance willingness, start date or availability, commute or location fit, and the posting's reference/job ID where one exists. When the employer operates across several countries, a truthful language-capabilities sentence mapped to their footprint is high-value targeting.
+
 ### CV (`cv/main_<company>_<role>.tex`)
 - In the **CV language from the profile** (the `CV language:` line in CLAUDE.md's Identity section). When the profile does not set one, default to **English**. Never switch language per posting - the CV language is a profile-level choice, so all CVs stay consistent and reusable
 - Follow the moderncv/banking format from `05-cv-templates.md`

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -1,5 +1,5 @@
 ---
-framework_version: 1.1.1
+framework_version: 1.2.0
 ---
 
 # CV Templates and Tailoring Guide
@@ -107,6 +107,8 @@ This is the most important section to customize. It appears right after `\makecv
 
 Write 5-7 lines that function as an "elevator pitch": a concise, compelling introduction explaining why you're qualified for *this specific role*. Focus on what the employer gains from hiring you.
 
+When the role sits outside your home domain, **lead with the domain-transfer argument** - the one or two sentences connecting your background to their problem (e.g. wave physics to radar signal processing) belong in the profile statement's opening, not buried in the cover letter. It is the strongest card a domain-changer holds; play it first.
+
 **Create 2-3 profile statement templates for your main role types:**
 
 <!-- SETUP: These are populated based on your background -->
@@ -122,6 +124,8 @@ Statements labeled *[Used for: <company>_<role>]* were extracted from archived a
 Reorder and emphasize based on the role. Use bold category labels.
 
 List **5-7 key competencies** in bullet format, tailored to the specific job. For each competency, briefly explain how it adds value to the position.
+
+Use the posting's own core term in the matching bullet's bold label when it truthfully applies - ATS and skim-reading hiring managers match literally, and "MLOps" in a heading outperforms a paraphrase like "ML Deployment".
 
 ### Education
 - Always include your highest degrees
@@ -143,6 +147,9 @@ If there is a gap in your employment history:
 - Include Google Scholar link if applicable
 - Select 3-4 most relevant publications (not always all of them)
 - For non-academic roles, keep brief
+
+### Evidence Links
+Wherever the CV names a verifiable artifact - a public project, a hackathon entry, a publication - carry its link (`\href`) so a reader can verify the claim in one click. A CV whose strongest claims are checkable reads as more credible everywhere else too.
 
 ### Honors and Awards
 - Keep format brief, one line each


### PR DESCRIPTION
Seven methodology improvements from a private output-quality benchmark: the current framework was re-run end-to-end on three real historical applications and blind-scored against the actually-submitted packages. It won 3-0 - but the judges' regression probes identified concrete things the older outputs did *better*, and this PR folds those back in:

**apply.md - new Requirement Coverage block (Step 2):**
1. Every stated requirement addressed - matched or honestly gapped, never silently omitted (the benchmark's own run omitted a stated Kubernetes requirement; a blind judge called the omission 'hiding rather than acknowledging')
2. Nice-to-haves engaged by name with honest adjacency framing
3. Posting's literal term over synonyms, including CV section headings ('MLOps' beats 'ML Deployment' for ATS and skim-readers)
4. Stated logistics/prerequisites addressed in the letter: clearances, availability, job/reference ID, and language-capabilities mapping for multi-country employers

**05-cv-templates.md:**
5. Domain-transfer argument leads the profile statement for domain-changers (the strongest card, played first)
6. Literal-keyword heading guidance under Core Competencies
7. New Evidence Links note - `\href` on every verifiable named artifact

All additions are honesty-compatible by construction: each rule contains its own truthfulness constraint. `framework_version` 05 → 1.2.0.

Verification: lint, version guard, 119 tests pass; personal-data scan of diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)