### PR TITLE
fix: parse Jobbank JSON-LD graphs

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/detail.ts
@@ -1,7 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { fetchWithUA, writeError, BASE_URL } from "../helpers.js"
-import { parse as parseHtml } from "node-html-parser"
+import { fetchWithUA, parseJobPostingJsonLd, writeError, BASE_URL } from "../helpers.js"
 
 export const detail = defineCommand({
   name: "detail",
@@ -39,31 +38,7 @@ export const detail = defineCommand({
 
       if (signal.aborted) return
 
-      const root = parseHtml(html)
-
-      // Find all <script type="application/ld+json"> tags
-      const scripts = root.querySelectorAll('script[type="application/ld+json"]')
-      let jobPosting: Record<string, unknown> | null = null
-
-      for (const script of scripts) {
-        try {
-          const json = JSON.parse(script.text)
-          if (json["@type"] === "JobPosting") {
-            jobPosting = json
-            break
-          }
-          // Could be an array
-          if (Array.isArray(json)) {
-            const found = json.find((item) => item["@type"] === "JobPosting")
-            if (found) {
-              jobPosting = found
-              break
-            }
-          }
-        } catch {
-          // not valid JSON — skip
-        }
-      }
+      const jobPosting = parseJobPostingJsonLd(html)
 
       if (!jobPosting) {
         writeError("No JSON-LD found on job page", "PARSE_ERROR")

--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -1,3 +1,5 @@
+import { parse as parseHtml } from "node-html-parser"
+
 export const BASE_URL = "https://jobbank.dk"
 
 export const USER_AGENT =
@@ -157,4 +159,37 @@ export function extractJobIdFromUrl(url: string): string {
   // URL format: https://jobbank.dk/job/{id}/{company-slug}/{title-slug}
   const match = url.match(/\/job\/(\d+)\//)
   return match ? match[1] : ""
+}
+
+function findJobPosting(value: unknown): Record<string, unknown> | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const jobPosting = findJobPosting(item)
+      if (jobPosting) return jobPosting
+    }
+    return null
+  }
+
+  if (!value || typeof value !== "object") return null
+
+  const record = value as Record<string, unknown>
+  if (record["@type"] === "JobPosting") return record
+
+  return findJobPosting(record["@graph"])
+}
+
+export function parseJobPostingJsonLd(html: string): Record<string, unknown> | null {
+  const root = parseHtml(html)
+  const scripts = root.querySelectorAll('script[type="application/ld+json"]')
+
+  for (const script of scripts) {
+    try {
+      const jobPosting = findJobPosting(JSON.parse(script.text) as unknown)
+      if (jobPosting) return jobPosting
+    } catch {
+      // Invalid JSON-LD should not prevent later scripts from being checked.
+    }
+  }
+
+  return null
 }

--- a/.agents/skills/jobbank-search/cli/tests/detail-jsonld.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/detail-jsonld.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { parseJobPostingJsonLd } from "../src/helpers"
+
+const script = (value: string) => `<script type="application/ld+json">${value}</script>`
+
+describe("parseJobPostingJsonLd", () => {
+  test("finds a JobPosting inside an @graph", () => {
+    const html = script(
+      JSON.stringify({
+        "@context": "https://schema.org",
+        "@graph": [
+          { "@type": "WebPage", name: "Jobs" },
+          { "@type": "JobPosting", title: "Data Engineer" },
+        ],
+      }),
+    )
+
+    expect(parseJobPostingJsonLd(html)).toEqual({
+      "@type": "JobPosting",
+      title: "Data Engineer",
+    })
+  })
+
+  test("preserves top-level object and array support", () => {
+    expect(parseJobPostingJsonLd(script('{"@type":"JobPosting","title":"One"}'))?.title).toBe("One")
+    expect(
+      parseJobPostingJsonLd(script('[{"@type":"WebPage"},{"@type":"JobPosting","title":"Two"}]'))?.title,
+    ).toBe("Two")
+  })
+
+  test("skips malformed scripts and checks later JSON-LD", () => {
+    const html = `${script("{not-json")}${script('{"@type":"JobPosting","title":"Valid"}')}`
+
+    expect(parseJobPostingJsonLd(html)?.title).toBe("Valid")
+  })
+
+  test("returns null when no JobPosting exists", () => {
+    expect(parseJobPostingJsonLd(script('{"@graph":[{"@type":"WebPage"}]}'))).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- recognize `JobPosting` entries nested in a JSON-LD `@graph`
- preserve top-level object and array parsing
- continue past malformed JSON-LD scripts
- cover the parser with network-free Bun tests

## Reproduction

A valid script shaped as `{ "@graph": [{ "@type": "WebPage" }, { "@type": "JobPosting" }] }` previously fell through to `No JSON-LD found on job page`.

## Validation

- Jobbank CLI: 12 tests passed
- Jobbank CLI: `bun run typecheck`
- `python3 tools/lint_skills.py`
- `python3 tools/check_framework_version.py`
- repository Python suite: 119 tests passed

Closes #189