### PR TITLE
fix(convert_salary_excel): store standalone count columns as counts, not indexes

### DIFF
--- a/tests/test_convert_salary_excel.py
+++ b/tests/test_convert_salary_excel.py
@@ -169,6 +169,22 @@ class DetectColumnTypeTests(unittest.TestCase):
         self.assertEqual(categories["kvinder"], {"count": 15, "index": 95.0})
         self.assertEqual(categories["mænd"], {"count": 20, "index": 108.0})
 
+    def test_standalone_count_column_is_stored_as_count_not_index(self):
+        # A count column with no matching index column (e.g. a lone total
+        # headcount) is still count data. It must not be emitted as a salary
+        # index, which salary_lookup would render with a bogus "vs baseline"
+        # percentage. The paired category alongside it is unaffected.
+        ws = FakeWorksheet([
+            ("Company", "Antal", "IT Count", "IT Index"),
+            ("Example Corp", 250, 30, 108.5),
+        ])
+
+        companies = parse_sheet(ws)
+
+        categories = companies[0]["categories"]
+        self.assertEqual(categories["antal"], {"count": 250})
+        self.assertEqual(categories["it"], {"count": 30, "index": 108.5})
+
     def test_parse_sheet_non_adjacent_columns_no_cross_match(self):
         ws = FakeWorksheet([
             ("Company", "Count_A", "Count_B", "Index_A", "Index_B"),

--- a/tools/convert_salary_excel.py
+++ b/tools/convert_salary_excel.py
@@ -168,10 +168,14 @@ def parse_sheet(ws, sheet_label=None):
                 used_indexes.add(ii)
                 break
 
-    # Remaining unmatched count columns become standalone (use original header)
+    # Remaining unmatched count columns become standalone. They are still count
+    # data, so tag them as such — otherwise a lone headcount would be emitted as
+    # a salary index and rendered with a meaningless "vs baseline" percentage.
     for ci, (c_idx, c_header, _) in enumerate(count_cols):
         if ci not in used_counts:
-            categories.append({"name": c_header.lower().replace(" ", "_"), "value_col": c_idx})
+            categories.append(
+                {"name": c_header.lower().replace(" ", "_"), "value_col": c_idx, "field": "count"}
+            )
 
     # Remaining unmatched index columns become standalone (use original header)
     for ii, (i_idx, i_header, _) in enumerate(index_cols):
@@ -226,7 +230,8 @@ def parse_sheet(ws, sheet_label=None):
                         # Non-numeric standalone value (e.g. a free-text "Notes"
                         # column) is not salary data; skip it for this row.
                         continue
-                    entry["categories"][cat_name] = {"index": val}
+                    field = cat.get("field", "index")
+                    entry["categories"][cat_name] = {field: int(val) if field == "count" else val}
 
         companies.append(entry)
 


### PR DESCRIPTION
## Problem

When a count column has no matching index column to pair with — e.g. a lone total-headcount column (`Antal`) — `parse_sheet` appended it as an untyped standalone value column, and the row loop stored every standalone value under `"index"`:

```python
entry["categories"][cat_name] = {"index": val}
```

So a column that `detect_column_type` had already classified as a **count** was emitted as a salary **index**. `salary_lookup.format_entry` then rendered the raw headcount in the Index column with a meaningless "vs baseline" percentage:

```
Antal        -      250.0     +150.0%
```

## Fix

Tag unmatched count columns with `field="count"` and have the standalone-value branch honor it:

```python
field = cat.get("field", "index")
entry["categories"][cat_name] = {field: int(val) if field == "count" else val}
```

`int()` mirrors the existing paired-count branch. Standalone index columns and genuinely untyped columns still default to `"index"`, so their behavior is unchanged.

## Tests

Adds `test_standalone_count_column_is_stored_as_count_not_index` to `tests/test_convert_salary_excel.py` (a lone `Antal` count column is stored as `{"count": 250}`, and the paired `IT` category is unaffected). Full suite `python -m unittest discover -s tests -t .` → 132 passed.
