### PR TITLE
fix(jobbank): extract job ID from URL without trailing slug

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -157,8 +157,8 @@ export function parseRssDescription(desc: string): ParsedDescription {
 }
 
 export function extractJobIdFromUrl(url: string): string {
-  // URL format: https://jobbank.dk/job/{id}/{company-slug}/{title-slug}
-  const match = url.match(/\/job\/(\d+)\//)
+  // URL format: https://jobbank.dk/job/{id}[/{company-slug}/{title-slug}]
+  const match = url.match(/\/job\/(\d+)(?:\/|$)/)
   return match ? match[1] : ""
 }
 

--- a/.agents/skills/jobbank-search/cli/tests/rss-parsing.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/rss-parsing.test.ts
@@ -86,4 +86,8 @@ describe("extractJobIdFromUrl", () => {
     expect(extractJobIdFromUrl("https://jobbank.dk/job/12345/acme/role")).toBe("12345");
     expect(extractJobIdFromUrl("https://jobbank.dk/job/not-a-number/acme/role")).toBe("");
   });
+
+  test("extracts ID from URL without trailing slug segments", () => {
+    expect(extractJobIdFromUrl("https://jobbank.dk/job/12345")).toBe("12345");
+  });
 });


### PR DESCRIPTION
`extractJobIdFromUrl()` uses the regex `/\/job\/(\d+)\//` which requires a trailing slash after the numeric ID. URLs like `https://jobbank.dk/job/12345` (without `/company-slug/title-slug`) return `""`, causing downstream failures when the job ID is needed.

**Root cause:** The regex `\/job\/(\d+)\/` requires a `/` after the captured digits. Not all job listing URLs include slug segments.

**Fix:** Changed the regex to `/\/job\/(\d+)(?:\/|$)/` — the trailing slash is now optional, and end-of-string is accepted as a terminator.

**Test added:** `extracts ID from URL without trailing slug segments` — verifies that `https://jobbank.dk/job/12345` returns `"12345"`.

**Verification:**
```
with slug:  https://jobbank.dk/job/12345/acme/role  → "12345" (unchanged)
bare:       https://jobbank.dk/job/12345             → "12345" (was "")
non-numeric: https://jobbank.dk/job/abc              → "" (unchanged)
```
