### PR TITLE
fix(cli): add fetch timeout to all portal CLIs — a stalled connection no longer hangs forever

### DIFF
--- a/.agents/skills/freehire-search/cli/src/helpers.ts
+++ b/.agents/skills/freehire-search/cli/src/helpers.ts
@@ -40,6 +40,7 @@ export async function apiGet<T>(path: string): Promise<Envelope<T> | null> {
     let response: Response
     try {
       response = await fetch(url, {
+        signal: AbortSignal.timeout(15000),
         headers: { "User-Agent": UA, Accept: "application/json" },
         redirect: "follow",
       })

--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -14,6 +14,7 @@ export async function fetchWithUA(url: string): Promise<Response> {
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
+      signal: AbortSignal.timeout(15000),
       headers: { "User-Agent": USER_AGENT },
     })
     if (response.status === 429 || response.status >= 500) {

--- a/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
@@ -213,6 +213,7 @@ export const detail = defineCommand({
 
     try {
       const response = await fetch(url, {
+        signal: AbortSignal.timeout(15000),
         headers: {
           "Accept": "text/html,application/xhtml+xml",
           "User-Agent": "Mozilla/5.0",

--- a/.agents/skills/jobdanmark-search/cli/src/helpers.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/helpers.ts
@@ -10,7 +10,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   const maxRetries = 6
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url)
+    const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {
         throw new Error(`API request failed: ${response.status} ${response.statusText}`)
@@ -35,6 +35,7 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
+      signal: AbortSignal.timeout(15000),
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/.agents/skills/jobindex-search/cli/src/helpers.ts
+++ b/.agents/skills/jobindex-search/cli/src/helpers.ts
@@ -14,7 +14,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   const maxRetries = 6
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url)
+    const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {
         throw new Error(`API request failed: ${response.status} ${response.statusText}`)
@@ -37,6 +37,7 @@ export async function htmlFetch(url: string): Promise<string> {
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
+      signal: AbortSignal.timeout(15000),
       headers: {
         "User-Agent": "Mozilla/5.0 (compatible; jobindex-cli/1.0)",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",

--- a/.agents/skills/jobnet-search/cli/src/helpers.ts
+++ b/.agents/skills/jobnet-search/cli/src/helpers.ts
@@ -11,6 +11,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
+      signal: AbortSignal.timeout(15000),
       headers: {
         "x-csrf": "1",
       },

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -22,6 +22,7 @@ export async function htmlFetch(url: string): Promise<string> {
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
+      signal: AbortSignal.timeout(15000),
       headers: {
         "User-Agent": UA,
         Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",


### PR DESCRIPTION
Closes #196

## Summary
None of the six portal-search CLIs set a request timeout on fetch(). fetch() has no default timeout. A connection that is accepted and then never responds (black-holed TCP, hung TLS, stalled proxy) hangs the command indefinitely � no output, no exit, the agent driving it waits forever.

## Fix
Adds signal: AbortSignal.timeout(15000) to every fetch() across all six board CLIs:

| Portal | Location | Fetch count |
|--------|----------|-------------|
| jobnet-search | helpers.ts (apiFetch) | 1 |
| jobindex-search | helpers.ts (apiFetch, htmlFetch) | 2 |
| jobdanmark-search | helpers.ts (apiFetch, apiPost) + commands/detail.ts (direct fetch) | 3 |
| jobbank-search | helpers.ts (fetchWithUA, used by rssFetch + detail) | 1 |
| freehire-search | helpers.ts (apiGet) | 1 |
| linkedin-search | helpers.ts (htmlFetch) | 1 |

On timeout, fetch throws a TimeoutError which the existing error paths already handle � each portal's outer try/catch calls writeError(...) + exit 1, and freehire's graceful "could not reach the freehire API" message is triggered without modification. A stalled upstream now degrades quickly rather than wedging the CLI.

No behavior change for successful requests. 9 fetches across 7 files, +9/-2 lines.
