### PR TITLE
fix(salary): detect city column from header token, not exact match

### DIFF
--- a/tests/test_convert_salary_excel.py
+++ b/tests/test_convert_salary_excel.py
@@ -104,6 +104,22 @@ class DetectColumnTypeTests(unittest.TestCase):
                     companies[0]["categories"]["salary"], {"index": 105.5}
                 )
 
+    def test_parse_sheet_detects_city_column_with_token_header(self):
+        # City headers are matched with the same token-based header_matches()
+        # used for the company column, not exact string equality. Real-world
+        # sheets rarely use the bare token "City" or "Kommune" alone; headers
+        # like "City Name" / "City/Kommune" must still be detected as the city
+        # column (previously silently left as city_col=None -> empty city).
+        for header in ("City", "City Name", "Kommune", "City/Kommune"):
+            with self.subTest(header=header):
+                ws = FakeWorksheet([
+                    ("Company", header, "Salary"),
+                    ("Example Corp", "Aarhus", 105.5),
+                ])
+                companies = parse_sheet(ws)
+                self.assertEqual(len(companies), 1)
+                self.assertEqual(companies[0]["city"], "Aarhus")
+
     def test_skips_free_text_column(self):
         # A free-text "Notes" column must not become a bogus salary category.
         ws = FakeWorksheet([

--- a/tools/convert_salary_excel.py
+++ b/tools/convert_salary_excel.py
@@ -114,10 +114,9 @@ def parse_sheet(ws, sheet_label=None):
     company_col = None
     city_col = None
     for i, h in enumerate(headers):
-        h_lower = h.lower()
         if header_matches(h, COMPANY_PATTERNS):
             company_col = i
-        elif h_lower in CITY_PATTERNS:
+        elif header_matches(h, CITY_PATTERNS):
             city_col = i
 
     if company_col is None:


### PR DESCRIPTION
### Bug
convert_salary_excel.py detected the city column via exact membership in CITY_PATTERNS. Real-world headers like "City Name", "City/Kommune", or "Kommune" with any suffix were never matched, leaving city_col=None and silently writing every company with an empty "city" field.

This is the same bug class fixed for the company column in #151 ("detect company column from header token, not exact match"), where "Company Name" / "Employer Name" were dropped for the same reason.

### Fix
One line: use header_matches(h, CITY_PATTERNS) instead of h.lower() in CITY_PATTERNS, the same token matcher already used for company, count, index, and ID columns. Inputs that already worked (bare "City"/"Kommune"/...) are unaffected.

### Reproduction
`
pytest tests/test_convert_salary_excel.py::DetectColumnTypeTests::test_parse_sheet_detects_city_column_with_token_header -v
`
Fails on master with AssertionError: '' != 'Aarhus'. Passes 100% after the fix.

### Tests
- 14/14 green in 	ests/test_convert_salary_excel.py
- New regression test covers: City, City Name, Kommune, City/Kommune
- Verified: lint_skills and check_framework_version pass
- Note: "Employer City" collides with COMPANY_PATTERNS (employer) -- excluded to keep the PR single-concern
