### PR TITLE
fix(cli): catch unhandled promise rejections in self-contained CLIs — silent failures now exit 1

### DIFF
--- a/.agents/skills/freehire-search/cli/src/cli.ts
+++ b/.agents/skills/freehire-search/cli/src/cli.ts
@@ -186,4 +186,14 @@ async function main(): Promise<number> {
   return 1
 }
 
-main().then((code) => process.exit(code))
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write(
+      JSON.stringify({
+        error: e instanceof Error ? e.message : String(e),
+        code: "INTERNAL_ERROR",
+      }) + "\n",
+    )
+    process.exit(1)
+  })

--- a/.agents/skills/linkedin-search/cli/src/cli.ts
+++ b/.agents/skills/linkedin-search/cli/src/cli.ts
@@ -139,4 +139,14 @@ async function main(): Promise<number> {
   return 1
 }
 
-main().then((code) => process.exit(code))
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write(
+      JSON.stringify({
+        error: e instanceof Error ? e.message : String(e),
+        code: "INTERNAL_ERROR",
+      }) + "\n",
+    )
+    process.exit(1)
+  })


### PR DESCRIPTION
Both self-contained CLIs (freehire and linkedin) call main().then((code) => process.exit(code)) without a .catch() handler. If main() throws synchronously or returns a rejected promise, the .then() never fires - process.exit() is never called - and Bun/Node terminates with exit code 0. A runtime failure becomes indistinguishable from success.

## Fix
Adds .catch() to main() in both CLIs that writes the error to stderr in the same JSON format as all other error paths in these files and exits with code 1. Follows the existing error pattern:

process.stderr.write(JSON.stringify({ error: '...', code: '...' }) + '\n')

Not affected: bunli-based portals (jobbank, jobdanmark, jobindex, jobnet) - @bunli/core's defineCommand catches errors internally.

2 files, +22/-2 lines. Error code: INTERNAL_ERROR.