### PR TITLE
feat(tools): add check_upstream_commits.py for repo-wide fork drift awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ To wipe your profile data and start fresh:
 
 ### Staying up to date
 
-Upstream moves fast. Rather than pulling raw `master` and hoping, update your fork to a tagged [release](../../releases) - a vetted checkpoint described in [CHANGELOG.md](CHANGELOG.md). `python3 tools/check_upstream_updates.py` previews exactly which of your personalized files an update touches before you merge. Full walkthrough in [SETUP.md, section 8](SETUP.md#8-pulling-upstream-updates-into-your-fork).
+Upstream moves fast. Rather than pulling raw `master` and hoping, update your fork to a tagged [release](../../releases) - a vetted checkpoint described in [CHANGELOG.md](CHANGELOG.md). `python3 tools/check_upstream_updates.py` previews exactly which of your personalized files an update touches before you merge; `python3 tools/check_upstream_commits.py` lists every upstream commit you're missing, regardless of which files it touched. Full walkthrough in [SETUP.md, section 8](SETUP.md#8-pulling-upstream-updates-into-your-fork).
 
 ## Tips for better results
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -296,7 +296,7 @@ Upstream keeps improving the methodology files your fork has personalized, so pl
    git fetch upstream    # or origin, if you cloned the template directly
    python3 tools/check_upstream_updates.py
    ```
-   It compares the `framework_version` markers in your framework files against upstream and lists exactly which methodology files changed, with the diff command for each.
+   It compares the `framework_version` markers in your framework files against upstream and lists exactly which methodology files changed, with the diff command for each. This only covers the 9 methodology files under `.claude/skills/job-application-assistant/` — it won't tell you about changes elsewhere (portal CLIs, `tools/`, CI). For that, `python3 tools/check_upstream_commits.py` lists every upstream commit your fork doesn't have yet, regardless of which files it touched.
 3. **Merge normally.** `git merge upstream/master` (or `git pull`) three-way-merges upstream's edits around your personalization; because methodology edits rarely touch the lines `/setup` filled in, most updates land cleanly. A conflict in a personalized file is a *feature*, not a failure — it means upstream changed methodology in a section you customized, and the version marker plus its changelog commit tell you why. Resolve by keeping your data and adopting the methodology change around it.
 
 ## Troubleshooting

--- a/tools/check_upstream_commits.py
+++ b/tools/check_upstream_commits.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Report new upstream commits not yet in the current branch.
+
+Usage: python tools/check_upstream_commits.py [--remote upstream] [--branch master] [--limit 10] [--quiet-if-empty]
+
+Complements check_upstream_updates.py, which only tracks framework_version
+markers on the 9 methodology files under .claude/skills/job-application-assistant/.
+This script answers a different question: is my fork behind upstream at all,
+across tools/, .agents/skills/, tests/, CI, etc.? Fetches the given remote
+(bounded by a timeout so a flaky network never hangs the session) and prints
+the commit subjects reachable from <remote>/<branch> but not from HEAD.
+Report-only: never merges, rebases, or pulls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FETCH_TIMEOUT_SECONDS = 10
+
+
+def run_git(args: list[str], timeout: float | None = None) -> tuple[int, str, str]:
+    try:
+        res = subprocess.run(
+            ["git"] + args, cwd=str(ROOT), capture_output=True, text=True, timeout=timeout
+        )
+        return res.returncode, res.stdout, res.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", "timed out"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report new commits on an upstream remote.")
+    parser.add_argument("--remote", default="upstream", help="Remote name (default: upstream)")
+    parser.add_argument("--branch", default="master", help="Branch on the remote (default: master)")
+    parser.add_argument("--limit", type=int, default=10, help="Max commit subjects to print (default: 10)")
+    parser.add_argument(
+        "--quiet-if-empty", action="store_true", help="Print nothing when there are no new commits"
+    )
+    parser.add_argument("--no-fetch", action="store_true", help="Skip fetching from remote")
+    args = parser.parse_args()
+
+    rc, stdout, _ = run_git(["remote"])
+    remotes = stdout.splitlines()
+    if args.remote not in remotes:
+        if not args.quiet_if_empty:
+            print(f"[upstream-check] Remote '{args.remote}' not configured; skipping.")
+        return 0
+
+    if not args.no_fetch:
+        fetch_rc, _, fetch_err = run_git(
+            ["fetch", args.remote, args.branch], timeout=FETCH_TIMEOUT_SECONDS
+        )
+        if fetch_rc != 0:
+            if not args.quiet_if_empty:
+                print(f"[upstream-check] Could not fetch '{args.remote}': {fetch_err.strip()}")
+            return 0
+
+    ref = f"{args.remote}/{args.branch}"
+    rc, _, _ = run_git(["rev-parse", "--verify", ref])
+    if rc != 0:
+        if not args.quiet_if_empty:
+            print(f"[upstream-check] Ref '{ref}' not found after fetch; skipping.")
+        return 0
+
+    rc, current_branch, _ = run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+    current_branch = current_branch.strip() or "HEAD"
+
+    rc, log_out, _ = run_git(["log", f"HEAD..{ref}", "--oneline", "--no-merges"])
+    commits = [line for line in log_out.splitlines() if line.strip()]
+
+    if not commits:
+        if not args.quiet_if_empty:
+            print(f"[upstream-check] '{current_branch}' is up to date with {ref}.")
+        return 0
+
+    print(f"[upstream-check] {len(commits)} new commit(s) on {ref} not yet in '{current_branch}':")
+    for line in commits[: args.limit]:
+        print(f"  - {line}")
+    if len(commits) > args.limit:
+        print(f"  ... and {len(commits) - args.limit} more")
+    print(f"  (report only, not merged - see `git log HEAD..{ref} --oneline` or `git merge {ref}`)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`check_upstream_updates.py` answers "has the methodology changed?" — it only compares `framework_version` markers on the 9 files under `.claude/skills/job-application-assistant/`. It does not, and by design cannot, tell a fork maintainer whether they're behind upstream on `tools/`, `.agents/skills/` (portal CLIs), `tests/`, or CI.

**Reproduced concretely, not speculatively:** on a personal fork that was 6 commits behind `master` (job-scraper mass-posting detection #207, two `convert_salary_excel` bug fixes #219/#230, a CI type-drift pin fix #226, and doc updates), none of which touched the 9-file allowlist, `check_upstream_updates.py` reported:

```
[OK] All framework files are up to date with upstream!
```

...the entire time — including while a real bug fix to a tool the fork's own workflow depends on (`convert_salary_excel.py`) sat unmerged.

## What this adds

`tools/check_upstream_commits.py` — `git log HEAD..<remote>/<branch> --oneline`, scoped to whichever remote/branch you point it at, with:
- a bounded fetch timeout (10s) so a flaky connection can't hang a session
- `--quiet-if-empty` for scripting/hook use
- `--no-fetch` for offline/cached use
- report-only: never merges, rebases, or pulls

Mirrors `check_upstream_updates.py`'s CLI shape (`--remote`, `--branch`, `--no-fetch`) and is mentioned alongside it in `SETUP.md` step 8 and the README's "Staying up to date" section, framed explicitly as a complement, not a replacement.

## Scope note

Deliberately **not** included: wiring this as an automatic `SessionStart` hook. Auto-fetching on every session start is a bigger ask (network access + default execution for every fork user) than an opt-in command, and would require extending `security_guards.py`'s hook-checking, which doesn't exist yet since upstream ships zero hooks today. That's a second concern; keeping this PR to the standalone tool only, matching `check_upstream_updates.py`'s own shape.

## Test plan

- [x] `python tools/lint_skills.py` — OK (9 skills, 12 commands, settings.json)
- [x] `python tools/security_guards.py` — OK (untouched, no permission/hook changes)
- [x] `python -m unittest discover -s tests -t .` — all 132 existing tests pass
- [x] Manually verified both output paths (up-to-date silence with `--quiet-if-empty`, and commit listing) against a simulated ahead-of-HEAD ref
- [x] `--no-fetch` verified working

🤖 Assisted by [Claude Code](https://claude.com/claude-code)