### PR TITLE
chore(funding): add GitHub Sponsors button alongside Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: MadsLorentzen
 ko_fi: madslorentzen


### PR DESCRIPTION
## What

Adds `github: MadsLorentzen` to `.github/FUNDING.yml` above the existing Ko-fi entry.

## Why

The GitHub Sponsors profile for @MadsLorentzen is now live and accepting sponsorships. This lights up GitHub's native **"Sponsor this project"** box (repo sidebar + header button) with two links: GitHub Sponsors and Ko-fi.

The two channels have opposite friction profiles, so offering both widens the net rather than duplicating:
- **Ko-fi** - guest checkout, no account needed. Lowest friction for non-developers.
- **GitHub Sponsors** - one click for developers already logged into GitHub with a saved payment method.

## Scope / notes

- One-line change. No README edit: the existing Ko-fi coffee block and maintainer story are untouched; `FUNDING.yml` drives GitHub's native UI separately.
- No sponsor-gated features. Consistent with the project's anti-commercialization stance - this is a recognition/reach channel, not a revenue play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)