### PR TITLE
Add documents/postings/ drop folder for bot-blocked job postings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ documents/linkedin/**
 documents/diplomas/**
 documents/references/**
 documents/applications/**
+documents/postings/**
 !documents/**/.gitkeep
 
 # Personal job search tracking

--- a/documents/README.md
+++ b/documents/README.md
@@ -12,6 +12,8 @@ documents/
 ├── linkedin/                    # LinkedIn profile export (PDF)
 ├── diplomas/                    # Degree certificates and transcripts
 ├── references/                  # Reference letters
+├── postings/                    # Raw job posting text, pasted manually for pages Claude can't fetch
+│   └── <Job Title>.txt          # Filename = job title, content = full posting text
 ├── applications/                # Past job applications
 │   └── <company>_<role>/
 │       ├── job_posting.md       # The original job posting (paste as text)
@@ -92,6 +94,16 @@ Reference letters from former managers, supervisors, or collaborators.
 - Competency language used by referees (adds behavioral signal to `02-behavioral-profile.md`)
 
 **Naming:** Use the referee's name, e.g. `reference_ole_frandsen.pdf`.
+
+---
+
+## postings/
+
+A drop folder for raw job posting text when Claude can't fetch a page directly (bot-blocked ATS platforms like Lever, Greenhouse behind Cloudflare, JS-heavy SPAs that return empty content, etc.). You open the posting yourself and paste the full text into a `.txt` file here.
+
+**Naming:** File name is the exact job title, e.g. `Front End Engineer - React.js.txt`. Content is the full posting text, pasted as-is.
+
+**Workflow:** Drop the file, then tell Claude in the conversation — it isn't watched automatically. Once a posting has been evaluated or applied to, it can be deleted from here or left as a record; it's a scratch inbox, not an archive (use `applications/<company>_<role>/job_posting.md` for that once you actually apply).
 
 ---
 


### PR DESCRIPTION
## Summary
- Some ATS platforms (confirmed with Lever: both the board index and individual posting pages) return a 403 or empty content to automated fetches, so the posting text is otherwise unreachable.
- Adds `documents/postings/<Job Title>.txt` as a manual fallback: the user opens the posting themselves and pastes the text for Claude to work from.
- Documents the convention in `documents/README.md` alongside the existing `cv/`, `linkedin/`, `diplomas/`, `references/`, and `applications/` sections.
- `.gitignore` updated so pasted posting text stays local/personal, matching how the other `documents/` subfolders are handled (only the folder structure ships, via `.gitkeep`).

## Test plan
- [x] Verified `git add -n` only stages `.gitkeep`, confirming actual posting text is ignored
- [x] Verified this branch contains only the 3 relevant files (`.gitignore`, `documents/README.md`, `documents/postings/.gitkeep`), isolated from unrelated personal profile changes in the same working tree