### PR TITLE
fix(cli): reject negative and fractional count/pagination flags in Danish portal CLIs

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/search.ts
@@ -39,7 +39,7 @@ export const search = defineCommand({
     since: option(z.string().optional(), {
       description: "Posted on or after date, format YYYY-MM-DD (oprettet)",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap total results returned by CLI (client-side)",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobbank-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+// All cases fail schema validation (or the required-flag guard) before any
+// network request, so the suite is network-free. Regression context: a bare
+// z.coerce.number() accepted --limit=-1, and slice(0, -1) then silently
+// dropped the last result instead of erroring.
+
+function expectValidationError(result: { exitCode: number; stdout: string; stderr: string }, option: string) {
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  const error = JSON.parse(result.stderr);
+  expect(error.ok).toBe(false);
+  expect(error.error.kind).toBe("validation");
+  expect(error.error.option).toBe(option);
+}
+
+describe("Jobbank CLI flag validation", () => {
+  test("search --limit=-1 is rejected instead of silently dropping the last result", async () => {
+    const result = await runCLI(["search", "--key", "test", "--limit=-1"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("greater than or equal to 1");
+  });
+
+  test("search --limit=0 is rejected", async () => {
+    const result = await runCLI(["search", "--key", "test", "--limit=0"]);
+    expectValidationError(result, "limit");
+  });
+
+  test("search --limit=1.5 is rejected as non-integer", async () => {
+    const result = await runCLI(["search", "--key", "test", "--limit=1.5"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("Expected integer");
+  });
+
+  test("valid --limit passes schema validation (proven offline via the required-filter guard)", async () => {
+    const result = await runCLI(["search", "--limit=5"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--key or at least one filter is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+});

--- a/.agents/skills/jobdanmark-search/cli/src/commands/autocomplete.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/autocomplete.ts
@@ -22,7 +22,7 @@ export const autocomplete = defineCommand({
     query: option(z.string().optional(), {
       description: "Search text to autocomplete (required)",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap total suggestions returned",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobdanmark-search/cli/src/commands/categories.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/categories.ts
@@ -13,7 +13,7 @@ export const categories = defineCommand({
   name: "categories",
   description: "List all job categories with live counts",
   options: {
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap number of categories returned",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobdanmark-search/cli/src/commands/locations.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/locations.ts
@@ -22,7 +22,7 @@ export const locations = defineCommand({
     query: option(z.string().optional(), {
       description: "Location text to search (city, zip code, region) (required)",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap total suggestions returned",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobdanmark-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/search.ts
@@ -105,10 +105,10 @@ export const search = defineCommand({
     "job-type": option(z.string().optional(), {
       description: "Comma-separated job types: fuldtid,deltid,fleksjob,elev,studiejob,praktik",
     }),
-    page: option(z.coerce.number().default(1), {
+    page: option(z.coerce.number().int().min(1).default(1), {
       description: "Page number (30 items per page, server-enforced)",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap total results returned by CLI (client-side)",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobdanmark-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+// All cases fail schema validation (or the required-flag guard) before any
+// network request, so the suite is network-free. Regression context: a bare
+// z.coerce.number() accepted --limit=-1, and slice(0, -1) then silently
+// dropped the last result instead of erroring.
+
+function expectValidationError(result: { exitCode: number; stdout: string; stderr: string }, option: string) {
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  const error = JSON.parse(result.stderr);
+  expect(error.ok).toBe(false);
+  expect(error.error.kind).toBe("validation");
+  expect(error.error.option).toBe(option);
+}
+
+describe("Jobdanmark CLI flag validation", () => {
+  test("search --limit=-1 is rejected instead of silently dropping the last result", async () => {
+    const result = await runCLI(["search", "--limit=-1"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("greater than or equal to 1");
+  });
+
+  test("search --page=0 is rejected on the 1-indexed portal", async () => {
+    const result = await runCLI(["search", "--page=0"]);
+    expectValidationError(result, "page");
+  });
+
+  test("search --limit=1.5 is rejected as non-integer", async () => {
+    const result = await runCLI(["search", "--limit=1.5"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("Expected integer");
+  });
+
+  test("categories --limit=-1 is rejected", async () => {
+    const result = await runCLI(["categories", "--limit=-1"]);
+    expectValidationError(result, "limit");
+  });
+
+  test("locations --limit=-1 is rejected", async () => {
+    const result = await runCLI(["locations", "--query", "test", "--limit=-1"]);
+    expectValidationError(result, "limit");
+  });
+
+  test("autocomplete --limit=-1 is rejected", async () => {
+    const result = await runCLI(["autocomplete", "--query", "test", "--limit=-1"]);
+    expectValidationError(result, "limit");
+  });
+
+  test("valid numeric flags pass schema validation (proven offline via the required-flag guard)", async () => {
+    const result = await runCLI(["autocomplete", "--limit=3"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--query is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+});

--- a/.agents/skills/jobindex-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobindex-search/cli/src/commands/search.ts
@@ -10,7 +10,7 @@ export const search = defineCommand({
       short: "q",
       description: "Keyword search query (e.g. python, grafisk designer)",
     }),
-    page: option(z.coerce.number().default(1), {
+    page: option(z.coerce.number().int().min(1).default(1), {
       description: "Page number (1-indexed)",
     }),
     jobage: option(z.coerce.number().default(9999), {
@@ -19,7 +19,7 @@ export const search = defineCommand({
     sort: option(z.string().default("score"), {
       description: "Sort order: score (relevance) or date (newest first)",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap total results returned by the CLI (client-side)",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobindex-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+// All cases fail schema validation (or the required-flag guard) before any
+// network request, so the suite is network-free. Regression context: a bare
+// z.coerce.number() accepted --limit=-1, and slice(0, -1) then silently
+// dropped the last result instead of erroring.
+
+function expectValidationError(result: { exitCode: number; stdout: string; stderr: string }, option: string) {
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  const error = JSON.parse(result.stderr);
+  expect(error.ok).toBe(false);
+  expect(error.error.kind).toBe("validation");
+  expect(error.error.option).toBe(option);
+}
+
+describe("Jobindex CLI flag validation", () => {
+  test("--limit=-1 is rejected instead of silently dropping the last result", async () => {
+    const result = await runCLI(["search", "--query", "test", "--limit=-1"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("greater than or equal to 1");
+  });
+
+  test("--limit=0 is rejected", async () => {
+    const result = await runCLI(["search", "--query", "test", "--limit=0"]);
+    expectValidationError(result, "limit");
+  });
+
+  test("--limit=1.5 is rejected as non-integer", async () => {
+    const result = await runCLI(["search", "--query", "test", "--limit=1.5"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("Expected integer");
+  });
+
+  test("--page=0 is rejected on the 1-indexed portal", async () => {
+    const result = await runCLI(["search", "--query", "test", "--page=0"]);
+    expectValidationError(result, "page");
+  });
+
+  test("valid numeric flags pass schema validation (proven offline via the required-flag guard)", async () => {
+    const result = await runCLI(["search", "--page=2", "--limit=5"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--query is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+});

--- a/.agents/skills/jobnet-search/cli/src/commands/occupations.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/occupations.ts
@@ -21,7 +21,7 @@ export const occupations = defineCommand({
     "search-string": option(z.string().optional(), {
       description: "Search term for occupation, e.g. sygeplejerske",
     }),
-    "per-page": option(z.coerce.number().default(10), {
+    "per-page": option(z.coerce.number().int().min(1).default(10), {
       description: "Max results to return",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobnet-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/search.ts
@@ -131,10 +131,10 @@ export const search = defineCommand({
     "search-string": option(z.string().optional(), {
       description: "Free-text keyword search (job title, skills, employer)",
     }),
-    page: option(z.coerce.number().default(1), {
+    page: option(z.coerce.number().int().min(1).default(1), {
       description: "Page number (1-indexed)",
     }),
-    "per-page": option(z.coerce.number().default(10), {
+    "per-page": option(z.coerce.number().int().min(1).default(10), {
       description: "Results per page",
     }),
     order: option(z.string().default("PublicationDate"), {
@@ -164,7 +164,7 @@ export const search = defineCommand({
     "occupation-group": option(z.string().optional(), {
       description: "Occupation group identifier, e.g. 10060",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap total results returned by CLI",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobnet-search/cli/src/commands/suggestions.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/suggestions.ts
@@ -9,7 +9,7 @@ export const suggestions = defineCommand({
     query: option(z.string().optional(), {
       description: "Partial search string to complete",
     }),
-    limit: option(z.coerce.number().optional(), {
+    limit: option(z.coerce.number().int().min(1).optional(), {
       description: "Cap number of suggestions returned",
     }),
     format: option(z.enum(["json", "table", "plain"]).default("json"), {

--- a/.agents/skills/jobnet-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+// All cases fail schema validation (or the required-flag guard) before any
+// network request, so the suite is network-free. Regression context: a bare
+// z.coerce.number() accepted --limit=-1 / --per-page=-1, and slice(0, -1)
+// then silently dropped the last result instead of erroring.
+
+function expectValidationError(result: { exitCode: number; stdout: string; stderr: string }, option: string) {
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  const error = JSON.parse(result.stderr);
+  expect(error.ok).toBe(false);
+  expect(error.error.kind).toBe("validation");
+  expect(error.error.option).toBe(option);
+}
+
+describe("Jobnet CLI flag validation", () => {
+  test("search --limit=-1 is rejected instead of silently dropping the last result", async () => {
+    const result = await runCLI(["search", "--limit=-1"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("greater than or equal to 1");
+  });
+
+  test("search --page=0 is rejected on the 1-indexed API", async () => {
+    const result = await runCLI(["search", "--page=0"]);
+    expectValidationError(result, "page");
+  });
+
+  test("search --per-page=-5 is rejected", async () => {
+    const result = await runCLI(["search", "--per-page=-5"]);
+    expectValidationError(result, "per-page");
+  });
+
+  test("search --limit=1.5 is rejected as non-integer", async () => {
+    const result = await runCLI(["search", "--limit=1.5"]);
+    expectValidationError(result, "limit");
+    expect(JSON.parse(result.stderr).error.message).toContain("Expected integer");
+  });
+
+  test("occupations --per-page=-1 is rejected", async () => {
+    const result = await runCLI(["occupations", "--per-page=-1"]);
+    expectValidationError(result, "per-page");
+  });
+
+  test("suggestions --limit=-1 is rejected", async () => {
+    const result = await runCLI(["suggestions", "--limit=-1"]);
+    expectValidationError(result, "limit");
+  });
+
+  test("valid numeric flags pass schema validation (proven offline via the required-flag guard)", async () => {
+    const result = await runCLI(["occupations", "--per-page=5"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "--search-string is required",
+      code: "MISSING_REQUIRED",
+    });
+  });
+});


### PR DESCRIPTION
## Failing case (reproduced on master)

The four Danish portal CLIs validate numeric flags with a bare `z.coerce.number()`, so negative and fractional values pass schema validation. The visible failure: `--limit=-1` reaches `results.slice(0, -1)`, which **silently drops the last result** instead of erroring.

Live repro on `jobindex-search` (master):

```
search --query python              -> 20 results
search --query python --limit=-1   -> 19 results (last one silently dropped)
search --query python --limit=-5   -> 15 results (last five silently dropped)
```

The same unguarded `slice(0, flags.limit)` pattern exists in all four CLIs (jobnet `occupations` slices `--per-page` the same way). Invalid `--page=0`/`--page=-1` values additionally get sent verbatim to the 1-indexed portals. The reference CLIs already guard this class: `linkedin-search` checks `limit >= 0` before slicing and clamps page with `Math.max(1, ...)`; `freehire-search` clamps limit with `Math.max(1, ...)`.

## Fix

Tighten the zod schemas to `.int().min(1)` for the count/pagination flags (`limit`, `page`, `per-page`) across the four CLIs — 13 one-line changes. Invalid values now fail with the existing bunli validation JSON on stderr (exit 1) **before any network request**, consistent with the error contract the CLIs already ship:

- `jobindex-search`: search `--page`/`--limit`
- `jobnet-search`: search `--page`/`--per-page`/`--limit`, occupations `--per-page`, suggestions `--limit`
- `jobbank-search`: search `--limit`
- `jobdanmark-search`: search `--page`/`--limit`, categories/locations/autocomplete `--limit`

Deliberately **not** touched: ID-valued and domain-valued flags (`company`, `category`, `jobtitle-id`, `jobage`, `radius`) — no demonstrated failure there, keeping the diff to the demonstrated class. Rejecting (rather than clamping, as freehire does) was chosen because it reuses the validation channel these CLIs already emit and never second-guesses user intent.

## Tests

Each CLI gains `tests/cli-flag-validation.test.ts`, mirroring the linkedin/freehire flag-validation suites. All cases are network-free:

- `-1`, `0`, and `1.5` rejected per flag (asserting `kind: "validation"` and the offending `option`, empty stdout, exit 1)
- a valid-value case per CLI proven offline via each command's required-flag guard (numeric flags pass schema → handler fails with `MISSING_REQUIRED` before any request)

Assertions were written against observed CLI output, not assumed shapes.

## Verification

- `bun test`: jobindex 14 pass, jobnet 16 pass, jobbank 12 pass, jobdanmark 13 pass (0 fail everywhere, includes the pre-existing suites)
- `bun run typecheck` clean in all four CLIs
- `python3 tools/lint_skills.py`: OK

One quirk noted while reproducing, left out of scope: the space form `--limit -1` is eaten by the arg parser as a separate flag and silently ignored (the `=` form is the clean repro). That is parser-level behavior in bunli, not schema validation.