### PR TITLE
fix(jobnet): decode numeric HTML entities (decimal and hex) in stripHtml

### DIFF
--- a/.agents/skills/jobnet-search/cli/src/helpers.ts
+++ b/.agents/skills/jobnet-search/cli/src/helpers.ts
@@ -41,6 +41,15 @@ export function writeError(error: string, code: string): void {
   process.stderr.write(JSON.stringify({ error, code }) + "\n")
 }
 
+/**
+ * Convert a Unicode code point to a string. Uses `fromCodePoint` (not
+ * `fromCharCode`) so supplementary-plane code points (e.g. emoji, U+1F600)
+ * decode correctly, and drops out-of-range values instead of throwing.
+ */
+function numericEntity(cp: number): string {
+  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
+}
+
 export function stripHtml(html: string): string {
   return html
     .replace(/<[^>]*>/g, " ")
@@ -50,6 +59,8 @@ export function stripHtml(html: string): string {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
     .replace(/\s+/g, " ")
     .trim()
 }

--- a/.agents/skills/jobnet-search/cli/tests/detail-formatting.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/detail-formatting.test.ts
@@ -70,6 +70,26 @@ describe("formatDetailPlain", () => {
     expect(formatted).not.toContain("&amp;");
   });
 
+  test("decodes numeric HTML entities (decimal &#229; and hex &#xE5;)", () => {
+    const formatted = formatDetailPlain(
+      detail({ body: "<p>R&#229;dgivning &amp; &#xE5;rligt</p>" }),
+    );
+
+    expect(formatted).toContain("Rådgivning & årligt");
+    expect(formatted).not.toContain("&#229;");
+    expect(formatted).not.toContain("&#xE5;");
+  });
+
+  test("decodes supplementary-plane code points (&#128512;)", () => {
+    const formatted = formatDetailPlain(
+      detail({ body: "<p>Growth &#128512; &#x1F600;</p>" }),
+    );
+
+    expect(formatted).toContain("Growth 😀 😀");
+    expect(formatted).not.toContain("&#128512;");
+    expect(formatted).not.toContain("&#x1F600;");
+  });
+
   test("uses placeholders when optional city, deadline, and apply URL are absent", () => {
     const formatted = formatDetailPlain(
       detail({


### PR DESCRIPTION
stripHtml only decoded named entities (&amp;, &lt;, etc.) but not numeric character references like &#229; (decimal) or &#xE5; (hex). The other 5 portal CLIs (freehire, jobindex, linkedin, jobbank, jobdanmark) all handle both forms. Jobnet's API frequently uses numeric entities for Danish characters (æ, ø, å) and accents, so these appeared as raw &#NNN; codes in the output.

## Root cause

Lines 44-55 of helpers.ts: stripHtml had entity decoding for named entities only. No regex for &#(\d+); or &#[xX]([0-9a-fA-F]+);.

## Fix

Adds a numericEntity helper (with fromCodePoint and range guard — same as all other portals) and two regex replacements to stripHtml:

.replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
.replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))

## Tests

Three new tests in detail-formatting.test.ts: decimal entity (&#229; -> å), hex entity (&#xE5; -> å), and supplementary-plane emoji (&#128512; -> &#x1F600;).

2 files, +22/-2 lines.

By @oscarbol09.