### PR TITLE
feat(firecrawl-search): add metered web job search

### DIFF
--- a/.agents/skills/firecrawl-search/SKILL.md
+++ b/.agents/skills/firecrawl-search/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: firecrawl-search
+version: 1.0.0
+description: >
+  Use this skill to find job postings on job boards that have no dedicated portal
+  skill yet — any board, any country, any language — by searching the live web with
+  Firecrawl and reading a posting's full text. It needs no per-portal HTML parser, so
+  it is the fallback when a market's board is unsupported, when a shipped portal
+  skill has broken on a markup change, or when a posting URL needs to be read in
+  full. The hosted API requires FIRECRAWL_API_KEY and is metered per result; a
+  self-hosted FIRECRAWL_API_URL may be keyless. Invoke this skill directly rather
+  than through /scrape. Trigger phrases:
+  search the web for jobs, find jobs on <job board>, jobs in <country> without a
+  portal skill, read this job posting URL, scrape this job ad, my portal skill is
+  broken find jobs anyway.
+context: fork
+enabled: false # deliberate: a metered per-result source must not run unattended in /scrape - see "Why this stays out of /scrape"
+allowed-tools: Bash(bun run .agents/skills/firecrawl-search/cli/src/cli.ts *)
+---
+
+# Firecrawl Search Skill
+
+Find job postings anywhere on the web via **[Firecrawl](https://docs.firecrawl.dev)**
+and read a single posting in full. Where the other portal skills each target one
+board with its own parser, this one targets **the web**: Firecrawl runs the search
+and extracts the job fields from each posting page, so a single skill covers any
+board in any market and language with **no markup anchors to maintain**.
+
+> This is a country-agnostic worked example of the repo's job-portal-skill pattern,
+> like `linkedin-search` and `freehire-search`. Unlike both, it is **not** tied to a
+> single site — the board is chosen per query with `--site` — and unlike either, it
+> requires an API key when using the hosted service.
+
+## ⚠️ Credentialed and metered — invoke it directly, not via `/scrape`
+
+Every other portal skill in this repo is credential-free and free to run. **The
+hosted version of this one is neither.** It needs `FIRECRAWL_API_KEY` (get one at
+[firecrawl.dev](https://firecrawl.dev)) and every result costs credits:
+
+```bash
+export FIRECRAWL_API_KEY="fc-..."
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q "data engineer job opening" --limit 5
+```
+
+**Measured credit cost** (from live runs; `meta.credits_used` reports the real figure
+every time):
+
+| Call | Cost |
+|------|------|
+| Plain search (`--no-enrich`) | **2 × ceil(limit / 10)** — 2 at `--limit 10`, 4 at `--limit 15` |
+| Enriched search (default) | search cost above + **~5 per successfully enriched result** — ~27 at `--limit 5`, **~104 at `--limit 20`** when every result is enriched |
+| `detail <url>` | one scrape + extraction, ~5 |
+
+### Why this stays out of `/scrape`
+
+`/scrape` has no notion of a metered source. Step 1b runs **every enabled portal**
+as a co-equal primary for several query categories at ~20 results each — so flipping
+`enabled: true` would silently make this the most expensive part of a routine run:
+roughly **100 credits per query**, i.e. several hundred per `/scrape`. That is not a
+sensible default for a source whose free tier is measured in hundreds of credits
+total.
+
+So `enabled: false` here is **not** "enable me once you have a key" — it is the
+intended steady state. Use this skill the way you'd use a generalist tool: **invoke
+it directly** when you need it, with a small `--limit` you have chosen. It still
+triggers by name from its description, and `detail <url>` works on a posting URL from
+*any* source, including another portal whose own `detail` has broken.
+
+If you do enable it for `/scrape`, do it knowingly: cap `--limit` hard and expect a
+recurring per-run bill. A `fallback`-tier source that `/scrape` reaches for only after
+an unsupported or failed portal — with a visible per-run credit budget — would be the
+right way to automate this, and does not exist in the framework today.
+
+Without a key (and without a self-hosted `FIRECRAWL_API_URL`) every command exits `1`
+with `NO_API_KEY` on stderr, so nothing runs up a bill by accident.
+
+## ℹ️ Hosted-service dependency
+
+This skill depends on the hosted Firecrawl API. If it is unreachable the CLI fails
+gracefully — a non-zero exit with a clear message — so an outage degrades this source
+rather than breaking the surrounding workflow. Firecrawl is also self-hostable
+([open source](https://github.com/firecrawl/firecrawl)); the skill honors a base-URL
+env var, `FIRECRAWL_API_URL` (default `https://api.firecrawl.dev`). A self-hosted
+instance runs **unauthenticated by default**, so no key is required when
+`FIRECRAWL_API_URL` is set — and running your own instance is also how you avoid the
+credit costs above entirely:
+
+```bash
+FIRECRAWL_API_URL=http://localhost:3002 bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q "data engineer job"
+```
+
+If your self-host *does* require a key, set `FIRECRAWL_API_KEY` as well and it is sent
+to that instance. Note the corollary: whenever a key is set it goes to whatever
+`FIRECRAWL_API_URL` names, so don't point it at a host you don't trust with your
+cloud key.
+
+## When to use this skill
+
+- Your market's job board has **no portal skill** and you have not built one with
+  `/add-portal` yet
+- A shipped portal skill has gone **degraded or broken** on a markup change (see
+  `/scrape health`) and you still want coverage of that board today
+- You want to sweep **several boards at once** by domain rather than one at a time
+- You have a **posting URL** and want its full text, deadline, and employment type
+
+For a board that you search regularly, a dedicated `/add-portal` skill is still the
+better tool: it is free, faster, and needs no key. This skill is the generalist.
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q "<keywords>" [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q <text>` — **required.** Keywords. Google-style operators
+  work: `"exact phrase"`, `-exclude`, `inurl:`, `site:`.
+- `--site <domains>` — restrict to these boards (comma-separated, repeatable), e.g.
+  `--site jobs.lever.co,job-boards.greenhouse.io`. Maps to `includeDomains`.
+- `--exclude-site <domains>` — drop these domains instead. **Mutually exclusive**
+  with `--site` (the API rejects both; the CLI catches it before spending credits).
+- `--country <code>` — ISO-3166 alpha-2 search locale, e.g. `--country DK`. Default `US`.
+- `--location <place>` / `-l <place>` — geo-target the results, e.g. `--location "Berlin,Germany"`.
+- `--jobage <days>` — search-freshness hint, **not** a posting-date filter. See **Notes**.
+- `--page <n>` — 1-indexed page. Default 1.
+- `--limit <n>` / `-n <n>` — results per page. Default 10; `page × limit` must be ≤ 100.
+- `--no-enrich` — skip per-result extraction. Much cheaper and faster, but
+  `company`, `location`, and `date` come back `null`.
+- `--format json|table|plain` — default `json`.
+
+### Fetch full job detail
+
+```bash
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts detail <url> [--format json|plain]
+```
+
+`<url>` is a posting URL — a search result's `id` **is** its URL, so it can be passed
+straight through. Returns the posting text as markdown plus the extracted company,
+location, posting date, employment type, and application deadline.
+
+## Usage examples
+
+```bash
+# Data engineering roles across the big ATS boards, last 30 days
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q "data engineer job opening" --site job-boards.greenhouse.io,jobs.lever.co,jobs.ashbyhq.com --jobage 30 --limit 5 --format table
+
+# A market with no portal skill yet: Germany, in German
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q "Stellenangebot Datenanalyst bewerben" --country DE --location "Germany" --limit 5 --format table
+
+# Cheap, wide sweep for URLs only (4 credits at --limit 20)
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q '"machine learning engineer" remote apply' --no-enrich --limit 20
+
+# Everything except one noisy aggregator
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts search -q "geophysicist vacancy" --exclude-site indeed.com --limit 5 --format table
+
+# Read one posting in full
+bun run .agents/skills/firecrawl-search/cli/src/cli.ts detail https://job-boards.greenhouse.io/acme/jobs/123 --format plain
+```
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing a result's `id` (its URL) to `detail` |
+| `table` | Quick human-readable scanning |
+| `plain` | Reading a single posting's full detail (`detail` command) |
+
+Search JSON is `{ "meta": { "count", "page", "total", "enriched", "credits_used" }, "results": [...] }`;
+each result carries at least `id` (the posting URL), `title`, `company`, `location`,
+`date`, and `url` (missing values are `null`, never omitted), plus a `snippet`. All
+errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the
+process exits with code `1`.
+
+## Write the query like a job search, not a keyword
+
+This searches **the whole web**, so an unqualified role name finds reference pages
+rather than vacancies — `-q "geophysicist"` returns Wikipedia and a careers-advice
+page. Two habits fix it, and the CLI deliberately does **not** apply them for you
+(it never rewrites your query behind your back):
+
+- **State the intent**: `"geophysicist job opening apply"`, `"Stellenangebot ..."`,
+  `"ledige stillinger ..."` — in the market's own language.
+- **Scope the domains**: `--site` with the boards you actually want. ATS domains
+  (`job-boards.greenhouse.io`, `jobs.lever.co`, `jobs.ashbyhq.com`, `*.workday.com`)
+  resolve to individual postings; large aggregators often rank their **search-results
+  pages** instead, so `--site jobindex.dk` can return `/jobsoegning?q=...` listing
+  URLs rather than single ads. Add `inurl:` to bias toward posting paths, or prefer a
+  dedicated `/add-portal` skill for such a board.
+
+## Notes
+
+- **`--jobage` does not honor the contract's posting-age semantics.** It maps to
+  Firecrawl's `tbs` parameter, which filters on the **search engine's freshness
+  signal for the page** — not on the posting's `date_posted`, which is only extracted
+  afterwards, per result. It is therefore a *hint*, and a lossy one in both
+  directions: it can return postings older than N days, and it can miss recent ones
+  whose page the index dates differently. It is also bucketed
+  (hour/day/week/month/year), so `--jobage 14` requests the **month** bucket. When
+  posting age actually matters, filter on the extracted `date` field downstream
+  rather than trusting this flag.
+- **`--page` re-fetches.** Firecrawl search has no offset parameter, so page N is
+  served by requesting `page × limit` results and returning the last window. Page 1
+  (the common case) fetches exactly what it needs; deeper pages cost proportionally
+  more.
+- **Extraction is model-based, so treat fields as best-effort.** `company` and
+  `location` land reliably on real posting pages; `date` is often absent because many
+  boards do not publish one. A `date` the page states in a non-ISO form (e.g.
+  "3 days ago") is kept **verbatim** rather than converted to a guessed calendar date.
+- `id` in search results is the posting **URL** — pass it as-is to `detail`.
+- Results whose URL cannot be resolved are dropped rather than emitted with a
+  placeholder.
+- The API retries 429/5xx with exponential backoff and jitter; a `401`/`403` fails
+  immediately with a key-specific message instead of retrying.
+- Endpoints, parameters, and response shapes are documented in `url-reference.md` —
+  that is the file to update if the Firecrawl API changes.

--- a/.agents/skills/firecrawl-search/cli/README.md
+++ b/.agents/skills/firecrawl-search/cli/README.md
@@ -1,0 +1,108 @@
+# firecrawl-cli
+
+CLI for finding job postings on **any** job board, in any market and language, via
+the [Firecrawl](https://docs.firecrawl.dev) v2 REST API — and for reading a single
+posting in full. There is no per-portal HTML parser: Firecrawl extracts the job
+fields from each posting page, so nothing here breaks when a board changes its markup.
+
+**Data source**: the Firecrawl v2 REST API (`POST /v2/search`, `POST /v2/scrape`).
+**Authentication**: `FIRECRAWL_API_KEY` ([get one](https://firecrawl.dev)) for the
+hosted API; not required against a self-hosted `FIRECRAWL_API_URL`.
+**Dependencies**: zero runtime dependencies (plain `fetch`, no SDK); dev types only.
+
+> **Credentialed and metered.** Unlike the other portal CLIs in this repo, this one
+> needs an API key and spends credits per result. Measured live: a plain search
+> (`--no-enrich`) costs **2 × ceil(limit / 10)**, and enrichment adds **~5 per
+> successfully enriched result** — so `--limit 20` costs ~104 when every result
+> is enriched.
+> `meta.credits_used` reports the real figure on every run.
+>
+> The skill therefore ships `enabled: false` **as its steady state**, not as a
+> pending opt-in: `/scrape` has no metered-source tier, and would run this as a
+> co-equal primary at ~20 results across several queries. Invoke it directly with a
+> `--limit` you have chosen. See `../SKILL.md` for the full rationale.
+>
+> Without a key (and without a self-hosted URL) every command exits `1` with
+> `NO_API_KEY` on stderr, so nothing bills by accident.
+
+## Installation
+
+```bash
+cd .agents/skills/firecrawl-search/cli && bun install
+```
+
+The install is optional — the CLI has no runtime dependencies and runs with plain
+`bun`; `bun install` only pulls TypeScript dev types for `bun run typecheck`.
+
+## Self-hosting / base URL
+
+Firecrawl is [open source](https://github.com/firecrawl/firecrawl). Point the CLI at
+your own instance with `FIRECRAWL_API_URL` (default `https://api.firecrawl.dev`). A
+self-hosted instance runs unauthenticated by default, so **no key is needed** — and
+no credits are spent:
+
+```bash
+FIRECRAWL_API_URL=http://localhost:3002 bun run src/cli.ts search -q "data engineer job"
+```
+
+If your instance does require a key, set `FIRECRAWL_API_KEY` too and it is sent
+there. Whenever a key is set it goes to whatever `FIRECRAWL_API_URL` names, so don't
+point it at a host you don't trust with your cloud key.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `search` | Search the web for job postings, optionally scoped to given job-board domains |
+| `detail <url>` | Scrape one posting: full text as markdown plus the extracted fields |
+
+`search` accepts `--format json|table|plain` (default `json`); `detail` accepts
+`--format json|plain`. A search result's `id` is its URL, so it can be passed
+straight to `detail`.
+
+All errors go to **stderr** as `{ "error": "...", "code": "..." }` with exit code `1`.
+
+## Quick examples
+
+```bash
+# Data engineering roles across the big ATS boards, last 30 days
+bun run src/cli.ts search -q "data engineer job opening" --site job-boards.greenhouse.io,jobs.lever.co --jobage 30 --limit 5 --format table
+
+# A market with no portal skill yet: Germany, in German
+bun run src/cli.ts search -q "Stellenangebot Datenanalyst bewerben" --country DE --limit 5 --format table
+
+# Cheap, wide sweep for URLs only (4 credits at --limit 20; no company/location/date)
+bun run src/cli.ts search -q '"machine learning engineer" remote apply' --no-enrich --limit 20
+
+# Read one posting in full
+bun run src/cli.ts detail https://job-boards.greenhouse.io/acme/jobs/123 --format plain
+```
+
+See `../SKILL.md` for the full flag reference, the credit-cost breakdown, and query
+advice; `../url-reference.md` documents the API shapes this CLI depends on.
+
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--query <text>` | `-q` | **Required.** Keywords; supports `""`, `-`, `inurl:`, `intitle:` operators |
+| `--site <domains>` | | Restrict to these boards (comma-separated, repeatable) |
+| `--exclude-site <domains>` | | Drop these domains; mutually exclusive with `--site` |
+| `--country <code>` | | ISO-3166 alpha-2 search locale (default `US`) |
+| `--location <place>` | `-l` | Geo-target the results, e.g. `"Berlin,Germany"` |
+| `--jobage <days>` | | Search-freshness hint, bucketed to day/week/month/year — **not** a filter on the posting date |
+| `--page <n>` | | 1-indexed page, default 1 (re-fetches; search has no offset param) |
+| `--limit <n>` | `-n` | Results per page, default 10; `page × limit` must be ≤ 100 |
+| `--no-enrich` | | Skip per-result extraction: cheap and fast, but no company/location/date |
+| `--format <fmt>` | | `json` (default), `table`, or `plain` |
+
+Because this searches the whole web, an unqualified role name finds reference pages
+rather than vacancies. State the intent in the query ("... job opening apply", or the
+market's own phrasing) and scope `--site` to boards you want; the CLI never rewrites
+your query for you. See the query section in `../SKILL.md`.
+
+## Tests
+
+```bash
+bun test        # network-free: unit tests plus mocked-fetch command tests
+```

--- a/.agents/skills/firecrawl-search/cli/package.json
+++ b/.agents/skills/firecrawl-search/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "firecrawl-cli",
+  "version": "1.0.0",
+  "description": "CLI for searching job postings on any job board via the Firecrawl v2 REST API — no per-portal parser, zero runtime dependencies. The hosted API requires FIRECRAWL_API_KEY; FIRECRAWL_API_URL may name a keyless self-host.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "firecrawl-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "1.3.14"
+  }
+}

--- a/.agents/skills/firecrawl-search/cli/src/cli.ts
+++ b/.agents/skills/firecrawl-search/cli/src/cli.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env bun
+// Self-contained CLI for searching job postings via the Firecrawl v2 REST API.
+// No external CLI framework and zero runtime dependencies (no SDK — plain
+// `fetch`), so it runs anywhere `bun` is available with nothing installed beyond
+// the repo clone.
+//
+// Credentialed hosted source: the cloud API needs FIRECRAWL_API_KEY. A self-hosted
+// FIRECRAWL_API_URL may be keyless. Without either, every command exits 1 with a
+// NO_API_KEY error, so /scrape degrades this source instead of breaking the run.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+import { NO_API_KEY_MESSAGE, baseUrl, normalizeDomain, requiresApiKey } from "./helpers.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+// Short-flag aliases.
+const ALIAS: Record<string, string> = { q: "query", n: "limit", l: "location" }
+
+// Flags that may repeat; each occurrence is collected instead of last-wins.
+const REPEATABLE = new Set(["site", "exclude-site"])
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (!a.startsWith("-")) {
+      ;(flags._ as string[]).push(a)
+      continue
+    }
+    const name = a.replace(/^-+/, "")
+    const key = ALIAS[name] ?? name
+    const next = argv[i + 1]
+    // A flag with no following value (or another flag next) is a boolean.
+    let value: string | boolean = true
+    if (next !== undefined && !next.startsWith("-")) {
+      value = next
+      i++
+    }
+    if (REPEATABLE.has(key)) {
+      const acc = Array.isArray(flags[key]) ? (flags[key] as string[]) : []
+      if (typeof value === "string") acc.push(value)
+      flags[key] = acc
+    } else {
+      flags[key] = value
+    }
+  }
+  return flags
+}
+
+type FlagValue = string | boolean | string[] | undefined
+
+function stringFlag(raw: FlagValue): string | undefined {
+  return typeof raw === "string" ? raw : undefined
+}
+
+/** Split comma-separated and repeated values into one trimmed hostname list. */
+function domainList(raw: FlagValue): string[] {
+  const parts = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : []
+  return parts
+    .flatMap((p) => p.split(","))
+    .map(normalizeDomain)
+    .filter((d): d is string => d !== null)
+}
+
+const HELP = `firecrawl-cli — search job postings anywhere on the web via Firecrawl
+
+USAGE
+  bun run src/cli.ts search -q "<keywords>" [--site <domains>] [--format json|table|plain]
+  bun run src/cli.ts detail <url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>      Keywords (required). Supports search operators, e.g.
+                          "data engineer" -internship
+  --site <domains>        Restrict to these job boards (comma-separated, repeatable),
+                          e.g. --site jobindex.dk,linkedin.com
+  --exclude-site <doms>   Drop these domains instead. Mutually exclusive with --site.
+  --country <code>        ISO-3166 alpha-2 search locale, e.g. --country DK. Default US.
+  --location, -l <place>  Geo-target the results, e.g. --location "Berlin,Germany"
+  --jobage <days>         Search-freshness hint (bucketed: day/week/month/year).
+                          NOT a filter on the posting date - see SKILL.md.
+  --page <n>              1-indexed page. Default 1.
+  --limit, -n <n>         Results per page. Default 10 (page x limit must be <= 100).
+  --no-enrich             Skip per-result extraction: much cheaper and faster, but
+                          company/location/date come back null.
+  --format <fmt>          json (default) | table | plain.
+
+DETAIL
+  <url>                   A posting URL (a search result's id/url is exactly this).
+
+EXAMPLES
+  bun run src/cli.ts search -q "data engineer" --country DK --jobage 14 --format table
+  bun run src/cli.ts search -q "geophysicist" --site linkedin.com,jobindex.dk --limit 5 --format table
+  bun run src/cli.ts search -q "\\"machine learning engineer\\" remote" --no-enrich --limit 20
+  bun run src/cli.ts detail https://job-boards.greenhouse.io/acme/jobs/123 --format plain
+
+Endpoint: ${baseUrl()} — needs FIRECRAWL_API_KEY (https://firecrawl.dev); override
+with FIRECRAWL_API_URL for a self-hosted instance, which needs no key by default.
+
+COST — this is a metered API. Measured: a plain search costs 2 * ceil(limit / 10);
+enrichment adds ~5 per successfully enriched result, so --limit 20 costs ~104 when
+all results are enriched. Use --no-enrich for wide sweeps and keep --limit small.
+Every run reports meta.credits_used.
+`
+
+function parseIntFlag(name: string, raw: string | boolean | string[]): number | null {
+  const val = parseInt(raw as string, 10)
+  if (isNaN(val)) {
+    process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+    return null
+  }
+  return val
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  // Fail fast and identifiably when the hosted API is targeted without a key. A
+  // self-hosted instance (FIRECRAWL_API_URL) is exempt: it runs unauthenticated
+  // by default, so demanding a key there would reject a working local backend.
+  if ((cmd === "search" || cmd === "detail") && requiresApiKey()) {
+    process.stderr.write(JSON.stringify({ error: NO_API_KEY_MESSAGE, code: "NO_API_KEY" }) + "\n")
+    return 1
+  }
+
+  if (cmd === "search") {
+    const query = stringFlag(flags.query)
+    if (!query) {
+      process.stderr.write(JSON.stringify({ error: "search requires --query/-q", code: "NO_QUERY" }) + "\n")
+      return 1
+    }
+
+    for (const name of ["jobage", "page", "limit"] as const) {
+      if (flags[name] !== undefined) {
+        const v = parseIntFlag(name, flags[name])
+        if (v === null) return 1
+        flags[name] = String(v)
+      }
+    }
+
+    const sites = domainList(flags.site)
+    const excludeSites = domainList(flags["exclude-site"])
+    if (sites.length && excludeSites.length) {
+      process.stderr.write(
+        JSON.stringify({ error: "--site and --exclude-site cannot be combined", code: "BAD_ARG" }) + "\n",
+      )
+      return 1
+    }
+
+    const fmt = (flags.format as string) || "json"
+    const opts: SearchOpts = {
+      query,
+      jobage: flags.jobage ? parseInt(flags.jobage as string, 10) : undefined,
+      page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
+      limit: flags.limit ? Math.max(1, parseInt(flags.limit as string, 10)) : 10,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+      sites,
+      excludeSites,
+      country: stringFlag(flags.country)?.toUpperCase(),
+      location: stringFlag(flags.location),
+      // Presence of the flag disables enrichment, however it was written - a
+      // stray following word must not silently turn it back on.
+      enrich: flags["no-enrich"] === undefined,
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(JSON.stringify({ error: "detail requires a <url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = { id, format: fmt === "plain" ? "plain" : "json" }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write(
+      JSON.stringify({
+        error: e instanceof Error ? e.message : String(e),
+        code: "INTERNAL_ERROR",
+      }) + "\n",
+    )
+    process.exit(1)
+  })

--- a/.agents/skills/firecrawl-search/cli/src/commands/detail.ts
+++ b/.agents/skills/firecrawl-search/cli/src/commands/detail.ts
@@ -1,0 +1,77 @@
+import {
+  JOB_PROMPT,
+  JOB_SCHEMA,
+  apiPost,
+  toDetail,
+  writeError,
+  type JobDetailResult,
+  type ScrapedDoc,
+} from "../helpers.js"
+
+export interface DetailOpts {
+  id: string // a posting URL (search results use the URL as their id)
+  format: "json" | "plain"
+}
+
+/** Accept a bare URL, adding https:// when the scheme was left off. */
+export function normalizeUrl(input: string): string | null {
+  const text = input.trim()
+  if (!text) return null
+  const withScheme = /^[a-z]+:\/\//i.test(text) ? text : `https://${text}`
+  try {
+    const parsed = new URL(withScheme)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null
+    if (!parsed.hostname.includes(".")) return null
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+/** A human-readable rendering of one posting: header, present fields, description. */
+function renderPlain(job: JobDetailResult): string {
+  const lines = [job.title, `${job.company ?? "—"} · ${job.location ?? "—"}`]
+
+  const field = (label: string, value: string | null) => {
+    if (value) lines.push(`${label}: ${value}`)
+  }
+  field("Posted", job.date)
+  field("Employment", job.employment_type)
+  field("Deadline", job.deadline)
+
+  lines.push("", job.description ?? "(no description)", "", `URL: ${job.url}`)
+  return lines.join("\n")
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const url = normalizeUrl(opts.id)
+  if (!url) {
+    writeError(`could not parse a posting URL from "${opts.id}"`, "BAD_ID")
+    return 1
+  }
+  try {
+    // markdown carries the posting text; the json format extracts the structured
+    // fields from the same scrape, so this is one request rather than two.
+    const envelope = await apiPost<ScrapedDoc>("/v2/scrape", {
+      url,
+      onlyMainContent: true,
+      formats: ["markdown", { type: "json", prompt: JOB_PROMPT, schema: JOB_SCHEMA }],
+    })
+    const doc = envelope.data
+    if (!doc) {
+      writeError("posting not found", "NOT_FOUND")
+      return 1
+    }
+    const job = toDetail(doc, url)
+
+    if (opts.format === "plain") {
+      process.stdout.write(renderPlain(job) + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/firecrawl-search/cli/src/commands/search.ts
+++ b/.agents/skills/firecrawl-search/cli/src/commands/search.ts
@@ -1,0 +1,144 @@
+import {
+  JOB_PROMPT,
+  JOB_SCHEMA,
+  MAX_SEARCH_RESULTS,
+  apiPost,
+  jobageToTbs,
+  toResult,
+  writeError,
+  type JobResult,
+  type SearchItem,
+} from "../helpers.js"
+
+export interface SearchOpts {
+  query: string
+  jobage?: number
+  page: number
+  limit: number
+  format: "json" | "table" | "plain"
+  sites: string[] // includeDomains — restrict to these job boards
+  excludeSites: string[] // excludeDomains — mutually exclusive with sites
+  country?: string // ISO-3166 alpha-2, biases the search locale
+  location?: string // geo-targeting string, e.g. "Germany"
+  enrich: boolean // scrape each hit for company/location/date
+}
+
+interface SearchData {
+  web?: SearchItem[]
+}
+
+export function buildPayload(opts: SearchOpts, wanted: number): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    query: opts.query,
+    sources: ["web"],
+    limit: wanted,
+  }
+  const tbs = jobageToTbs(opts.jobage)
+  if (tbs) payload.tbs = tbs
+  if (opts.country) payload.country = opts.country
+  if (opts.location) payload.location = opts.location
+  // The API rejects both filters together; the CLI validates first (see cli.ts).
+  if (opts.sites.length) payload.includeDomains = opts.sites
+  else if (opts.excludeSites.length) payload.excludeDomains = opts.excludeSites
+
+  if (opts.enrich) {
+    // Firecrawl scrapes each hit and extracts the job fields against JOB_SCHEMA,
+    // which is what lets one skill cover every board: no markup anchors, so
+    // nothing to re-learn when a site changes its HTML. It costs extra credits
+    // per result, hence the --no-enrich escape hatch.
+    payload.scrapeOptions = {
+      onlyMainContent: true,
+      formats: [{ type: "json", prompt: JOB_PROMPT, schema: JOB_SCHEMA }],
+    }
+  }
+  return payload
+}
+
+// Table columns: header, width, and the cell value. The URL column is sized to the
+// longest URL so it is never truncated - the URL is also the result's `id`, and a
+// cut one cannot be looked up with `detail`; the rest truncate for scanning.
+interface Column {
+  header: string
+  width: number
+  cell: (r: JobResult) => string
+}
+
+function renderTable(rows: JobResult[]): string {
+  if (rows.length === 0) return "No results."
+  const columns: Column[] = [
+    { header: "TITLE", width: 42, cell: (r) => r.title },
+    { header: "COMPANY", width: 22, cell: (r) => r.company ?? "—" },
+    { header: "LOCATION", width: 20, cell: (r) => r.location ?? "—" },
+    { header: "DATE", width: 10, cell: (r) => r.date ?? "—" },
+    { header: "URL", width: Math.max(3, ...rows.map((r) => r.url.length)), cell: (r) => r.url },
+  ]
+  const row = (cells: string[]) => cells.map((c, i) => c.slice(0, columns[i].width).padEnd(columns[i].width)).join("  ")
+
+  const header = row(columns.map((c) => c.header))
+  const body = rows.map((r) => row(columns.map((c) => c.cell(r))))
+  return [header, "-".repeat(header.length), ...body].join("\n")
+}
+
+function renderPlain(rows: JobResult[]): string {
+  if (rows.length === 0) return "No results."
+  const block = (r: JobResult) =>
+    [
+      r.title,
+      `  ${r.company ?? "—"} · ${r.location ?? "—"} · ${r.date ?? "—"}`,
+      `  ${r.url}`,
+      r.snippet ? `  ${r.snippet}` : "",
+    ]
+      .filter((l) => l !== "")
+      .join("\n")
+  return rows.map(block).join("\n\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  // Firecrawl search has no offset parameter, so page N is served by asking for
+  // page*limit results and returning the last window. Page 1 (the common case)
+  // fetches exactly what it needs; deeper pages re-fetch the earlier ones.
+  const wanted = opts.page * opts.limit
+  if (wanted > MAX_SEARCH_RESULTS) {
+    writeError(
+      `--page ${opts.page} x --limit ${opts.limit} needs ${wanted} results, but Firecrawl search ` +
+        `returns at most ${MAX_SEARCH_RESULTS} per query — narrow the query or lower --limit`,
+      "BAD_ARG",
+    )
+    return 1
+  }
+
+  try {
+    const envelope = await apiPost<SearchData>("/v2/search", buildPayload(opts, wanted))
+    const items = envelope.data?.web ?? []
+    // Items without a resolvable URL are dropped by toResult.
+    const all = items.map(toResult).filter((r): r is JobResult => r !== null)
+    const rows = all.slice((opts.page - 1) * opts.limit, wanted)
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(rows) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(renderPlain(rows) + "\n")
+    } else {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            meta: {
+              count: rows.length,
+              page: opts.page,
+              total: all.length,
+              enriched: opts.enrich,
+              credits_used: envelope.creditsUsed ?? null,
+            },
+            results: rows,
+          },
+          null,
+          2,
+        ) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/firecrawl-search/cli/src/helpers.ts
+++ b/.agents/skills/firecrawl-search/cli/src/helpers.ts
@@ -1,0 +1,306 @@
+// Data source: the Firecrawl v2 REST API (https://docs.firecrawl.dev).
+// `search` discovers postings anywhere on the web (optionally scoped to job-board
+// domains); `scrape` reads one posting. Unlike the HTML-scraping portals there is
+// no per-portal markup to parse — Firecrawl returns the structured fields — so this
+// skill works for any job board in any market without a parser to maintain.
+//
+// Zero runtime dependencies: plain `fetch` against the REST API, no SDK. The hosted
+// API requires FIRECRAWL_API_KEY; FIRECRAWL_API_URL may name a keyless self-host.
+
+export const DEFAULT_API_URL = "https://api.firecrawl.dev"
+
+/** API base URL: FIRECRAWL_API_URL (for a self-hosted instance) or the default. */
+export function baseUrl(): string {
+  const raw = (process.env.FIRECRAWL_API_URL ?? "").trim()
+  return (raw || DEFAULT_API_URL).replace(/\/+$/, "")
+}
+
+/** The API key, or null when unset. */
+export function apiKey(): string | null {
+  const raw = (process.env.FIRECRAWL_API_KEY ?? "").trim()
+  return raw || null
+}
+
+/** True when FIRECRAWL_API_URL points somewhere other than the hosted cloud API. */
+export function isSelfHosted(): boolean {
+  return baseUrl() !== DEFAULT_API_URL
+}
+
+/**
+ * Whether a key is required to proceed. Self-hosted Firecrawl ships with
+ * authentication disabled by default and treats keys as optional, so requiring
+ * one there would reject a perfectly good local instance; only the hosted cloud
+ * API always needs one.
+ */
+export function requiresApiKey(): boolean {
+  return !apiKey() && !isSelfHosted()
+}
+
+export const NO_API_KEY_MESSAGE =
+  "FIRECRAWL_API_KEY is not set — get a key at https://firecrawl.dev and export it, " +
+  "or point FIRECRAWL_API_URL at a self-hosted instance (which needs no key by default)"
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+const UA = "firecrawl-search-skill/1.0 (+https://docs.firecrawl.dev)"
+
+/** Firecrawl's response envelope: {success, data, creditsUsed, id, error}. */
+export interface Envelope<T> {
+  success: boolean
+  data?: T
+  creditsUsed?: number
+  id?: string
+  error?: string
+  details?: unknown
+}
+
+/**
+ * POST a JSON payload to the Firecrawl API. Retries 429/5xx (rate limits and
+ * transient server states) with exponential backoff plus jitter; a connection
+ * failure fails fast with a clear message, so an outage degrades this source
+ * rather than hanging the caller.
+ */
+export async function apiPost<T>(path: string, payload: unknown): Promise<Envelope<T>> {
+  const key = apiKey()
+  if (requiresApiKey()) throw new Error(NO_API_KEY_MESSAGE)
+  const url = `${baseUrl()}${path}`
+  // Keyless means no Authorization header at all - sending a placeholder would
+  // turn an unauthenticated self-host into a 401. When a key IS set it is sent to
+  // whatever FIRECRAWL_API_URL names, including a self-host that requires one.
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": UA,
+    Accept: "application/json",
+  }
+  if (key) headers.Authorization = `Bearer ${key}`
+  const maxRetries = 6
+  let delay = 500
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        // Enrichment scrapes each result, so a search can legitimately take a
+        // while; the timeout is generous but still bounded.
+        signal: AbortSignal.timeout(180000),
+      })
+    } catch (e) {
+      throw new Error(
+        `could not reach the Firecrawl API at ${baseUrl()} (${e instanceof Error ? e.message : String(e)})`,
+      )
+    }
+
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`Firecrawl API request failed: ${response.status} ${response.statusText}`)
+      }
+      await sleep(delay + Math.floor(Math.random() * 500))
+      delay = Math.min(delay * 2, 8000)
+      continue
+    }
+
+    const body = (await response.json().catch(() => null)) as Envelope<T> | null
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        body?.error || "Firecrawl rejected the API key (check FIRECRAWL_API_KEY)",
+      )
+    }
+    if (!response.ok || body?.success === false) {
+      // Validation errors carry a `details` array that names the offending field;
+      // surfacing it turns "Invalid request body" into something actionable.
+      const detail = body?.details ? ` (${JSON.stringify(body.details)})` : ""
+      throw new Error(
+        (body?.error || `Firecrawl API request failed: ${response.status} ${response.statusText}`) + detail,
+      )
+    }
+    if (!body) throw new Error("Firecrawl API returned an unparseable response body")
+    return body
+  }
+  // Unreachable in practice; the loop returns or throws on the last attempt.
+  throw new Error("Firecrawl API request failed after retries")
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/**
+ * The job fields Firecrawl extracts from each posting page. This replaces the
+ * per-portal HTML parsing the scraping skills need: the same schema works on any
+ * board, so there are no markup anchors to break when a site is redesigned.
+ */
+export const JOB_SCHEMA = {
+  type: "object",
+  properties: {
+    company: { type: "string", description: "The hiring company or organisation name" },
+    location: { type: "string", description: "Work location as written on the posting" },
+    date_posted: { type: "string", description: "Publication date, ISO YYYY-MM-DD when stated" },
+    employment_type: { type: "string", description: "e.g. full-time, part-time, contract" },
+    deadline: { type: "string", description: "Application deadline, ISO YYYY-MM-DD when stated" },
+  },
+} as const
+
+export const JOB_PROMPT =
+  "Extract the job posting's hiring company, work location, publication date, employment type " +
+  "and application deadline. Use an empty string for anything the page does not state."
+
+/** The extracted job fields; every one may be absent or empty on a given page. */
+export interface ExtractedJob {
+  company?: string
+  location?: string
+  date_posted?: string
+  employment_type?: string
+  deadline?: string
+}
+
+/**
+ * One `data.web[]` item. Without `scrapeOptions` these are plain search results
+ * with top-level url/title/description; with it they are Documents that also
+ * carry `metadata` (where url/title are mirrored) and the extracted `json`. The
+ * union is why every read below falls back across both shapes.
+ */
+export interface SearchItem {
+  url?: string
+  title?: string
+  description?: string
+  position?: number
+  json?: ExtractedJob | null
+  metadata?: {
+    sourceURL?: string
+    url?: string
+    title?: string
+    description?: string
+    statusCode?: number
+  }
+}
+
+/** A scraped document, as returned by /v2/scrape. */
+export interface ScrapedDoc {
+  markdown?: string
+  json?: ExtractedJob | null
+  metadata?: {
+    sourceURL?: string
+    url?: string
+    title?: string
+    description?: string
+    statusCode?: number
+  }
+}
+
+/** A search result in the portal-skill contract shape; missing values are null. */
+export interface JobResult {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  date: string | null
+  url: string
+  snippet: string | null
+}
+
+/** A job detail: the search result plus the posting text and extra fields. */
+export interface JobDetailResult extends JobResult {
+  employment_type: string | null
+  deadline: string | null
+  description: string | null
+}
+
+/** Trim, collapse whitespace, and treat an empty result as absent. */
+function clean(value: string | null | undefined): string | null {
+  if (!value) return null
+  const text = value.replace(/\s+/g, " ").trim()
+  return text || null
+}
+
+/**
+ * Best-effort posting date. An ISO-prefixed value is normalised to YYYY-MM-DD;
+ * anything else the page stated (e.g. "3 days ago") is kept verbatim rather than
+ * guessed at, because a wrong date is worse than an unparsed one.
+ */
+export function normalizeDate(raw: string | null | undefined): string | null {
+  const text = clean(raw)
+  if (!text) return null
+  const iso = text.match(/^(\d{4}-\d{2}-\d{2})/)
+  return iso ? iso[1] : text
+}
+
+/**
+ * Reshape one search item into the contract's result fields. Returns null when no
+ * URL could be resolved from either shape — an unusable result is dropped rather
+ * than emitted with a placeholder.
+ */
+export function toResult(item: SearchItem): JobResult | null {
+  const url = clean(item.url) ?? clean(item.metadata?.sourceURL) ?? clean(item.metadata?.url)
+  if (!url) return null
+  const extracted = item.json ?? {}
+  return {
+    id: url,
+    title: clean(item.title) ?? clean(item.metadata?.title) ?? "(untitled)",
+    company: clean(extracted.company),
+    location: clean(extracted.location),
+    date: normalizeDate(extracted.date_posted),
+    url,
+    snippet: clean(item.description) ?? clean(item.metadata?.description),
+  }
+}
+
+/** Reshape a scraped document into the detail result. */
+export function toDetail(doc: ScrapedDoc, requestedUrl: string): JobDetailResult {
+  const extracted = doc.json ?? {}
+  const url = clean(doc.metadata?.sourceURL) ?? clean(doc.metadata?.url) ?? requestedUrl
+  return {
+    id: url,
+    title: clean(doc.metadata?.title) ?? "(untitled)",
+    company: clean(extracted.company),
+    location: clean(extracted.location),
+    date: normalizeDate(extracted.date_posted),
+    url,
+    snippet: clean(doc.metadata?.description),
+    employment_type: clean(extracted.employment_type),
+    deadline: normalizeDate(extracted.deadline),
+    description: doc.markdown?.trim() || null,
+  }
+}
+
+/**
+ * Map `--jobage` onto Firecrawl's `tbs` filter, picking the smallest bucket that
+ * covers the requested window. Returns null when no filter applies (unset, or
+ * wider than a year).
+ *
+ * IMPORTANT: `tbs` filters on the *search engine's* freshness signal for the page,
+ * NOT on the posting's `date_posted` (which is only extracted later, per result).
+ * So this is a freshness hint, not posting-age filtering: it can both return
+ * postings older than N days and miss recent ones whose page the index dates
+ * differently. It does not honor the portal contract's `--jobage` semantics -
+ * filter on the extracted `date` downstream when the distinction matters.
+ */
+export function jobageToTbs(days: number | undefined): string | null {
+  if (days === undefined || !Number.isFinite(days) || days <= 0) return null
+  if (days <= 1) return "qdr:d"
+  if (days <= 7) return "qdr:w"
+  if (days <= 31) return "qdr:m"
+  if (days <= 366) return "qdr:y"
+  return null
+}
+
+/**
+ * Reduce a user-supplied site to the bare hostname Firecrawl's domain filters
+ * expect: no scheme, no path, no leading "www.".
+ */
+export function normalizeDomain(input: string): string | null {
+  const text = input
+    .trim()
+    .replace(/^[a-z]+:\/\//i, "")
+    .replace(/\/.*$/, "")
+    .replace(/^www\./i, "")
+    .toLowerCase()
+  return text || null
+}
+
+/** Firecrawl search returns at most 100 results per query. */
+export const MAX_SEARCH_RESULTS = 100

--- a/.agents/skills/firecrawl-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/firecrawl-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+// Every case here is rejected before any request is made, so the suite is
+// network-free and safe to run in CI. A dummy key is injected where the command
+// would otherwise short-circuit on NO_API_KEY, and cleared where that is the
+// behaviour under test - so the results do not depend on the developer's shell.
+// FIRECRAWL_API_URL is pinned empty so an instance configured in the developer's
+// shell cannot change which code path these cases take.
+const KEY = { FIRECRAWL_API_KEY: "fc-test-key", FIRECRAWL_API_URL: "" };
+
+function stderrJSON(stderr: string): { error: string; code: string } {
+  return JSON.parse(stderr);
+}
+
+describe("CLI argument validation", () => {
+  test("search without --query exits 1 with NO_QUERY on stderr", async () => {
+    const result = await runCLI(["search"], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(stderrJSON(result.stderr).code).toBe("NO_QUERY");
+  });
+
+  test("--site and --exclude-site together exit 1 with BAD_ARG", async () => {
+    // The API rejects both filters in one request; catching it locally gives a
+    // clearer message and spends no credits.
+    const result = await runCLI(["search", "-q", "data engineer", "--site", "a.com", "--exclude-site", "b.com"], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(stderrJSON(result.stderr).code).toBe("BAD_ARG");
+  });
+
+  test("a non-numeric --jobage exits 1 with BAD_ARG", async () => {
+    const result = await runCLI(["search", "-q", "data engineer", "--jobage", "recently"], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(stderrJSON(result.stderr).code).toBe("BAD_ARG");
+  });
+
+  test("a page window beyond Firecrawl's 100-result cap exits 1 with BAD_ARG", async () => {
+    const result = await runCLI(["search", "-q", "data engineer", "--page", "20", "--limit", "10"], KEY);
+    expect(result.exitCode).toBe(1);
+    const parsed = stderrJSON(result.stderr);
+    expect(parsed.code).toBe("BAD_ARG");
+    expect(parsed.error).toContain("100");
+  });
+
+  test("detail without a URL exits 1 with NO_ID", async () => {
+    const result = await runCLI(["detail"], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(stderrJSON(result.stderr).code).toBe("NO_ID");
+  });
+
+  test("detail with an unparseable id exits 1 with BAD_ID", async () => {
+    const result = await runCLI(["detail", "not-a-url"], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(stderrJSON(result.stderr).code).toBe("BAD_ID");
+  });
+
+  test("an unknown command exits 1 with BAD_CMD", async () => {
+    const result = await runCLI(["crawl"], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(stderrJSON(result.stderr).code).toBe("BAD_CMD");
+  });
+
+  test("a missing API key exits 1 with NO_API_KEY and names the variable", async () => {
+    const result = await runCLI(["search", "-q", "data engineer"], {
+      FIRECRAWL_API_KEY: "",
+      FIRECRAWL_API_URL: "",
+    });
+    expect(result.exitCode).toBe(1);
+    const parsed = stderrJSON(result.stderr);
+    expect(parsed.code).toBe("NO_API_KEY");
+    expect(parsed.error).toContain("FIRECRAWL_API_KEY");
+  });
+
+  test("a keyless self-hosted instance is not rejected as NO_API_KEY", async () => {
+    // Self-hosted Firecrawl defaults to authentication disabled, so pointing
+    // FIRECRAWL_API_URL at one must reach the request rather than fail up front.
+    // Nothing listens on this port, so it fails at connect - which is the point:
+    // the error is a connection failure, not a missing credential.
+    const result = await runCLI(["search", "-q", "data engineer"], {
+      FIRECRAWL_API_KEY: "",
+      FIRECRAWL_API_URL: "http://127.0.0.1:9",
+    });
+    expect(result.exitCode).toBe(1);
+    const parsed = stderrJSON(result.stderr);
+    expect(parsed.code).toBe("SEARCH_FAILED");
+    expect(parsed.error).toContain("could not reach the Firecrawl API");
+  });
+
+  test("no arguments prints help to stdout and exits 1", async () => {
+    const result = await runCLI([], KEY);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("USAGE");
+    expect(result.stderr).toBe("");
+  });
+
+  test("--help on a command prints help and exits 0", async () => {
+    const result = await runCLI(["search", "--help"], KEY);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("SEARCH FLAGS");
+  });
+});

--- a/.agents/skills/firecrawl-search/cli/tests/commands.test.ts
+++ b/.agents/skills/firecrawl-search/cli/tests/commands.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { buildPayload, runSearch, type SearchOpts } from "../src/commands/search";
+import { runDetail } from "../src/commands/detail";
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write;
+const originalStderrWrite = process.stderr.write;
+const originalKey = process.env.FIRECRAWL_API_KEY;
+
+function captureStdout(): { get: () => string } {
+  let buf = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    buf += chunk.toString();
+    return true;
+  }) as typeof process.stdout.write;
+  return { get: () => buf };
+}
+
+function captureStderr(): { get: () => string } {
+  let buf = "";
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    buf += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  return { get: () => buf };
+}
+
+/** Mock fetch and record the request body the CLI sent. */
+function mockFetch(status: number, body: unknown): { payload: () => Record<string, unknown> } {
+  let sent: Record<string, unknown> = {};
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    sent = JSON.parse(String(init?.body ?? "{}"));
+    return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { payload: () => sent };
+}
+
+function searchOpts(overrides: Partial<SearchOpts> = {}): SearchOpts {
+  return {
+    query: "data engineer",
+    page: 1,
+    limit: 10,
+    format: "json",
+    sites: [],
+    excludeSites: [],
+    enrich: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env.FIRECRAWL_API_KEY = "fc-test-key";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  if (originalKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+  else process.env.FIRECRAWL_API_KEY = originalKey;
+});
+
+describe("buildPayload", () => {
+  test("requests per-result extraction when enrichment is on", () => {
+    const payload = buildPayload(searchOpts({ enrich: true }), 10);
+    const scrapeOptions = payload.scrapeOptions as { formats: Array<{ type: string }> };
+    expect(scrapeOptions.formats[0].type).toBe("json");
+    expect(payload.sources).toEqual(["web"]);
+    expect(payload.limit).toBe(10);
+  });
+
+  test("omits scrapeOptions entirely with --no-enrich (the cheap path)", () => {
+    const payload = buildPayload(searchOpts({ enrich: false }), 10);
+    expect(payload.scrapeOptions).toBeUndefined();
+  });
+
+  test("maps --jobage to a tbs bucket and --site to includeDomains", () => {
+    const payload = buildPayload(searchOpts({ jobage: 14, sites: ["jobindex.dk"] }), 10);
+    expect(payload.tbs).toBe("qdr:m");
+    expect(payload.includeDomains).toEqual(["jobindex.dk"]);
+    expect(payload.excludeDomains).toBeUndefined();
+  });
+
+  test("sends excludeDomains only when no --site filter is set", () => {
+    // The API rejects both filters in one request, so only one may ever be sent.
+    const both = buildPayload(searchOpts({ sites: ["a.com"], excludeSites: ["b.com"] }), 10);
+    expect(both.includeDomains).toEqual(["a.com"]);
+    expect(both.excludeDomains).toBeUndefined();
+
+    const only = buildPayload(searchOpts({ excludeSites: ["b.com"] }), 10);
+    expect(only.excludeDomains).toEqual(["b.com"]);
+  });
+
+  test("omits recency and geo params when unset", () => {
+    const payload = buildPayload(searchOpts(), 10);
+    expect(payload.tbs).toBeUndefined();
+    expect(payload.country).toBeUndefined();
+    expect(payload.location).toBeUndefined();
+  });
+});
+
+describe("runSearch", () => {
+  test("emits the contract JSON shape and reports credits used", async () => {
+    mockFetch(200, {
+      success: true,
+      creditsUsed: 17,
+      data: {
+        web: [
+          {
+            url: "https://example.com/jobs/1",
+            title: "Data Engineer",
+            description: "snippet",
+            json: { company: "Acme", location: "Berlin", date_posted: "2026-07-06" },
+          },
+        ],
+      },
+    });
+    const out = captureStdout();
+    const code = await runSearch(searchOpts());
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(out.get());
+    expect(parsed.meta).toEqual({ count: 1, page: 1, total: 1, enriched: true, credits_used: 17 });
+    expect(parsed.results[0]).toMatchObject({
+      id: "https://example.com/jobs/1",
+      title: "Data Engineer",
+      company: "Acme",
+      location: "Berlin",
+      date: "2026-07-06",
+      url: "https://example.com/jobs/1",
+    });
+  });
+
+  test("returns page 2 by slicing an over-fetched result set", async () => {
+    // Firecrawl search has no offset param, so page 2 asks for page*limit results
+    // and returns the second window.
+    const web = Array.from({ length: 4 }, (_, i) => ({
+      url: `https://example.com/jobs/${i + 1}`,
+      title: `Job ${i + 1}`,
+    }));
+    const mock = mockFetch(200, { success: true, data: { web } });
+    const out = captureStdout();
+    const code = await runSearch(searchOpts({ page: 2, limit: 2 }));
+    expect(code).toBe(0);
+    expect(mock.payload().limit).toBe(4);
+
+    const parsed = JSON.parse(out.get());
+    expect(parsed.results.map((r: { title: string }) => r.title)).toEqual(["Job 3", "Job 4"]);
+    expect(parsed.meta.page).toBe(2);
+  });
+
+  test("refuses a window Firecrawl search cannot serve", async () => {
+    const err = captureStderr();
+    const code = await runSearch(searchOpts({ page: 20, limit: 10 }));
+    expect(code).toBe(1);
+    expect(JSON.parse(err.get()).code).toBe("BAD_ARG");
+  });
+
+  test("surfaces an API validation error on stderr and exits 1", async () => {
+    mockFetch(400, { success: false, error: "Invalid request body", details: [{ path: ["limit"] }] });
+    const err = captureStderr();
+    const code = await runSearch(searchOpts());
+    expect(code).toBe(1);
+    const parsed = JSON.parse(err.get());
+    expect(parsed.code).toBe("SEARCH_FAILED");
+    expect(parsed.error).toContain("Invalid request body");
+    // The details array names the offending field - keep it in the message.
+    expect(parsed.error).toContain("limit");
+  });
+
+  test("renders a table without truncating the URL (it is the detail lookup key)", async () => {
+    const url = "https://example.com/a-very-long-job-posting-path/that-keeps-going/12345678";
+    mockFetch(200, { success: true, data: { web: [{ url, title: "Data Engineer" }] } });
+    const out = captureStdout();
+    const code = await runSearch(searchOpts({ format: "table" }));
+    expect(code).toBe(0);
+    expect(out.get()).toContain(url);
+  });
+
+  test("reports an empty result set as No results in table format", async () => {
+    mockFetch(200, { success: true, data: { web: [] } });
+    const out = captureStdout();
+    expect(await runSearch(searchOpts({ format: "table" }))).toBe(0);
+    expect(out.get().trim()).toBe("No results.");
+  });
+});
+
+describe("runDetail", () => {
+  test("scrapes the posting and returns markdown plus the extracted fields", async () => {
+    const mock = mockFetch(200, {
+      success: true,
+      data: {
+        markdown: "# Data Engineer\n\nWe are hiring.",
+        json: { company: "Acme", location: "Copenhagen", deadline: "2026-08-01" },
+        metadata: { sourceURL: "https://example.com/jobs/1", title: "Data Engineer" },
+      },
+    });
+    const out = captureStdout();
+    const code = await runDetail({ id: "https://example.com/jobs/1", format: "json" });
+    expect(code).toBe(0);
+    expect(mock.payload().url).toBe("https://example.com/jobs/1");
+
+    const parsed = JSON.parse(out.get());
+    expect(parsed.description).toBe("# Data Engineer\n\nWe are hiring.");
+    expect(parsed.company).toBe("Acme");
+    expect(parsed.deadline).toBe("2026-08-01");
+  });
+
+  test("rejects an unusable id before making a request", async () => {
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+    const err = captureStderr();
+    const code = await runDetail({ id: "not-a-url", format: "json" });
+    expect(code).toBe(1);
+    expect(called).toBe(false);
+    expect(JSON.parse(err.get()).code).toBe("BAD_ID");
+  });
+
+  test("exits 1 with NO_API_KEY when the key is missing", async () => {
+    delete process.env.FIRECRAWL_API_KEY;
+    const err = captureStderr();
+    const code = await runDetail({ id: "https://example.com/jobs/1", format: "json" });
+    expect(code).toBe(1);
+    expect(JSON.parse(err.get()).error).toContain("FIRECRAWL_API_KEY");
+  });
+});

--- a/.agents/skills/firecrawl-search/cli/tests/helpers.ts
+++ b/.agents/skills/firecrawl-search/cli/tests/helpers.ts
@@ -1,0 +1,40 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[], env: Record<string, string> = {}): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/firecrawl-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/firecrawl-search/cli/tests/parsing.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import {
+  jobageToTbs,
+  normalizeDate,
+  normalizeDomain,
+  toDetail,
+  toResult,
+  type SearchItem,
+} from "../src/helpers";
+import { normalizeUrl } from "../src/commands/detail";
+
+// Firecrawl returns two different item shapes from /v2/search: plain results
+// (top-level url/title) without scrapeOptions, and Documents (fields under
+// `metadata`) with it. Both must map onto the portal-skill contract.
+describe("toResult", () => {
+  test("maps a plain (unenriched) search result", () => {
+    const item: SearchItem = {
+      url: "https://job-boards.greenhouse.io/acme/jobs/1",
+      title: "Data Engineer at Acme",
+      description: "Build pipelines",
+      position: 1,
+    };
+    expect(toResult(item)).toEqual({
+      id: "https://job-boards.greenhouse.io/acme/jobs/1",
+      title: "Data Engineer at Acme",
+      company: null,
+      location: null,
+      date: null,
+      url: "https://job-boards.greenhouse.io/acme/jobs/1",
+      snippet: "Build pipelines",
+    });
+  });
+
+  test("maps an enriched Document, taking the extracted job fields", () => {
+    const item: SearchItem = {
+      url: "https://job-boards.greenhouse.io/acme/jobs/2",
+      title: "Job Application for Data Engineer at Acme",
+      json: { company: "Acme", location: "Berlin, Germany", date_posted: "2026-07-06" },
+      metadata: { sourceURL: "https://job-boards.greenhouse.io/acme/jobs/2", title: "ignored" },
+    };
+    const result = toResult(item);
+    expect(result?.company).toBe("Acme");
+    expect(result?.location).toBe("Berlin, Germany");
+    expect(result?.date).toBe("2026-07-06");
+  });
+
+  test("falls back to metadata.sourceURL when the top-level url is absent", () => {
+    const item: SearchItem = {
+      metadata: { sourceURL: "https://example.com/jobs/3", title: "Geophysicist" },
+    };
+    const result = toResult(item);
+    expect(result?.url).toBe("https://example.com/jobs/3");
+    // The URL doubles as the id, which `detail` consumes.
+    expect(result?.id).toBe("https://example.com/jobs/3");
+    expect(result?.title).toBe("Geophysicist");
+  });
+
+  test("drops an item with no resolvable URL rather than emitting a placeholder", () => {
+    expect(toResult({ title: "Orphaned posting" })).toBeNull();
+  });
+
+  test("treats empty extracted strings as missing, not as empty values", () => {
+    const item: SearchItem = {
+      url: "https://example.com/jobs/4",
+      title: "Analyst",
+      json: { company: "", location: "   ", date_posted: "" },
+    };
+    const result = toResult(item);
+    expect(result?.company).toBeNull();
+    expect(result?.location).toBeNull();
+    expect(result?.date).toBeNull();
+  });
+});
+
+describe("toDetail", () => {
+  test("carries the markdown body and the extra extracted fields", () => {
+    const job = toDetail(
+      {
+        markdown: "  # Data Engineer\n\nWe are hiring.  ",
+        json: {
+          company: "Acme",
+          location: "Copenhagen",
+          date_posted: "2026-07-01T09:00:00Z",
+          employment_type: "Full-time",
+          deadline: "2026-08-01",
+        },
+        metadata: { sourceURL: "https://example.com/jobs/5", title: "Data Engineer" },
+      },
+      "https://example.com/jobs/5",
+    );
+    expect(job.description).toBe("# Data Engineer\n\nWe are hiring.");
+    expect(job.employment_type).toBe("Full-time");
+    expect(job.deadline).toBe("2026-08-01");
+    expect(job.date).toBe("2026-07-01");
+  });
+
+  test("falls back to the requested URL when metadata omits it", () => {
+    const job = toDetail({ markdown: "text" }, "https://example.com/jobs/6");
+    expect(job.url).toBe("https://example.com/jobs/6");
+    expect(job.title).toBe("(untitled)");
+    expect(job.company).toBeNull();
+  });
+});
+
+describe("normalizeDate", () => {
+  test("normalises an ISO timestamp to YYYY-MM-DD", () => {
+    expect(normalizeDate("2026-07-06T15:00:00Z")).toBe("2026-07-06");
+  });
+
+  test("keeps an unparseable value verbatim instead of guessing a date", () => {
+    expect(normalizeDate("3 days ago")).toBe("3 days ago");
+  });
+
+  test("returns null for empty or absent input", () => {
+    expect(normalizeDate("")).toBeNull();
+    expect(normalizeDate(undefined)).toBeNull();
+  });
+});
+
+// tbs buckets the search engine's own freshness signal - it is not a filter over
+// the posting's date_posted. --jobage therefore rounds *up* to the smallest
+// covering bucket, which is a hint, not a guarantee about posting age.
+describe("jobageToTbs", () => {
+  test("maps day counts to the smallest covering bucket", () => {
+    expect(jobageToTbs(1)).toBe("qdr:d");
+    expect(jobageToTbs(7)).toBe("qdr:w");
+    expect(jobageToTbs(8)).toBe("qdr:m");
+    expect(jobageToTbs(14)).toBe("qdr:m");
+    expect(jobageToTbs(31)).toBe("qdr:m");
+    expect(jobageToTbs(90)).toBe("qdr:y");
+  });
+
+  test("returns null when no filter applies", () => {
+    expect(jobageToTbs(undefined)).toBeNull();
+    expect(jobageToTbs(0)).toBeNull();
+    expect(jobageToTbs(NaN)).toBeNull();
+    expect(jobageToTbs(9999)).toBeNull();
+  });
+});
+
+describe("normalizeDomain", () => {
+  test("reduces user input to the bare hostname Firecrawl expects", () => {
+    expect(normalizeDomain("https://www.jobindex.dk/jobsoegning?q=x")).toBe("jobindex.dk");
+    expect(normalizeDomain("  LinkedIn.com  ")).toBe("linkedin.com");
+    expect(normalizeDomain("job-boards.greenhouse.io/acme")).toBe("job-boards.greenhouse.io");
+  });
+
+  test("returns null for empty input", () => {
+    expect(normalizeDomain("   ")).toBeNull();
+  });
+});
+
+describe("normalizeUrl", () => {
+  test("adds a scheme when omitted", () => {
+    expect(normalizeUrl("example.com/jobs/1")).toBe("https://example.com/jobs/1");
+  });
+
+  test("keeps an explicit http(s) URL", () => {
+    expect(normalizeUrl("http://example.com/jobs/1")).toBe("http://example.com/jobs/1");
+  });
+
+  test("rejects non-http schemes and bare words", () => {
+    expect(normalizeUrl("file:///etc/passwd")).toBeNull();
+    expect(normalizeUrl("not-a-url")).toBeNull();
+    expect(normalizeUrl("")).toBeNull();
+  });
+});

--- a/.agents/skills/firecrawl-search/cli/tests/request-timeout.test.ts
+++ b/.agents/skills/firecrawl-search/cli/tests/request-timeout.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { apiPost } from "../src/helpers";
+
+// A stalled upstream connection (accepted socket, no response) would otherwise
+// hang the CLI forever - fetch has no default timeout. Assert the request wrapper
+// carries an AbortSignal timeout and authenticates with a bearer token.
+const originalFetch = globalThis.fetch;
+const originalKey = process.env.FIRECRAWL_API_KEY;
+const originalUrl = process.env.FIRECRAWL_API_URL;
+
+beforeEach(() => {
+  process.env.FIRECRAWL_API_KEY = "fc-test-key";
+  delete process.env.FIRECRAWL_API_URL;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalKey === undefined) delete process.env.FIRECRAWL_API_KEY;
+  else process.env.FIRECRAWL_API_KEY = originalKey;
+  if (originalUrl === undefined) delete process.env.FIRECRAWL_API_URL;
+  else process.env.FIRECRAWL_API_URL = originalUrl;
+});
+
+/** Capture the headers of a single mocked request that returns an empty success. */
+function captureHeaders(): () => Record<string, string> {
+  let headers: Record<string, string> = {};
+  globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+    headers = (i?.headers ?? {}) as Record<string, string>;
+    return new Response(JSON.stringify({ success: true, data: {} }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return () => headers;
+}
+
+describe("apiPost request", () => {
+  test("passes an AbortSignal timeout and a bearer token to fetch", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response(JSON.stringify({ success: true, data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await apiPost("/v2/search", { query: "test" });
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect(init?.method).toBe("POST");
+    expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer fc-test-key");
+  });
+
+  test("throws a key-specific error on 401 rather than retrying", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response(JSON.stringify({ success: false, error: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(apiPost("/v2/search", { query: "test" })).rejects.toThrow("Unauthorized");
+    expect(calls).toBe(1);
+  });
+});
+
+// Self-hosted Firecrawl runs with authentication disabled by default, so a local
+// instance must work with no key at all - and keyless means *no* Authorization
+// header, not a placeholder one (which the backend would reject).
+describe("self-hosted instances (FIRECRAWL_API_URL)", () => {
+  test("sends no Authorization header when self-hosted and keyless", async () => {
+    delete process.env.FIRECRAWL_API_KEY;
+    process.env.FIRECRAWL_API_URL = "http://localhost:3002";
+    const headers = captureHeaders();
+
+    await apiPost("/v2/search", { query: "test" });
+    expect(headers().Authorization).toBeUndefined();
+  });
+
+  test("still sends an explicitly set key to a self-hosted instance", async () => {
+    process.env.FIRECRAWL_API_URL = "http://localhost:3002";
+    const headers = captureHeaders();
+
+    await apiPost("/v2/search", { query: "test" });
+    expect(headers().Authorization).toBe("Bearer fc-test-key");
+  });
+
+  test("still requires a key for the hosted cloud API", async () => {
+    delete process.env.FIRECRAWL_API_KEY;
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as unknown as typeof fetch;
+
+    await expect(apiPost("/v2/search", { query: "test" })).rejects.toThrow("FIRECRAWL_API_KEY");
+    expect(called).toBe(false);
+  });
+});

--- a/.agents/skills/firecrawl-search/cli/tsconfig.json
+++ b/.agents/skills/firecrawl-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/firecrawl-search/url-reference.md
+++ b/.agents/skills/firecrawl-search/url-reference.md
@@ -1,0 +1,154 @@
+# Firecrawl API reference
+
+The endpoints, parameters, and response shapes this skill depends on.
+**This is the file to update if the API changes.** Official docs:
+<https://docs.firecrawl.dev>.
+
+Base URL: `https://api.firecrawl.dev` (API version `v2`), overridable with the
+`FIRECRAWL_API_URL` env var for a self-hosted instance.
+
+## Authentication
+
+Requests carry `Authorization: Bearer $FIRECRAWL_API_KEY` **when a key is set**.
+Auth handling depends on which endpoint is targeted:
+
+| `FIRECRAWL_API_URL` | `FIRECRAWL_API_KEY` | Behaviour |
+|---------------------|---------------------|-----------|
+| unset (hosted cloud) | set | `Authorization` sent |
+| unset (hosted cloud) | unset | exits `1` with `NO_API_KEY` before any request |
+| set (self-hosted) | unset | **no `Authorization` header at all** — self-hosted Firecrawl [defaults to authentication disabled](https://github.com/firecrawl/firecrawl/blob/main/SELF_HOST.md), and a placeholder key would turn that into a 401 |
+| set (self-hosted) | set | `Authorization` sent to that instance |
+
+Note the last row's corollary: a key that is set is sent to whatever
+`FIRECRAWL_API_URL` names, so it should only point at a trusted host.
+
+Verified against the live cloud API:
+
+| Endpoint | Status |
+|----------|--------|
+| `POST /v2/search` | 200 with a valid key |
+| `POST /v2/scrape` | 200 with a valid key |
+| either, bogus key | `401` — failed immediately, not retried |
+
+## Envelope
+
+Both endpoints wrap their payload:
+
+```jsonc
+{
+  "success": true,
+  "data": { /* endpoint-specific */ },
+  "creditsUsed": 17,      // surfaced as meta.credits_used on search
+  "id": "…"               // search job id (used by the feedback endpoint; unused here)
+}
+```
+
+On failure `success` is `false` with an `error` string, and validation failures add a
+`details` array naming the offending field. The CLI appends `details` to the error
+message, so `Invalid request body` becomes actionable.
+
+## `POST /v2/search`
+
+Body parameters used by the skill:
+
+| Param | Maps to CLI flag | Notes |
+|-------|------------------|-------|
+| `query` | `--query` / `-q` | Required. Supports operators: `""`, `-`, `site:`, `inurl:`, `intitle:`, `filetype:` |
+| `limit` | `--limit` × `--page` | **Max 100** (verified: 101+ returns `too_big`) |
+| `sources` | — | Always `["web"]`; `news`/`images` are not job sources |
+| `tbs` | `--jobage` | Bucketed: `qdr:h`, `qdr:d`, `qdr:w`, `qdr:m`, `qdr:y`. Omitted when > 366 days. Filters the **search index's freshness signal**, *not* the posting's `date_posted` — see "Recency" below |
+| `country` | `--country` | ISO-3166 alpha-2. API default `US` |
+| `location` | `--location` / `-l` | Free-text geo-target, e.g. `"Berlin,Germany"` |
+| `includeDomains` | `--site` | Bare hostnames, no scheme or path |
+| `excludeDomains` | `--exclude-site` | **Mutually exclusive** with `includeDomains` — sending both returns `includeDomains and excludeDomains cannot both be specified` |
+| `scrapeOptions` | (omitted by `--no-enrich`) | `{onlyMainContent: true, formats: [{type: "json", prompt, schema}]}` |
+
+There is **no offset/cursor parameter**, which is why `--page n` over-fetches
+`n × limit` results and returns the last window.
+
+### Recency (`tbs`) is not posting age
+
+`tbs` is applied by the search backend when selecting results, i.e. before any page
+is scraped and before `date_posted` exists. It therefore filters on how fresh the
+*index* considers the page, which is not the same as when the job was posted: a
+long-lived posting page that was recently recrawled can pass a narrow bucket, and a
+freshly posted job on a stale-looking page can be excluded. The skill maps
+`--jobage` onto it as a best-effort hint and documents it as such; precise
+posting-age filtering has to happen downstream on the extracted `date`.
+
+### Credits (measured live)
+
+| Request | Credits |
+|---------|---------|
+| search, no `scrapeOptions` | **2 × ceil(limit / 10)** (2 at `limit` 10, 4 at `limit` 15) |
+| search with `scrapeOptions` json extraction | search cost above + **~5 per successfully enriched result** (12 at `limit` 2, 17 at `limit` 3, ~104 at `limit` 20 when every result is enriched) |
+| `POST /v2/scrape` with markdown + json | ~5 |
+
+`creditsUsed` is returned on every response and surfaced as `meta.credits_used`;
+treat the table as indicative and the response field as authoritative.
+
+### Result items (`data.web[]`)
+
+The item shape depends on whether `scrapeOptions` was sent — this union is the main
+parsing hazard, so the CLI reads both shapes with fallbacks.
+
+```jsonc
+// Without scrapeOptions (--no-enrich): a plain search result
+{
+  "url": "https://job-boards.greenhouse.io/acme/jobs/1",
+  "title": "Job Application for Data Engineer at Acme",
+  "description": "…snippet…",
+  "position": 1
+}
+
+// With scrapeOptions: a Document. Top-level url/title are still present, but
+// metadata mirrors them (metadata.sourceURL / metadata.title) and `json` carries
+// the extracted fields. An item with no resolvable URL is dropped.
+{
+  "url": "…", "title": "…", "description": "…", "position": 1,
+  "json": {                       // matches JOB_SCHEMA in cli/src/helpers.ts
+    "company": "Acme",
+    "location": "Berlin, Germany",
+    "date_posted": "2026-07-06",  // "" when the page states none
+    "employment_type": "",
+    "deadline": ""
+  },
+  "metadata": { "sourceURL": "…", "title": "…", "statusCode": 200 }
+}
+```
+
+Extraction is model-based, so absent fields come back as **empty strings**; the CLI
+maps those to `null` so "stated but empty" never reaches the contract output.
+
+## `POST /v2/scrape`
+
+Body parameters used by `detail`:
+
+| Param | Maps to CLI flag | Notes |
+|-------|------------------|-------|
+| `url` | the `<url>` argument | A search result's `id` is exactly this |
+| `onlyMainContent` | — | Always `true`: strips nav/footer from the posting text |
+| `formats` | — | `["markdown", {type: "json", prompt, schema}]` — one request returns both the text and the structured fields |
+
+Response `data` is a document: `markdown` (the posting text), `json` (same schema as
+above), and `metadata` (`sourceURL`, `title`, `description`, `statusCode`).
+
+Not every site is scrapeable — some are explicitly unsupported and return
+`success: false` with a message pointing at Firecrawl's intake form. The CLI surfaces
+that message as a `DETAIL_FAILED` error rather than pretending the posting was empty.
+
+## Parsing notes
+
+- `formats: ["markdown"]` returns the page text. It is **not** a summary — the
+  `summary` format would be an LLM digest, which this skill deliberately does not use
+  for `detail`, so `/scrape` sees the real posting wording.
+- Dates: an ISO-prefixed value is truncated to `YYYY-MM-DD`; anything else the page
+  stated is preserved verbatim rather than converted to a guessed date.
+- Domains are normalised before sending: scheme, path, and a leading `www.` are
+  stripped and the host is lowercased.
+- Requests use a `firecrawl-search-skill/1.0` User-Agent, a 180 s `AbortSignal`
+  timeout (enrichment scrapes every hit, so a search is legitimately slow), and
+  exponential backoff with jitter on 429/5xx up to 6 retries. `401`/`403` is terminal.
+- Other Firecrawl operations (`crawl`, `map`, `monitor`, `batch`) are intentionally
+  **not** wired: this skill is search + detail only, matching the portal-skill
+  contract.

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -4,7 +4,7 @@
 
 ## Installed portal CLIs (primary for `/scrape`)
 
-`/scrape` discovers every portal skill under `.agents/skills/*/SKILL.md` and runs its CLI first. Shipped country-agnostic CLIs include `linkedin-search` and `freehire-search`; Danish demos and any skill you add with `/add-portal` are included the same way. You do **not** need a matching `site:` line below for those CLIs to run.
+`/scrape` discovers every portal skill under `.agents/skills/*/SKILL.md` and runs its CLI first. Shipped country-agnostic CLIs include `linkedin-search` and `freehire-search`; Danish demos and any skill you add with `/add-portal` are included the same way. You do **not** need a matching `site:` line below for those CLIs to run. (`firecrawl-search` also ships, but is `enabled: false` on purpose - it is a metered per-result source you invoke directly, not one `/scrape` should run unattended.)
 
 The `site:` query templates in this file are the **WebSearch fallback** — for portals without a CLI, company career pages, or when a CLI fails.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
       fail-fast: false
       matrix:
         tool:
+          - firecrawl-search
           - freehire-search
           - jobbank-search
           - jobdanmark-search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ per-file diff commands.
   source extension and a full compile command, so Typst (`typst compile`) registers the same
   way a custom LaTeX template does. Stock CV/cover letter templates stay LaTeX, unchanged.
 
+- **New country-agnostic portal skill: `firecrawl-search`** - searches the live web via the
+  [Firecrawl](https://docs.firecrawl.dev) v2 REST API instead of one specific board, so it covers
+  any job board in any market and language with no HTML parser to maintain (Firecrawl extracts
+  company, location, and posting date from each page). Scope per query with `--site`, `--country`,
+  and `--location`; `detail <url>` reads any posting in full. Fills the gap when a market has no
+  portal skill yet or a shipped one has broken on a markup change. It is the first portal skill
+  whose hosted service needs credentials (`FIRECRAWL_API_KEY`) and the first that is metered per
+  result, so it ships `enabled: false` as its steady state - a generalist you invoke directly
+  rather than one `/scrape` runs unattended - and stays zero-runtime-dependency (REST, no SDK).
+  A self-hosted instance via `FIRECRAWL_API_URL` needs no key and no credits.
+
 ## [1.0.0] - 2026-07-22
 
 First tagged release. This marks the framework as stable and gives forks a described

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd ai-job-search
 PowerShell:
 
 ```powershell
-$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search")
+$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search", "firecrawl-search")
 foreach ($tool in $tools) {
   Push-Location ".agents/skills/$tool/cli"
   bun install
@@ -92,12 +92,12 @@ foreach ($tool in $tools) {
 Bash / zsh / Git Bash:
 
 ```bash
-for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search; do
+for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search firecrawl-search; do
   (cd .agents/skills/$tool/cli && bun install)
 done
 ```
 
-For `linkedin-search` and `freehire-search` the install is optional: both have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
+For `linkedin-search`, `freehire-search`, and `firecrawl-search` the install is optional: all three have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
 
 ### 3. Set up your profile
 
@@ -188,7 +188,8 @@ ai-job-search/
 │   ├── jobindex-search/               # Jobindex.dk (Denmark)
 │   ├── jobnet-search/                 # Jobnet.dk (Denmark, government portal)
 │   ├── linkedin-search/               # LinkedIn public job listings (country-agnostic)
-│   └── freehire-search/               # freehire.me tech job aggregator (multi-market, REST API)
+│   ├── freehire-search/               # freehire.me tech job aggregator (multi-market, REST API)
+│   └── firecrawl-search/              # Firecrawl web search - any board, any market (API key, metered)
 ├── cv/
 │   └── main_example.tex               # moderncv LaTeX template
 ├── cover_letters/
@@ -297,10 +298,11 @@ Give it your local job board's URL. The command investigates the portal (search-
 
 Maintaining a fork adapted to your market or language? Add it to the [Community forks & adaptations](https://github.com/MadsLorentzen/ai-job-search/discussions/78) thread so others can find it.
 
-For **country-agnostic** starting points outside Denmark, the repo ships two portal skills alongside the Danish demos:
+For **country-agnostic** starting points outside Denmark, the repo ships three portal skills alongside the Danish demos:
 
 - **`linkedin-search`** — built on LinkedIn's public, unauthenticated `jobs-guest` endpoints. Field-agnostic, **zero runtime dependencies** (runs with just `bun`), and takes the search location as an explicit flag, so it works for any market out of the box (`-l "Berlin, Germany"`, `-l "Mumbai, Maharashtra, India"`, `-l "Remote"`, …). Intended for **personal use only** — automated access is against LinkedIn's Terms of Service, so keep volume low. See `.agents/skills/linkedin-search/SKILL.md`.
 - **`freehire-search`** — queries the [freehire.me](https://freehire.me) aggregator's public REST API (JSON, no API key). Tech-focused (software, data, engineering, DevOps, remote), multi-market via facet flags (`--region`, `--country`, `--remote`), and **zero runtime dependencies**. Unlike the HTML-scraping Danish portals, results come back structured (skills, seniority, category). The backend is MIT-licensed and [self-hostable](https://github.com/strelov1/freehire) — point `FREEHIRE_API_URL` at your own instance if you prefer. See `.agents/skills/freehire-search/SKILL.md`.
+- **`firecrawl-search`** — searches the live web with [Firecrawl](https://docs.firecrawl.dev) instead of one specific board, so it covers **any** job board in any market and language with **no HTML parser to maintain**: Firecrawl extracts company, location, and posting date from each page. Scope it per query with `--site jobs.lever.co,job-boards.greenhouse.io`, `--country`, and `--location`. Useful when your market has no portal skill yet, or when a shipped one has broken on a markup change — and `detail <url>` reads a posting from *any* source. **Unlike every other portal skill, the hosted service needs an API key** (`FIRECRAWL_API_KEY`) and is **metered per result** (2 credits per 10 requested results, rounded up; ~5 per enriched result), so it is meant to be **invoked directly** with a `--limit` you choose rather than run by `/scrape`, and ships `enabled: false` as its steady state. [Self-hostable](https://github.com/firecrawl/firecrawl) via `FIRECRAWL_API_URL`, which needs no key and no credits. Still **zero runtime dependencies** (REST, no SDK). See `.agents/skills/firecrawl-search/SKILL.md`.
 
 ### Salary benchmarking
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -26,7 +26,7 @@ On Windows, `py --version` is often the most reliable check. If your system expo
 
 ### Bun (for job search tools)
 
-The job portal CLIs (four Danish portals plus the country-agnostic `linkedin-search` and `freehire-search` tools) are written in TypeScript and run with Bun.
+The job portal CLIs (four Danish portals plus the country-agnostic `linkedin-search`, `freehire-search`, and `firecrawl-search` tools) are written in TypeScript and run with Bun.
 
 - macOS/Linux:
 
@@ -166,7 +166,7 @@ Run these from the repository root.
 - PowerShell:
 
 ```powershell
-$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search")
+$tools = @("jobbank-search", "jobdanmark-search", "jobindex-search", "jobnet-search", "linkedin-search", "freehire-search", "firecrawl-search")
 foreach ($tool in $tools) {
   Push-Location ".agents/skills/$tool/cli"
   bun install
@@ -176,12 +176,14 @@ foreach ($tool in $tools) {
 
 - Bash / zsh / Git Bash:
 ```bash
-for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search; do
+for tool in jobbank-search jobdanmark-search jobindex-search jobnet-search linkedin-search freehire-search firecrawl-search; do
   (cd .agents/skills/$tool/cli && bun install)
 done
 ```
 
-For `linkedin-search` and `freehire-search` the install is optional: both have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
+For `linkedin-search`, `freehire-search`, and `firecrawl-search` the install is optional: all three have zero runtime dependencies and run with plain `bun`; `bun install` only pulls TypeScript dev types.
+
+The hosted `firecrawl-search` service additionally needs a [Firecrawl](https://firecrawl.dev) API key and is **metered per result**, so it ships `enabled: false` and is meant to be invoked directly rather than run by `/scrape` — export `FIRECRAWL_API_KEY` and call it when you need it. (A [self-hosted](https://github.com/firecrawl/firecrawl) instance via `FIRECRAWL_API_URL` needs no key and no credits.) Every other portal skill works without credentials.
 
 If you're outside Denmark, you can generate an equivalent search skill for your local job board with `/add-portal` — it scaffolds the same CLI structure for any public portal and test-runs a live query before registering. See the "Job search tools" section in the README.
 


### PR DESCRIPTION
## What changed and why

Adds a country-agnostic Firecrawl portal skill for finding and reading job postings when a dedicated portal skill is unavailable or degraded.

The integration follows the existing portal CLI contract, uses the v2 REST API without runtime dependencies, supports hosted authentication and keyless self-hosted instances, and includes retry, timeout, validation, formatting, and parsing coverage. It remains `enabled: false` by design because hosted searches are metered; users invoke it directly with an explicit result limit instead of adding recurring cost to `/scrape`.

Documentation covers query scoping, search-freshness limitations, self-hosting, and the measured credit formula. CI includes the new CLI in the portal matrix.

## Failing case / reproduction (for fixes)

Not applicable; this is a new optional integration.

## Verification

- `python3 tools/lint_skills.py`
- `python3 tools/security_guards.py`
- `python3 tools/check_framework_version.py`
- `python3 -m unittest discover -s tests -t .` — 132 passed
- `bun run typecheck`
- `bun test` — 47 passed
- Hosted Firecrawl search → detail flow
- Keyless self-hosted search → detail flow over HTTP, with no `Authorization` header sent