### PR TITLE
fix(portals): add a 15s request timeout to every board fetch (a stalled connection hangs the CLI)

### DIFF
--- a/.agents/skills/freehire-search/cli/src/helpers.ts
+++ b/.agents/skills/freehire-search/cli/src/helpers.ts
@@ -42,6 +42,7 @@ export async function apiGet<T>(path: string): Promise<Envelope<T> | null> {
       response = await fetch(url, {
         headers: { "User-Agent": UA, Accept: "application/json" },
         redirect: "follow",
+        signal: AbortSignal.timeout(15000),
       })
     } catch (e) {
       // Connection refused / DNS failure / timeout: the API is unreachable.

--- a/.agents/skills/freehire-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/freehire-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiGet } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert the request
+// wrapper carries an AbortSignal timeout. Fails on the pre-fix code (no signal).
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("apiGet request timeout", () => {
+  test("passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await apiGet("/jobs");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -15,6 +15,7 @@ export async function fetchWithUA(url: string): Promise<Response> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
       headers: { "User-Agent": USER_AGENT },
+      signal: AbortSignal.timeout(15000),
     })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {

--- a/.agents/skills/jobbank-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fetchWithUA } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert the request
+// wrapper carries an AbortSignal timeout. Fails on the pre-fix code (no signal).
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("fetchWithUA request timeout", () => {
+  test("passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("<rss></rss>", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await fetchWithUA("https://jobbank.dk/job/rss");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
@@ -217,6 +217,7 @@ export const detail = defineCommand({
           "Accept": "text/html,application/xhtml+xml",
           "User-Agent": "Mozilla/5.0",
         },
+        signal: AbortSignal.timeout(15000),
       })
 
       if (response.status === 404) {

--- a/.agents/skills/jobdanmark-search/cli/src/helpers.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/helpers.ts
@@ -10,7 +10,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   const maxRetries = 6
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url)
+    const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {
         throw new Error(`API request failed: ${response.status} ${response.statusText}`)
@@ -40,6 +40,7 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15000),
     })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {

--- a/.agents/skills/jobdanmark-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch, apiPost } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert both request
+// wrappers carry an AbortSignal timeout. Fails on the pre-fix code (no signal).
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("request timeout", () => {
+  test("apiFetch passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await apiFetch("/search");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("apiPost passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await apiPost("/search", { q: "x" });
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/.agents/skills/jobindex-search/cli/src/helpers.ts
+++ b/.agents/skills/jobindex-search/cli/src/helpers.ts
@@ -14,7 +14,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   const maxRetries = 6
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url)
+    const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {
         throw new Error(`API request failed: ${response.status} ${response.statusText}`)
@@ -43,6 +43,7 @@ export async function htmlFetch(url: string): Promise<string> {
         "Accept-Language": "da,en;q=0.9",
       },
       redirect: "follow",
+      signal: AbortSignal.timeout(15000),
     })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {

--- a/.agents/skills/jobindex-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch, htmlFetch } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert both request
+// wrappers carry an AbortSignal timeout. Fails on the pre-fix code (no signal).
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("request timeout", () => {
+  test("apiFetch passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await apiFetch("/search");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("htmlFetch passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("<html></html>", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await htmlFetch("https://www.jobindex.dk/x");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/.agents/skills/jobnet-search/cli/src/helpers.ts
+++ b/.agents/skills/jobnet-search/cli/src/helpers.ts
@@ -14,6 +14,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
       headers: {
         "x-csrf": "1",
       },
+      signal: AbortSignal.timeout(15000),
     })
 
     if (response.status === 429 || response.status >= 500) {

--- a/.agents/skills/jobnet-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert every request
+// carries an AbortSignal timeout. This fails on the pre-fix code (no signal).
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("apiFetch request timeout", () => {
+  test("passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await apiFetch("/search");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -29,6 +29,7 @@ export async function htmlFetch(url: string): Promise<string> {
         "X-Requested-With": "XMLHttpRequest",
       },
       redirect: "follow",
+      signal: AbortSignal.timeout(15000),
     })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {

--- a/.agents/skills/linkedin-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { htmlFetch } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert the request
+// wrapper carries an AbortSignal timeout. Fails on the pre-fix code (no signal).
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("htmlFetch request timeout", () => {
+  test("passes an AbortSignal timeout to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("<html></html>", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await htmlFetch("https://www.linkedin.com/jobs-guest/jobs/api/x");
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+});


### PR DESCRIPTION
## What changed and why

None of the board CLIs set a request timeout on `fetch`. `fetch` has no default timeout, and the retry loops react only to received HTTP status codes (429/5xx), not to a connection that is accepted and then never responds (black-holed TCP, hung TLS, a stalled proxy). `await fetch(...)` never settles, so the command hangs indefinitely with no output and no exit. `freehire`'s helpers even document the intended contract — "an outage degrades this source quickly rather than hanging the caller" — but its `try/catch` only catches an *immediate* connection failure; a mid-flight stall still hangs.

This adds `signal: AbortSignal.timeout(15000)` to every board `fetch`:

- `jobnet-search` `apiFetch`
- `jobindex-search` `apiFetch`, `htmlFetch`
- `jobdanmark-search` `apiFetch`, `apiPost`, and `commands/detail.ts` detail fetch
- `jobbank-search` `fetchWithUA`
- `freehire-search` `apiGet`
- `linkedin-search` `htmlFetch`

On timeout `fetch` rejects with a `TimeoutError`, which propagates to each board's existing retry-loop / `try/catch` error path → `writeError(..., "API_ERROR")` + exit 1 (or freehire's graceful "could not reach" message). No behavior change on healthy responses.

Fixes #196

## Failing case / reproduction (for fixes)

Point any board at a host that accepts the socket but never responds (a listener that accepts and holds the connection, or an unroutable IP that black-holes packets): e.g. `jobnet search --search-string x` hangs forever with no output and no exit.

Deterministic, network-free version: mock `fetch` with a never-settling promise → the command never returns on `master`. Each new `tests/request-timeout.test.ts` asserts the board's `fetch` is called with an `AbortSignal`; every one **fails on `master`** (no `signal` is passed → `init.signal` is `undefined`) and passes here. Verified by reverting one board's `helpers.ts` to `master` and re-running its test:

```
(fail) apiFetch request timeout > passes an AbortSignal timeout to fetch
 0 pass  1 fail        # master
 1 pass  0 fail        # this branch
```

## Verification

- `bun run typecheck` in all six touched CLIs → exit 0
- `bun test` in all six touched CLIs → all pass (jobnet 17, jobindex 16, jobdanmark 15, jobbank 17, freehire 27, linkedin 18), including the six new timeout tests
- `python3 tools/lint_skills.py` → exit 0
- `python3 tools/check_framework_version.py` → exit 0
- `python3 tools/security_guards.py` → exit 0
- Confirmed each new test fails against the `master` code and passes here (0→1 pass shown above)
