### PR TITLE
fix(cli): pin @types/bun and @bunli/* to stop CI type-drift

### DIFF
--- a/.agents/skills/freehire-search/cli/package.json
+++ b/.agents/skills/freehire-search/cli/package.json
@@ -15,6 +15,6 @@
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14"
   }
 }

--- a/.agents/skills/jobbank-search/cli/package.json
+++ b/.agents/skills/jobbank-search/cli/package.json
@@ -13,13 +13,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bunli/core": "latest",
-    "@bunli/utils": "latest",
+    "@bunli/core": "0.9.1",
+    "@bunli/utils": "0.6.0",
     "node-html-parser": "^6.1.13",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.3.14",
     "typescript": "^5.4.0"
   }
 }

--- a/.agents/skills/jobdanmark-search/cli/package.json
+++ b/.agents/skills/jobdanmark-search/cli/package.json
@@ -13,13 +13,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bunli/core": "latest",
-    "@bunli/utils": "latest",
+    "@bunli/core": "0.9.1",
+    "@bunli/utils": "0.6.0",
     "node-html-parser": "^6.1.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14"
   }
 }

--- a/.agents/skills/jobindex-search/cli/package.json
+++ b/.agents/skills/jobindex-search/cli/package.json
@@ -13,13 +13,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bunli/core": "latest",
-    "@bunli/utils": "latest",
+    "@bunli/core": "0.9.1",
+    "@bunli/utils": "0.6.0",
     "node-html-parser": "^6.1.13",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14"
   }
 }

--- a/.agents/skills/jobnet-search/cli/package.json
+++ b/.agents/skills/jobnet-search/cli/package.json
@@ -13,12 +13,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@bunli/core": "latest",
-    "@bunli/utils": "latest",
+    "@bunli/core": "0.9.1",
+    "@bunli/utils": "0.6.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14"
   }
 }

--- a/.agents/skills/linkedin-search/cli/package.json
+++ b/.agents/skills/linkedin-search/cli/package.json
@@ -15,6 +15,6 @@
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/bun": "latest"
+    "@types/bun": "1.3.14"
   }
 }


### PR DESCRIPTION
## Why

CI runs `bun install` (not `--frozen-lockfile`), and every CLI's `package.json` pinned `@types/bun`, `@bunli/core`, and `@bunli/utils` to `"latest"`. So each fresh CI install could resolve a *different* version than the committed lockfile pins. When a `"latest"` `bun-types` resolved that didn't satisfy the tsconfig - `lib: ["ESNext"]` (no DOM) with `types: ["bun-types"]` as the sole source of `Response`/`URL`/`fetch` globals - `bun run typecheck` failed across every `.ts` file.

That produced a **transient red on PRs that never touched TypeScript**. Observed on #207, whose only change is `SKILL.md`: its jobdanmark typecheck job went red purely from a `bun-types` "latest" drift (a re-run of the same commit went green).

## What

Pin the three previously-floating dev/framework deps to the versions the lockfiles already resolve, so behavior is unchanged and the drift class is closed:

| dep | before | after | CLIs |
|---|---|---|---|
| `@types/bun` | `latest` | `1.3.14` | all 6 |
| `@bunli/core` | `latest` | `0.9.1` | jobbank, jobdanmark, jobindex, jobnet |
| `@bunli/utils` | `latest` | `0.6.0` | jobbank, jobdanmark, jobindex, jobnet |

The `^`-ranged deps (`node-html-parser`, `zod`, `typescript`) are left as-is - semver-guarded and not the cause. No lockfiles committed; `bun.lock` stays gitignored per existing policy.

## Verified

All 6 CLIs `bun install` and `bun run typecheck` clean with the pins (versions resolve identically to before). Diff is 6 `package.json` files, 14 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)