### PR TITLE
fix(check_framework_version): handle CRLF line endings on Windows

### DIFF
--- a/tools/check_framework_version.py
+++ b/tools/check_framework_version.py
@@ -56,6 +56,7 @@ def parse_frontmatter(path: Path) -> dict:
     if not path.exists():
         return {}
     text = path.read_text(encoding="utf-8")
+    text = text.replace("\r\n", "\n")
     if not text.startswith("---\n"):
         return {}
     end = text.find("\n---", 4)


### PR DESCRIPTION
`parse_frontmatter()` hardcodes `\n` in `startswith`/`find` checks (lines 59, 61). On Windows, Git checks out files with CRLF line endings (`\r\n`), so every framework file fails frontmatter detection and is reported as missing `framework_version` — a constant false positive for Windows users.

**Root cause:** `text.startswith("---\n")` returns `False` when the file begins with `---\r\n`. The subsequent `text.find("\n---", 4)` also fails to locate the closing delimiter.

**Fix:** Normalize `\r\n` to `\n` at the start of `parse_frontmatter()` so the existing parsing logic works unchanged on all platforms. This is a one-line addition with no side effects — `\r\n` has no semantic meaning in frontmatter content.

**Verification:** Both LF and CRLF files now parse correctly:
- LF: `parse_frontmatter()` → `{'framework_version': '1.0.0'}`
- CRLF: `parse_frontmatter()` → `{'framework_version': '1.0.0'}`

**Scope:** Targets upstream `master` (`d88c023`). Independent of PRs #219 and #220.
