### PR TITLE
feat(04): add work-authorization eligibility gate before scoring

### DIFF
--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -1,10 +1,34 @@
 ---
-framework_version: 1.0.0
+framework_version: 1.1.0
 ---
 
 # Job Evaluation Framework
 
 <!-- SETUP: Skill match areas and career goals are personalized by running /setup -->
+
+## Eligibility Gate — run before scoring
+
+If the candidate is not a citizen or permanent resident of the country they are applying in, run this first. It is a hard filter, not a scoring dimension, and it is separate from work-permit *timing*: timing asks "can they work the required hours yet?", eligibility asks "are they permitted to hold this job at all?". A candidate can pass timing and still be categorically excluded.
+
+Read the posting's eligibility / work rights / "who can apply" section **verbatim** and classify:
+
+| Posting wording | Verdict |
+|-----------------|---------|
+| Names a **citizenship or permanent-residency requirement** ("must be a citizen of X", "permanent resident", "PR required", "full working rights" where the employer means citizen/PR) | **FAIL — hard stop.** Do not score, do not draft. Quote the exact wording back to the user. |
+| Requires a **security clearance** at any level | **FAIL** in most countries, since clearance is normally gated on citizenship. Verify the specific scheme rather than assuming. |
+| **Explicitly names** the candidate's permit class, or says "international applicants welcome", "visa holders considered", "we sponsor" | **PASS** — verified acceptance. Worth noting as a positive in the application. |
+| **Silent** on citizenship or residency | **PROCEED, but mark unverified.** Check the employer's own careers or international-applicant page before drafting. |
+
+**Two rules that are easy to get wrong:**
+
+1. **Silence is not permission.** Large graduate programs frequently gate eligibility on their own website rather than in the job ad. Highest-risk categories: professional-services firms, government and defence, banking, telecommunications, and anything touching critical infrastructure.
+2. **A company-wide "we accept international applicants" statement is not role-level permission.** The common pattern is a general welcome followed by a *named list* of the specific programs or service lines it covers. Confirm the **specific posting or stream** appears on that list before drafting.
+
+**Report an eligibility failure to the user with the quoted source** rather than silently dropping the role. They may know something about their own status that the profile does not record.
+
+If the candidate's permit also constrains *hours* or *start date* (a student visa with a term-time cap, a permit that begins on graduation), record that as a second gate under this section during `/setup`, with the specific dates. Do not merge it with the eligibility question above — they fail for different reasons and need different answers.
+
+A role that fails this gate is not scored and not drafted. Everything below applies only to roles that pass it.
 
 ## Scoring Dimensions
 


### PR DESCRIPTION
Second of the #199 split. Touches one file: `04-job-evaluation.md`.

## Why this is a gate and not a dimension

Eligibility is separate from work-permit *timing*. Timing asks "can they work the required hours yet?" Eligibility asks "are they permitted to hold this job at all?" A candidate can pass timing and still be categorically excluded — which is exactly how I lost two applications: scored well, drafted, then found the citizenship requirement.

The gate runs before scoring so the framework doesn't spend a scoring pass and a drafting pass on a role that was never open.

## What it adds

A posting-wording → verdict table:

- citizenship/PR requirement, or a security clearance at any level → **FAIL**, hard stop, quote the wording back to the user
- explicitly names the candidate's permit class, or "we sponsor" / "visa holders considered" → **PASS**, and worth citing as a positive in the application
- silent → **PROCEED but unverified**, check the employer's own careers page before drafting

Plus the two failure modes that actually cost me the applications:

1. **Silence is not permission.** Large graduate programs gate eligibility on their own website, not in the ad.
2. **A company-wide "international applicants welcome" is not role-level permission.** The usual shape is a general welcome followed by a *named list* of covered programs or service lines — the stream you're applying to has to appear on it.

Failures get reported to the user with the quoted source rather than silently dropped: the user may know something about their own status that the profile doesn't record.

## One change from the version in #199

In #199 this sat as an `####` subsection under dimension 4 (Location & Logistics), between dimensions 4 and 5 — while its own heading said "check this BEFORE scoring anything else." That contradiction was mine. It is now a top-level `## Eligibility Gate — run before scoring` section placed ahead of `## Scoring Dimensions`, so the position matches the instruction, with a closing line stating that everything below applies only to roles that pass.

`framework_version` 1.0.0 → 1.1.0. No other file touched, so no interaction with the per-file versions of `03`/`05` that have moved since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)