### PR TITLE
fix(privacy): ignore scraper state and interview records at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,12 @@ venv/
 
 # Personal data (never commit these)
 salary_data.json
-job_scraper/seen_jobs.json
-job_scraper/notion_sync.json
-job_scraper/*.md
+# Match at any depth: the job-scraper skill resolves `job_scraper/` relative to
+# its own directory, so these land at .claude/skills/job-scraper/job_scraper/*.
+# A rooted `job_scraper/...` pattern silently fails to match them.
+**/job_scraper/seen_jobs.json
+**/job_scraper/notion_sync.json
+**/job_scraper/*.md
 *_BehavioralReport.pdf
 linkedin_Profile.pdf
 
@@ -61,6 +64,9 @@ documents/diplomas/**
 documents/references/**
 documents/applications/**
 documents/postings/**
+# Interview prep and experience records: these name the employers applied to,
+# quote what was submitted, and set out the candidate's weak points.
+documents/interview/**
 !documents/**/.gitkeep
 
 # Personal job search tracking

--- a/tools/security_guards.py
+++ b/tools/security_guards.py
@@ -44,7 +44,10 @@ ALLOWED_PERMISSIONS = {
 # Personal-data ignore rules that must never disappear from .gitignore.
 REQUIRED_IGNORE_RULES = [
     "salary_data.json",
-    "job_scraper/seen_jobs.json",
+    # Depth-independent: the job-scraper skill resolves `job_scraper/` relative
+    # to its own directory, so the state file lands under .claude/skills/... and
+    # a repo-rooted rule silently fails to match it.
+    "**/job_scraper/seen_jobs.json",
     "cv/main_*.tex",
     "!cv/main_example.tex",
     "cover_letters/cover_*.tex",
@@ -53,6 +56,7 @@ REQUIRED_IGNORE_RULES = [
     "documents/diplomas/**",
     "documents/references/**",
     "documents/applications/**",
+    "documents/interview/**",
     "job_search_tracker.csv",
 ]
 


### PR DESCRIPTION
Split out of #199 at your request — this is the standalone gitignore fix, rebased onto current master (post-#195).

## The two leaks

**1. `job_scraper/seen_jobs.json` never matches.** The pattern is repo-rooted, but the job-scraper skill resolves `job_scraper/` relative to its own directory, so the state file actually lands at `.claude/skills/job-scraper/job_scraper/seen_jobs.json`. Same problem for `notion_sync.json` and `job_scraper/*.md`. Prefixing the three with `**/` makes them depth-independent.

**2. `documents/interview/**` was not ignored at all.** Interview prep and experience records name the employers applied to, quote what was submitted, and set out the candidate's weak points — the same sensitivity class as `documents/applications/**`, which is already ignored.

## Guard coordination

`REQUIRED_IGNORE_RULES` in `tools/security_guards.py` is updated in the same commit, as the guard requires. **No `.gitignore` negations are added**, so the #195 negation allowlist is untouched and unaffected.

## Verification on this branch

```
$ git check-ignore -v .claude/skills/job-scraper/job_scraper/seen_jobs.json documents/interview/foo.md
.gitignore:26:**/job_scraper/seen_jobs.json  .claude/skills/job-scraper/job_scraper/seen_jobs.json
.gitignore:69:documents/interview/**         documents/interview/foo.md

$ python3 tools/security_guards.py
security_guards: OK (permissions allowlist, gitignore rules, package manifests)
```

Both paths were unignored before this change on the same checkout.

The remaining five changes from #199 will follow as separate PRs along the lines you sketched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)