### PR TITLE
test(cli): pin the 429/5xx retry contract in all six portal CLIs

### DIFF
--- a/.agents/skills/freehire-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/freehire-search/cli/tests/retry-backoff.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiGet } from "../src/helpers";
+
+// The portal contract requires backoff on 429/5xx. These tests pin the retry
+// loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
+// fires immediately so the exhaustion case does not sleep through the real
+// 500ms -> 8s backoff schedule. apiGet's documented graceful-degradation
+// contract (connection failures fail fast, no retry) is pinned too.
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+function instantTimers() {
+  globalThis.setTimeout = ((fn: () => void) =>
+    originalSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+}
+
+function stubFetch(responses: Array<() => Response>): { calls: number } {
+  const state = { calls: 0 };
+  globalThis.fetch = (async () => {
+    const i = Math.min(state.calls, responses.length - 1);
+    state.calls++;
+    return responses[i]();
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+describe("apiGet retry/backoff", () => {
+  test("retries a 429 and succeeds on the next attempt", async () => {
+    instantTimers();
+    const state = stubFetch([
+      () => new Response("", { status: 429 }),
+      () => new Response('{"data":[]}', { status: 200 }),
+    ]);
+
+    const envelope = await apiGet<unknown[]>("/x");
+    expect(envelope).not.toBeNull();
+    expect(state.calls).toBe(2);
+  });
+
+  test("returns the documented null on 404 without retrying", async () => {
+    const state = stubFetch([() => new Response("", { status: 404 })]);
+
+    const envelope = await apiGet("/x");
+    expect(envelope).toBeNull();
+    expect(state.calls).toBe(1);
+  });
+
+  test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+    instantTimers();
+    const state = stubFetch([() => new Response("", { status: 500 })]);
+
+    await expect(apiGet("/x")).rejects.toThrow(/500/);
+    expect(state.calls).toBe(7);
+  });
+
+  test("fails fast on a connection error - no retry, per the graceful-degradation contract", async () => {
+    const state = { calls: 0 };
+    globalThis.fetch = (async () => {
+      state.calls++;
+      throw new TypeError("Unable to connect");
+    }) as unknown as typeof fetch;
+
+    await expect(apiGet("/x")).rejects.toThrow(/could not reach the freehire API/);
+    expect(state.calls).toBe(1);
+  });
+});

--- a/.agents/skills/jobbank-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/retry-backoff.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fetchWithUA } from "../src/helpers";
+
+// The portal contract requires backoff on 429/5xx. These tests pin the retry
+// loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
+// fires immediately so the exhaustion case does not sleep through the real
+// 500ms -> 5s backoff schedule.
+//
+// fetchWithUA deliberately RETURNS non-retry statuses instead of throwing -
+// callers own 4xx handling (e.g. rssFetch's Cloudflare 403 message). The 4xx
+// test pins that contract.
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+function instantTimers() {
+  globalThis.setTimeout = ((fn: () => void) =>
+    originalSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+}
+
+function stubFetch(responses: Array<() => Response>): { calls: number } {
+  const state = { calls: 0 };
+  globalThis.fetch = (async () => {
+    const i = Math.min(state.calls, responses.length - 1);
+    state.calls++;
+    return responses[i]();
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+describe("fetchWithUA retry/backoff", () => {
+  test("retries a 429 and succeeds on the next attempt", async () => {
+    instantTimers();
+    const state = stubFetch([
+      () => new Response("", { status: 429 }),
+      () => new Response("ok", { status: 200 }),
+    ]);
+
+    const response = await fetchWithUA("https://jobbank.dk/x");
+    expect(response.status).toBe(200);
+    expect(state.calls).toBe(2);
+  });
+
+  test("returns a plain 4xx to the caller without retrying", async () => {
+    const state = stubFetch([() => new Response("", { status: 403 })]);
+
+    const response = await fetchWithUA("https://jobbank.dk/x");
+    expect(response.status).toBe(403);
+    expect(state.calls).toBe(1);
+  });
+
+  test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+    instantTimers();
+    const state = stubFetch([() => new Response("", { status: 500 })]);
+
+    await expect(fetchWithUA("https://jobbank.dk/x")).rejects.toThrow(/500/);
+    expect(state.calls).toBe(7);
+  });
+});

--- a/.agents/skills/jobdanmark-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/retry-backoff.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch, apiPost } from "../src/helpers";
+
+// The portal contract requires backoff on 429/5xx. These tests pin the retry
+// loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
+// fires immediately so the exhaustion case does not sleep through the real
+// 500ms -> 5s backoff schedule. apiFetch and apiPost carry separate copies of
+// the loop, so both are exercised to keep them from drifting apart.
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+function instantTimers() {
+  globalThis.setTimeout = ((fn: () => void) =>
+    originalSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+}
+
+function stubFetch(responses: Array<() => Response>): { calls: number } {
+  const state = { calls: 0 };
+  globalThis.fetch = (async () => {
+    const i = Math.min(state.calls, responses.length - 1);
+    state.calls++;
+    return responses[i]();
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+const wrappers: Array<[string, () => Promise<{ ok: boolean }>]> = [
+  ["apiFetch", () => apiFetch<{ ok: boolean }>("/x")],
+  ["apiPost", () => apiPost<{ ok: boolean }>("/x", {})],
+];
+
+for (const [name, call] of wrappers) {
+  describe(`${name} retry/backoff`, () => {
+    test("retries a 429 and succeeds on the next attempt", async () => {
+      instantTimers();
+      const state = stubFetch([
+        () => new Response("", { status: 429 }),
+        () => new Response('{"ok":true}', { status: 200 }),
+      ]);
+
+      const data = await call();
+      expect(data.ok).toBe(true);
+      expect(state.calls).toBe(2);
+    });
+
+    test("does not retry a plain 4xx", async () => {
+      const state = stubFetch([() => new Response("", { status: 400 })]);
+
+      await expect(call()).rejects.toThrow(/400/);
+      expect(state.calls).toBe(1);
+    });
+
+    test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+      instantTimers();
+      const state = stubFetch([() => new Response("", { status: 500 })]);
+
+      await expect(call()).rejects.toThrow(/500/);
+      expect(state.calls).toBe(7);
+    });
+  });
+}

--- a/.agents/skills/jobindex-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/retry-backoff.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { htmlFetch } from "../src/helpers";
+import { apiFetch, htmlFetch } from "../src/helpers";
 
 // The portal contract requires backoff on 429/5xx. These tests pin the retry
 // loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
 // fires immediately so the exhaustion case does not sleep through the real
-// 500ms -> 5s backoff schedule.
+// 500ms -> 5s backoff schedule. apiFetch and htmlFetch carry separate copies
+// of the loop, so both are exercised to keep them from drifting apart.
 
 const originalFetch = globalThis.fetch;
 const originalSetTimeout = globalThis.setTimeout;
@@ -54,6 +55,35 @@ describe("htmlFetch retry/backoff", () => {
     const state = stubFetch([() => new Response("", { status: 500 })]);
 
     await expect(htmlFetch("https://www.jobindex.dk/x")).rejects.toThrow(/500/);
+    expect(state.calls).toBe(7);
+  });
+});
+
+describe("apiFetch retry/backoff", () => {
+  test("retries a 429 and succeeds on the next attempt", async () => {
+    instantTimers();
+    const state = stubFetch([
+      () => new Response("", { status: 429 }),
+      () => new Response('{"ok":true}', { status: 200 }),
+    ]);
+
+    const data = await apiFetch<{ ok: boolean }>("/x");
+    expect(data.ok).toBe(true);
+    expect(state.calls).toBe(2);
+  });
+
+  test("does not retry a plain 4xx", async () => {
+    const state = stubFetch([() => new Response("", { status: 400 })]);
+
+    await expect(apiFetch("/x")).rejects.toThrow(/400/);
+    expect(state.calls).toBe(1);
+  });
+
+  test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+    instantTimers();
+    const state = stubFetch([() => new Response("", { status: 500 })]);
+
+    await expect(apiFetch("/x")).rejects.toThrow(/500/);
     expect(state.calls).toBe(7);
   });
 });

--- a/.agents/skills/jobindex-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/retry-backoff.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { htmlFetch } from "../src/helpers";
+
+// The portal contract requires backoff on 429/5xx. These tests pin the retry
+// loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
+// fires immediately so the exhaustion case does not sleep through the real
+// 500ms -> 5s backoff schedule.
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+function instantTimers() {
+  globalThis.setTimeout = ((fn: () => void) =>
+    originalSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+}
+
+function stubFetch(responses: Array<() => Response>): { calls: number } {
+  const state = { calls: 0 };
+  globalThis.fetch = (async () => {
+    const i = Math.min(state.calls, responses.length - 1);
+    state.calls++;
+    return responses[i]();
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+describe("htmlFetch retry/backoff", () => {
+  test("retries a 429 and succeeds on the next attempt", async () => {
+    instantTimers();
+    const state = stubFetch([
+      () => new Response("", { status: 429 }),
+      () => new Response("<html>ok</html>", { status: 200 }),
+    ]);
+
+    const html = await htmlFetch("https://www.jobindex.dk/x");
+    expect(html).toContain("ok");
+    expect(state.calls).toBe(2);
+  });
+
+  test("does not retry a plain 4xx", async () => {
+    const state = stubFetch([() => new Response("", { status: 400 })]);
+
+    await expect(htmlFetch("https://www.jobindex.dk/x")).rejects.toThrow(/400/);
+    expect(state.calls).toBe(1);
+  });
+
+  test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+    instantTimers();
+    const state = stubFetch([() => new Response("", { status: 500 })]);
+
+    await expect(htmlFetch("https://www.jobindex.dk/x")).rejects.toThrow(/500/);
+    expect(state.calls).toBe(7);
+  });
+});

--- a/.agents/skills/jobnet-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/retry-backoff.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch } from "../src/helpers";
+
+// The portal contract requires backoff on 429/5xx. These tests pin the retry
+// loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
+// fires immediately so the exhaustion case does not sleep through the real
+// 500ms -> 5s backoff schedule.
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+function instantTimers() {
+  globalThis.setTimeout = ((fn: () => void) =>
+    originalSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+}
+
+function stubFetch(responses: Array<() => Response>): { calls: number } {
+  const state = { calls: 0 };
+  globalThis.fetch = (async () => {
+    const i = Math.min(state.calls, responses.length - 1);
+    state.calls++;
+    return responses[i]();
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+describe("apiFetch retry/backoff", () => {
+  test("retries a 429 and succeeds on the next attempt", async () => {
+    instantTimers();
+    const state = stubFetch([
+      () => new Response("", { status: 429 }),
+      () => new Response('{"ok":true}', { status: 200 }),
+    ]);
+
+    const data = await apiFetch<{ ok: boolean }>("/x");
+    expect(data.ok).toBe(true);
+    expect(state.calls).toBe(2);
+  });
+
+  test("does not retry a plain 4xx", async () => {
+    const state = stubFetch([() => new Response("", { status: 400 })]);
+
+    await expect(apiFetch("/x")).rejects.toThrow(/400/);
+    expect(state.calls).toBe(1);
+  });
+
+  test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+    instantTimers();
+    const state = stubFetch([() => new Response("", { status: 500 })]);
+
+    await expect(apiFetch("/x")).rejects.toThrow(/500/);
+    expect(state.calls).toBe(7);
+  });
+});

--- a/.agents/skills/linkedin-search/cli/tests/retry-backoff.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/retry-backoff.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { htmlFetch } from "../src/helpers";
+
+// The portal contract requires backoff on 429/5xx. These tests pin the retry
+// loop offline: a stubbed fetch counts attempts, and a stubbed setTimeout
+// fires immediately so the exhaustion case does not sleep through the real
+// 500ms -> 8s backoff schedule.
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
+
+function instantTimers() {
+  globalThis.setTimeout = ((fn: () => void) =>
+    originalSetTimeout(fn, 0)) as unknown as typeof setTimeout;
+}
+
+function stubFetch(responses: Array<() => Response>): { calls: number } {
+  const state = { calls: 0 };
+  globalThis.fetch = (async () => {
+    const i = Math.min(state.calls, responses.length - 1);
+    state.calls++;
+    return responses[i]();
+  }) as unknown as typeof fetch;
+  return state;
+}
+
+describe("htmlFetch retry/backoff", () => {
+  test("retries a 429 and succeeds on the next attempt", async () => {
+    instantTimers();
+    const state = stubFetch([
+      () => new Response("", { status: 429 }),
+      () => new Response("<html>ok</html>", { status: 200 }),
+    ]);
+
+    const html = await htmlFetch("https://www.linkedin.com/x");
+    expect(html).toContain("ok");
+    expect(state.calls).toBe(2);
+  });
+
+  test("returns the documented empty string on 404 without retrying", async () => {
+    const state = stubFetch([() => new Response("", { status: 404 })]);
+
+    const html = await htmlFetch("https://www.linkedin.com/x");
+    expect(html).toBe("");
+    expect(state.calls).toBe(1);
+  });
+
+  test("gives up after the initial attempt plus six retries on persistent 5xx", async () => {
+    instantTimers();
+    const state = stubFetch([() => new Response("", { status: 500 })]);
+
+    await expect(htmlFetch("https://www.linkedin.com/x")).rejects.toThrow(/500/);
+    expect(state.calls).toBe(7);
+  });
+});


### PR DESCRIPTION
## The gap

The portal-skill contract requires backoff on 429/5xx, and all six CLIs implement it — a retry loop with exponential delay and jitter in each fetch wrapper. But nothing verifies the loops actually retry, stop retrying on plain 4xx, or give up after the documented attempt budget. A regression here is invisible in normal use: a CLI that silently stops retrying still works on every healthy request and only misbehaves under rate-limiting, exactly when nobody is watching. This completes the fetch-layer coverage that #197's `request-timeout.test.ts` started, using the same pattern (import the wrapper, stub `globalThis.fetch`, restore after).

## What's covered

Each CLI gains a network-free `tests/retry-backoff.test.ts` with three assertions per fetch wrapper, adapted to each CLI's documented semantics rather than assumed ones:

- **a 429 is retried** and the next attempt's result is returned (fetch called exactly twice)
- **a plain 4xx is not retried** — pinned per-CLI: jobbank's `fetchWithUA` *returns* the response for callers to handle (the contract behind rssFetch's Cloudflare 403 message), linkedin's `htmlFetch` returns `""` on 404, freehire's `apiGet` returns `null` on 404, the rest throw
- **persistent 5xx gives up after the initial attempt plus six retries** (exactly 7 fetch calls) with the status in the error

Extras where the code has extra surface: freehire also pins its documented graceful-degradation contract (a connection failure fails fast, no retry — one fetch call); jobdanmark exercises **both** `apiFetch` and `apiPost`, which carry separate copies of the loop that could drift apart.

## Why the tests are fast

The exhaustion case would otherwise sleep through the real 500ms → 5s/8s backoff schedule (~17s per wrapper). The tests stub `globalThis.setTimeout` to fire immediately (restored in `afterEach`, same discipline as the fetch stub), so each CLI's suite runs in tens of milliseconds.

## Tests distinguish master from a regression

Mutation-checked rather than asserted: changing `maxRetries` from 6 to 2 in jobindex's helper makes the exhaustion test fail (calls=3 ≠ 7), then reverted. The suite catches a silently altered retry budget, not just a deleted loop.

## Verification

- `bun test` green in all six CLIs: jobindex 19, jobnet 20, jobbank 20, jobdanmark 21, linkedin 21, freehire 31 — 0 fail (full suites, not just the new files)
- `bun run typecheck` (`tsc --noEmit`) clean in all six
- `python3 tools/lint_skills.py`: OK