### PR TITLE
docs(releases): tagged-release update path + sharpen the real-path verification bar (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Releases are vetted checkpoints of `master`. If you maintain a personalized fork,
+prefer updating to a tagged release over pulling raw `master` (see
+[SETUP.md, section 8](SETUP.md#8-pulling-upstream-updates-into-your-fork)). The
+`framework_version` markers on methodology files tell you which of your customized
+files a release touched; `python3 tools/check_upstream_updates.py` lists them with
+per-file diff commands.
+
+## [Unreleased]
+
+_Changes landed on `master` since the last release will be listed here._
+
+## [1.0.0] - 2026-07-22
+
+First tagged release. This marks the framework as stable and gives forks a described
+checkpoint to update against instead of a moving `master`. It is a baseline of what
+already exists rather than a set of new changes; subsequent releases will document
+what changed since the previous tag.
+
+At this baseline the framework provides:
+
+- **Application workflow** - a drafter/reviewer `/apply` pipeline (CV + cover letter),
+  plus `/setup`, `/scrape`, `/rank`, `/interview`, `/outcome`, `/upskill`,
+  `/expand`, `/html-report`, `/gmail-sync`, `/notion-sync`, `/add-portal`,
+  `/add-template`, and `/reset`.
+- **Portal search skills** - country-agnostic job-board CLIs (LinkedIn, freehire, and
+  the Danish boards) in the portable Agent Skills format under `.agents/skills/`,
+  discovered and orchestrated by `/scrape`, with an `enabled:` toggle for skipping
+  portals.
+- **Framework versioning** - `framework_version` markers on methodology files plus
+  `tools/check_framework_version.py` (CI guard) and `tools/check_upstream_updates.py`
+  (fork-side update preview).
+- **Privacy and safety guards** - `.gitignore` protection for personal data, the
+  `tools/security_guards.py` allowlist for `.gitignore` negations, and a CI policy of
+  making no live portal requests.
+- **Cross-runtime support** - a root `AGENTS.md` pointer so Codex and Antigravity can
+  discover the portable portal skills, with Claude Code as the reference runtime.
+
+[Unreleased]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/MadsLorentzen/ai-job-search/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ A new command therefore faces a high bar. The test that admitted the existing on
 Reviews here are empirical. Bug reports are reproduced on master before the fix is considered; "all tests green" is checked against whether the tests can distinguish master from the fix. PRs whose premise doesn't reproduce get declined even when the code is fine - it has happened ([#35]'s converter fix, [#52]'s first version). You can make this fast:
 
 - State the failing case and how to reproduce it.
+- **Reproduce on the real path, not a constructed input.** A test that fails on master and passes on the fix is necessary but not sufficient: the failing input has to be one the workflow actually produces, not one the test hand-builds. Show the failure through the path the code really runs - the documented CLI invocation, real portal output, an actual data file - not a synthetic value fed straight to the function. A fix whose only demonstration is an input the real code path never receives gets declined even though its test is green.
 - Put CLI tests in `.agents/skills/<name>/cli/tests/` (bun test, network-free where possible); Python tool tests in `tests/`.
 - Run what CI runs: `python3 tools/lint_skills.py`, `python3 tools/check_framework_version.py`, `bun run typecheck` in touched CLIs, and the relevant test suites.
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ To wipe your profile data and start fresh:
 
 `/reset` shows exactly what will be deleted and requires you to type `RESET` to confirm. Nothing is deleted until you do.
 
+### Staying up to date
+
+Upstream moves fast. Rather than pulling raw `master` and hoping, update your fork to a tagged [release](../../releases) - a vetted checkpoint described in [CHANGELOG.md](CHANGELOG.md). `python3 tools/check_upstream_updates.py` previews exactly which of your personalized files an update touches before you merge. Full walkthrough in [SETUP.md, section 8](SETUP.md#8-pulling-upstream-updates-into-your-fork).
+
 ## Tips for better results
 
 ### Profile depth matters

--- a/SETUP.md
+++ b/SETUP.md
@@ -288,6 +288,8 @@ These commands apply to the stock templates (moderncv CV, `cover.cls` cover lett
 
 Upstream keeps improving the methodology files your fork has personalized, so plan for updates from day one:
 
+**Prefer releases over raw `master`.** Tagged [releases](../../releases) are vetted checkpoints, each described in [CHANGELOG.md](CHANGELOG.md). Updating to a tag pulls a stable, documented state instead of whatever `master` happens to be mid-review. Fetch tags with `git fetch upstream --tags` and merge a release (for example `git merge v1.0.0`) when you want stability; pull `master` directly only when you specifically want the latest unreleased changes. The steps below apply either way - substitute the release tag for `upstream/master` where you see it.
+
 1. **Commit your personalization to your fork.** `/setup` edits CLAUDE.md and the profile skill files in place — those edits are *yours*, and your fork is private working space, so commit them. The genuinely sensitive files (tracker, salary data, `documents/`, application archives) are gitignored and never enter git either way. An uncommitted working tree is the most common reason `git pull` refuses to merge at all (`Your local changes ... would be overwritten`).
 2. **Preview what changed before pulling:**
    ```bash


### PR DESCRIPTION
Addresses #213 ("How to update?") and closes the verification loophole surfaced in the 2026-07-22 triage audit.

## Why

**#213:** the repo merges to `master` continuously with no release checkpoints, so a fork maintainer's only update path today is `git pull` into whatever mid-review state `master` happens to be in. This gives users a vetted, described checkpoint instead.

**The audit:** a batch of bug-fix PRs shipped tests that failed on master and passed on the fix, yet reproduced nothing real - the failing input was hand-built by the test and never occurs on the path the workflow runs. CONTRIBUTING's "Claims get verified" section already asked that tests "distinguish master from the fix," which those tests technically did. This sharpens the bar to close that gap.

## Changes

- **`CHANGELOG.md`** (new): Keep a Changelog + semver. `v1.0.0` is the first tagged baseline (a checkpoint of what already exists, not new features), plus an `Unreleased` section for going forward.
- **`SETUP.md` §8:** recommend updating to a tagged release over raw `master`; `git fetch upstream --tags` and merge a tag for stability.
- **`README.md`:** a short "Staying up to date" pointer to Releases, the CHANGELOG, and `check_upstream_updates.py`.
- **`CONTRIBUTING.md`:** sharpen "Claims get verified" - a green test that distinguishes master from the fix is necessary but not sufficient; the failing input must be one the workflow actually produces. Fixes demonstrated only through a synthetic input get declined even when their test is green.

## Not included (intentional)

The git tag / GitHub Release for `v1.0.0` is left for the maintainer to cut. Once it exists, the `[1.0.0]` and `[Unreleased]` compare links in the CHANGELOG resolve, and the reply to #213 can point at the Releases tab.

Docs only. `lint_skills.py` and `check_framework_version.py` both pass (no framework-versioned files touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)