### PR TITLE
fix(jobdanmark): reject NOT_FOUND on 404-page patterns, not bare 404 substring in title

### DIFF
--- a/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
@@ -134,7 +134,14 @@ function overviewValue(root: ReturnType<typeof parse>, label: string): string | 
 
 function fromRenderedHtml(root: ReturnType<typeof parse>, slug: string, url: string): DetailResult {
   const pageTitle = cleanText(root.querySelector("title")?.text ?? "")
-  if (pageTitle.toLowerCase().includes("404") || root.text.toLowerCase().includes("siden blev ikke fundet")) {
+  const titleLower = pageTitle.toLowerCase()
+  const bodyText = root.text.toLowerCase()
+  if (
+    bodyText.includes("siden blev ikke fundet") ||
+    titleLower.startsWith("404") ||
+    titleLower.includes("page not found") ||
+    titleLower.includes("siden blev ikke fundet")
+  ) {
     throw new Error("NOT_FOUND")
   }
 

--- a/.agents/skills/jobdanmark-search/cli/tests/detail-parsing.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/detail-parsing.test.ts
@@ -49,4 +49,23 @@ describe("parseJobPostingFromHtml", () => {
     expect(parsed.description).toContain("identificere relevante datasæt");
     expect(parsed.applyUrl).toBe("https://jfm.career.emply.com/da/apply/example");
   });
+
+  test("does not reject titles containing '404' mid-phrase", () => {
+    const htmlWith404InTitle = HTML_WITHOUT_JSON_LD.replace(
+      "<title>Journalistisk udvikler s&#xF8;ges | jobdanmark</title>",
+      "<title>HTTP 404 Page Designer | jobdanmark</title>",
+    ).replace(
+      '<h3 class="title">Journalistisk udvikler s&#xF8;ges</h3>',
+      '<h3 class="title">HTTP 404 Page Designer</h3>',
+    );
+
+    const parsed = parseJobPostingFromHtml(
+      htmlWith404InTitle,
+      "http-404-designer",
+      "https://jobdanmark.dk/job/http-404-designer",
+    );
+
+    expect(parsed.title).toBe("HTTP 404 Page Designer");
+    expect(parsed.hiringOrganization.name).toBe("JFM");
+  });
 });


### PR DESCRIPTION
The NOT_FOUND detector in fromRenderedHtml used pageTitle.includes("404"), which matches the substring "404" anywhere — so a job titled "HTTP 404 Page Designer" or "Room 404 Cleaner" is falsely rejected as "not found".

## Root cause

Line 137 of detail.ts:

pageTitle.toLowerCase().includes("404")

String.includes does not care about word boundaries or context. Any "404" in any position triggers NOT_FOUND.

## Fix

Replaces the bare includes with targeted patterns that match actual error-page formats while allowing job titles with "404" in them:

- titleLower.startsWith("404") — matches "404 | Jobdanmark", "404 - Page Not Found", etc. No real job title on Jobdanmark starts with the digits "404".
- titleLower.includes("page not found") — English error-page titles.
- bodyText.includes("siden blev ikke fundet") + title variant — Danish error-page titles.

## Existing test preserved

expect(() => parseJobPostingFromHtml("<html><head><title>404 | Jobdanmark</title></head><body></body></html>", "missing")).toThrow("NOT_FOUND")

## New regression test

Rendered HTML with title "HTTP 404 Page Designer" parses successfully and returns the full title.

2 files, +24/-2 lines.

By @oscarbol09.