### PR TITLE
feat(05): state in-progress qualifications explicitly; check tenure against output

### DIFF
--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -1,5 +1,5 @@
 ---
-framework_version: 1.2.1
+framework_version: 1.3.0
 ---
 
 # CV Templates and Tailoring Guide
@@ -136,10 +136,44 @@ Use the posting's own core term in the matching bullet's bold label when it trut
 - For senior roles, keep education brief (dates and titles only)
 - Include thesis topics when relevant to the target role
 
+#### In-progress qualifications must say so explicitly
+
+**A bare year range is not enough.** An entry reading `2025–2026`, seen partway through 2026, looks like a *finished* degree, because a reader skimming a CV treats a closed range as closed. A profile statement that says "currently completing…" does not fix it: the education entry is where a reader checks the credential, so it has to stand on its own.
+
+State completion inside the entry itself:
+
+```latex
+\item{\cventry{2025--2026}{[Degree], [Field]}{[Institution]}{[Location]}{}{\vspace{1pt}
+In progress, expected [Month Year]. [Relevant topics]
+}}
+```
+
+Any consistent form works: `In progress, expected <Month Year>.` / `Expected completion <Month Year>.` / a date field of `2025–present`.
+
+Claiming a credential not yet held is a factual misstatement, and it is the kind discovered at transcript or reference check rather than at interview. It costs nothing to prevent. The same applies to in-progress certifications and courses.
+
+**Check for agreement:** for a current student, the profile statement, the education entry, and any availability or work-permit note must all give the same completion date. Contradiction between them is worse than any single version.
+
 ### Professional Experience
 - Rewrite bullet points to emphasize aspects most relevant to the target role
 - Use 4-6 bullets for most recent role, 3-4 for previous, 2-3 for older
 - **Emphasize measurable results** where possible: "Reduced processing time by X%", "Model adopted by the team"
+
+#### Check tenure against visible output
+
+Before finalizing, look at each role the way a stranger will: **date span versus how much work is shown.** A two-year role represented by a single project reads as low output, whether or not that is fair. The reader cannot know what filled the time, so they guess, and the guess is unflattering.
+
+This bites hardest on **career changers** (part of the tenure went into learning the new field), on **long-cycle work** (industrial deployment, clinical or regulatory projects, research — one delivery genuinely takes quarters), and on anyone whose employer kept them on a single account or product.
+
+Three honest fixes, in order of preference:
+
+1. **Surface more real work.** Ask what else the period contained. There are often real secondary projects, internal tooling, or support work that never reached the CV because it felt minor. Best fix when the material exists.
+2. **Make the phases within the role explicit.** If the span genuinely had stages, say so — an initial period learning the domain or supporting the team, then ownership of the named work through to delivery. A phased arc reads as a growth curve; an undifferentiated multi-year block reads as stagnation.
+3. **Name what made the cycle long.** Data collection from a live environment, validation with domain experts, deployment and iteration against real output. Reviewers who know the domain accept this immediately.
+
+**Never** pad with invented projects, and **never** quietly shorten the employment dates so the ratio looks better. Both are discoverable, and both are worse than the perception problem being solved.
+
+**Prepare the interview answer too.** If a long span against little visible output survives these fixes, the question is coming. The candidate needs a ready two-part answer — what actually filled the time, and what the outcome was — recorded in their interview prep rather than improvised in the room.
 
 ### Handling Employment Gaps (Best Practice)
 If there is a gap in your employment history:


### PR DESCRIPTION
Third of the #199 split — the two `05` profile-accuracy rules, grouped as you suggested. One file, `05-cv-templates.md`.

## 1. In-progress qualifications must say so explicitly

A bare year range is not enough. An entry reading `2025–2026`, seen partway through 2026, reads as a **finished** degree — a skimming reader treats a closed range as closed. And a profile statement saying "currently completing…" does not fix it: the education entry is where a reader goes to check the credential, so it has to stand on its own.

Adds the LaTeX form (`In progress, expected <Month Year>.` inside the `\cventry`), notes that any consistent variant works, and adds an agreement check — profile statement, education entry, and any availability/work-permit note must give the **same** completion date, since a contradiction between them is worse than any single version.

The stakes are what make it worth a rule: claiming a credential not yet held is discovered at transcript or reference check, not at interview, and it costs nothing to prevent.

## 2. Check tenure against visible output

Before finalizing, look at each role the way a stranger will: date span versus how much work is shown. A two-year role represented by one project reads as low output whether or not that's fair — the reader can't know what filled the time, so they guess, and the guess is unflattering.

Hits hardest on career changers (part of the tenure went into learning the field), long-cycle work (industrial deployment, clinical, regulatory, research), and anyone whose employer kept them on a single account.

Three honest fixes, in preference order: surface more real work that never reached the CV; make the phases within the role explicit (a phased arc reads as a growth curve, an undifferentiated multi-year block reads as stagnation); name what made the cycle long.

And two explicit prohibitions, because they're the tempting fixes: **never** pad with invented projects, **never** quietly shorten the employment dates to improve the ratio. Both are discoverable, and both are worse than the perception problem they solve.

If the ratio survives all three fixes, the interview question is coming — so the rule sends the two-part answer (what filled the time, what the outcome was) to interview prep rather than leaving it to be improvised in the room.

`framework_version` 1.2.0 → 1.3.0, on top of the 1.2.0 currently on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)