### PR TITLE
fix(linkedin): default bare --remote flag to remote instead of silently ignoring it

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/cli.ts
+++ b/.agents/skills/linkedin-search/cli/src/cli.ts
@@ -36,6 +36,13 @@ function parseFlags(argv: string[]): Flags {
   return flags
 }
 
+/** Resolve a flag to a string: --flag "value" -> "value", bare --flag -> defaultValue */
+function stringFlag(raw: string | boolean | string[], defaultValue?: string): string | undefined {
+  if (typeof raw === "string") return raw
+  if (raw === true) return defaultValue
+  return undefined
+}
+
 const HELP = `linkedin-cli — search jobs on LinkedIn (any country/region, plus remote)
 
 USAGE
@@ -113,7 +120,7 @@ async function main(): Promise<number> {
       query: typeof flags.query === "string" ? flags.query : undefined,
       location,
       jobage: flags.jobage ? parseInt(flags.jobage as string, 10) : 9999,
-      remote: typeof flags.remote === "string" ? flags.remote : undefined,
+      remote: stringFlag(flags.remote, "remote"),
       page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
       limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,
       format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],

--- a/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
@@ -67,6 +67,20 @@ describe("LinkedIn CLI flag validation", () => {
     });
   });
 
+  describe("--remote flag", () => {
+    test("bare --remote (no value) defaults to 'remote', no error", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--remote", "--limit", "1"]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("BAD_ARG");
+    });
+
+    test("--remote hybrid passes through as string", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--remote", "hybrid", "--limit", "1"]);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).not.toBe("BAD_ARG");
+    });
+  });
+
   describe("existing validations (regression)", () => {
     test("missing --location exits 1 with NO_LOCATION", async () => {
       const result = await runCLI(["search"]);


### PR DESCRIPTION
When --remote is passed without a value (e.g. --remote with no argument), parseFlags sets flags.remote to true (boolean). The downstream check "typeof flags.remote === 'string'" rejects the boolean, making remote undefined and the flag is silently ignored — no f_WT parameter is sent, so the search returns all work types instead of only remote jobs.

## Root cause

Line 116 of cli.ts:

remote: typeof flags.remote === "string" ? flags.remote : undefined,

parseFlags sets bare flags (no value) to true, not a string. The type guard drops it.

## Fix

Adds a stringFlag helper (same pattern as freehire's cli.ts:57) that converts a bare boolean flag to the caller's default value:

function stringFlag(raw, defaultValue) {
  if (typeof raw === "string") return raw
  if (raw === true) return defaultValue
  return undefined
}

Used on line 116 as stringFlag(flags.remote, "remote") — bare --remote maps to "remote", --remote hybrid maps to "hybrid".

## Tests

Two new regression tests in cli-flag-validation.test.ts: bare --remote (no error) and --remote hybrid (passes through).

2 files, +16/-1 lines.

By @oscarbol09.