### PR TITLE
feat(setup): populate candidate profile for Srija Chakraborty

### DIFF
--- a/.agents/skills/jobbank-search/SKILL.md
+++ b/.agents/skills/jobbank-search/SKILL.md
@@ -19,7 +19,7 @@ description: >
   jobbank søgning, find stilling, data scientist job, software developer job,
   projektleder stilling, konsulent job, data analyse job.
 context: fork
-enabled: true  # set to false to keep this portal installed but have /scrape skip it
+enabled: false  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobbank-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobdanmark-search/SKILL.md
+++ b/.agents/skills/jobdanmark-search/SKILL.md
@@ -17,7 +17,7 @@ description: >
   work in denmark, employment denmark, job denmark, jobs near me denmark,
   apprentice denmark, internship denmark, part-time denmark, full-time denmark.
 context: fork
-enabled: true  # set to false to keep this portal installed but have /scrape skip it
+enabled: false  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobdanmark-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobindex-search/SKILL.md
+++ b/.agents/skills/jobindex-search/SKILL.md
@@ -17,7 +17,7 @@ description: >
   hiring denmark, job listings denmark, python jobs denmark, grafisk designer job,
   data engineer job, softwareudvikler job, full stack developer job danmark.
 context: fork
-enabled: true  # set to false to keep this portal installed but have /scrape skip it
+enabled: false  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobindex-search/cli/src/cli.ts *)
 ---
 

--- a/.agents/skills/jobnet-search/SKILL.md
+++ b/.agents/skills/jobnet-search/SKILL.md
@@ -18,7 +18,7 @@ description: >
   social worker job denmark, occupation search denmark, esco occupation, job deadline,
   ansøgningsfrist, søg efter job, full time job denmark, part time job denmark.
 context: fork
-enabled: true  # set to false to keep this portal installed but have /scrape skip it
+enabled: false  # set to false to keep this portal installed but have /scrape skip it
 allowed-tools: Bash(bun run .agents/skills/jobnet-search/cli/src/cli.ts *)
 ---
 

--- a/.claude/skills/job-application-assistant/01-candidate-profile.md
+++ b/.claude/skills/job-application-assistant/01-candidate-profile.md
@@ -8,55 +8,66 @@ framework_version: 1.0.0
 <!-- After running /setup, all sections will be filled with your actual information -->
 
 ## Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_ADDRESS]
-- **Phone:** [YOUR_PHONE]
-- **Email:** [YOUR_EMAIL]
-- **LinkedIn:** [YOUR_LINKEDIN_URL]
-- **GitHub:** [YOUR_GITHUB_URL]
-- **Languages:** [YOUR_LANGUAGES with proficiency levels]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
+- **Name:** Srija Chakraborty
+- **Location:** London, UK
+- **Phone:** 07546526104
+- **Email:** chakrabortysrija073@gmail.com
+- **LinkedIn:** linkedin.com/in/chakraborty-srija
+- **GitHub:** github.com/srija-chakraborty
+- **Languages:** English (fluent), Bengali (native), Hindi (fluent)
+- **Status:** Available immediately
+- **Constraints:** Based in London, UK. Prefers London-based or UK-wide remote roles; open to relocation for the right opportunity. Currently on a Graduate visa - requires future sponsorship for a Skilled Worker visa (or equivalent) beyond the visa's own work rights window.
 
 ## Education
 
 | Degree | Period | Institution | Key Topics |
 |--------|--------|-------------|------------|
-| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+| MSc Robotics, AI & Autonomous Systems (2:1, 70%) | Oct 2023 - Nov 2024 | City, University of London, UK | Machine Learning, Robotics, Imaging, Vision, AI for Engineering Design, Advanced Signal Processing. Dissertation: "Study of Camera LiDAR Fusion Techniques for Detection, Tracking & Mapping in Autonomous Vehicles" |
+| BTech Electronics & Communication Engineering (GPA: 8.77) | Aug 2019 - Aug 2023 | Techno India University | Computer Networks & Network Theory (OSI model, routing, latency/bandwidth analysis), Digital Electronics & Microprocessors (logic design, system-level thinking) |
 
 ## Professional Experience
 
-### [JOB_TITLE] - [COMPANY] ([START] - [END])
-[LOCATION]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+### AI Engineer - Nannie.ai (Sep 2025 - Present)
+London, UK
+- Frontier AI research using computer vision to identify animal body language and behaviour, contributing to AI-driven wellbeing monitoring solutions
+- Built a RAG workflow, bringing p95 response time to 5s and cutting cost by 75%; resolved context window failures and materially reduced hallucinations with grounding guardrails and QA regression checks
+- Led development of a Gemini-powered legal automation workflow integrating web intake, Gmail API ingestion, classification, and AI-assisted response drafting, reducing turnaround time from hours to 5 minutes
+- Created a prototype for containers and microservices to implement modular, API-based serving patterns for faster iteration, with documentation and written training modules to onboard new engineers
 
-<!-- Add more roles as needed -->
+### Business Manager - Belle Epoque Patisserie (Jan 2024 - Sep 2025)
+London, UK
+- Directed daily operations and shift execution, increasing monthly income by 18% and average daily footfall by 15% through improved staffing, service flow, and upsell routines
+- Owned hiring and onboarding (CV screening, interviews, training), reducing time to productivity by 30% with structured training checklists and coaching
 
 ## Independent Projects
 <!-- Projects outside of employment: freelance, open source, personal -->
-- **[PROJECT_NAME]**: [DESCRIPTION]
+- **Hybrid Hospital RAG Chatbot** (FastAPI, Neo4j, Streamlit, Docker): Built and shipped a 3-service hospital QA system with a Neo4j ETL pipeline loading 6 CSV datasets into a connected graph, fully Dockerised with Compose. Hybrid RAG pipeline routes queries across graph reasoning, semantic review retrieval, and operational lookup tools, supporting 14 benchmark query types across 6 linked healthcare entity classes
+- **Camera-LiDAR Sensor Fusion for Autonomous Driving** (MSc Dissertation): Trained and evaluated JMODT on the KITTI dataset, achieving 82% mAP and 91.37% MOTA; cross-dataset validation on NuScenes Mini reached 76% mAP and 85% MOTA. Built a repeatable evaluation loop to compare detection/tracking performance across datasets and configurations, and analysed failure modes (occlusion, dense scenes)
+- **Robotic Task Optimisation using Travelling Salesman Problem (TSP)**: Simulated robotic path planning as a TSP and evaluated heuristic optimisers on instances up to 100 cities; benchmarked Genetic Algorithm and Ant Colony Optimisation against an exact brute-force baseline (feasible up to n=10), achieving within 2% of the optimality gap in total route distance
 
 ## Technical Skills
 
 ### Programming & ML
-- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
-- [OTHER_SKILLS]
+- **Python**: PyTorch, LangChain, Hugging Face Transformers, OpenAI APIs, Gemini APIs
+- Vector DB / vector search, Prompt & Context Engineering, AI Agents, LLMOps, Model Evaluation, ML Inference, RAG Pipelines
 
 ### Domain Expertise
-- [DOMAIN_1]
-- [DOMAIN_2]
+- AI/ML systems and RAG pipeline engineering
+- Cloud infrastructure and deployment (GCP, AWS)
+- Robotics and autonomous systems (sensor fusion, detection, tracking)
 
 ### Software & Tools
-- [TOOL_LIST]
+- FastAPI, REST APIs, Docker, Kubernetes, Terraform, Jenkins, GitLab CI/CD, GCP (Cloud Run, Compute Engine, IAM), AWS, Linux/Unix
+- SQL, MongoDB, Pandas, NumPy, Power BI, Jupyter Notebook, Data Pipelines
+- Agile Methodologies, Scrum, Project Coordination, Documentation, Process Improvement, Technical Training
 
 ## Publications
 <!-- List peer-reviewed publications, if any -->
-1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+None yet.
 
 ## Awards
-- [AWARD] - [EVENT] ([YEAR])
+- Associate Google Cloud Digital Leader (GCP) - Certification - 2025
+- Global STEM Master's Leadership Scholarship - City, University of London (awarded to 2% of applicants) - 2023
 
 ## References
 - [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])

--- a/.claude/skills/job-application-assistant/02-behavioral-profile.md
+++ b/.claude/skills/job-application-assistant/02-behavioral-profile.md
@@ -8,47 +8,48 @@ framework_version: 1.0.0
 <!-- You can use results from PI, DISC, Myers-Briggs, StrengthsFinder, or a self-assessment -->
 
 ## Overview
-[YOUR_NAME]'s behavioral assessment identifies them as a **[PROFILE_TYPE]** pattern. [1-2 SENTENCE_SUMMARY].
+Srija's self-assessed behavioral profile is a hands-on AI/cloud engineer who pairs structured, evidence-driven execution with genuine comfort operating across technical and non-technical stakeholders. Not a formal PI/DISC/Myers-Briggs assessment - self-described in `/setup`, so treat it as a working hypothesis to refine as more evidence (references, LinkedIn recommendations) comes in.
+
+<!-- [Self-reported via /setup interview questions - no formal assessment (PI/DISC/MBTI) on file] -->
 
 ## Core Behavioral Drives
 
 | Drive | Level | Meaning |
 |-------|-------|---------|
-| [DRIVE_1] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_2] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_3] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_4] | [LEVEL] | [DESCRIPTION] |
+| Process orientation | High | Prefers structured teams with clear process over unstructured chaos |
+| Stakeholder engagement | High | Comfortable and energized by cross-functional, non-technical stakeholder contact (reinforced by Belle Epoque management background) |
+| Exploration tolerance | High | Also drawn to research-leaning, exploratory work (MSc dissertation, Nannie.ai frontier research) - not purely execution-focused |
+| Decision speed | Mixed | Iterates quickly on shippable work, but wants data/benchmarks before committing on ambiguous or high-stakes calls |
 
 ## Strongest Behaviors
-- **[BEHAVIOR_1]:** [DESCRIPTION]
-- **[BEHAVIOR_2]:** [DESCRIPTION]
-- **[BEHAVIOR_3]:** [DESCRIPTION]
+- **Collaborative, high-frequency communicator:** Checks in regularly with stakeholders rather than working in isolation; direct and concise rather than verbose
+- **Evidence-driven iteration:** Combines fast shipping with QA regression checks and benchmarking (RAG grounding guardrails, cross-dataset validation on the dissertation) rather than shipping blind
+- **Comfortable bridging technical and non-technical worlds:** Belle Epoque operations/hiring experience plus AI engineering gives credibility on both sides of a technical-business conversation
 
 ## How You Work Best
-- [ENVIRONMENT_PREFERENCE_1]
-- [ENVIRONMENT_PREFERENCE_2]
-- [ENVIRONMENT_PREFERENCE_3]
+- Structured team with clear process, not ambiguous ownership
+- Cross-functional roles with real stakeholder contact, not purely heads-down IC work
+- Some room for exploratory/research work alongside delivery work
 
 ## Growth Areas (frame positively in applications)
-- **[AREA_1]:** [HOW_TO_FRAME_IT_POSITIVELY]
-- **[AREA_2]:** [HOW_TO_FRAME_IT_POSITIVELY]
+- **Large-scale distributed systems depth:** Strong RAG/ML and cloud-native (Docker/Kubernetes/Terraform) experience, but less exposure than a senior platform engineer to very large-scale distributed infrastructure. Frame as: actively building this depth, with demonstrated cloud/infra fundamentals (GCP, AWS, Kubernetes, Terraform) as the foundation.
 
 ## Mapping to Job Posting Language
 
 When a job posting mentions these keywords, it's a **strong behavioral fit**:
-- [KEYWORD_OR_PHRASE_THAT_MATCHES_YOUR_STYLE]
-- [ANOTHER_KEYWORD]
+- "cross-functional collaboration", "stakeholder communication", "fast-paced", "ownership", "small team"
+- "research-driven", "experimentation", "data-driven decision making"
 
 When a job posting mentions these, flag as **potential friction** (not deal-breaker):
-- [KEYWORD_OR_PHRASE_THAT_MIGHT_CLASH]
-- [ANOTHER_KEYWORD]
+- "highly ambiguous, unstructured environment with no process" - Srija prefers some process scaffolding
+- Roles that are purely large-scale distributed-systems infrastructure with no AI/ML surface - not a fit with current strengths, more of a stretch role
 
 ## Management Style Preferences
-- [WHAT_MANAGEMENT_STYLE_WORKS_FOR_YOU]
-- [WHAT_DOESN'T_WORK]
+- Works well with managers who check in regularly and give clear direction on priorities
+- Values room to iterate and bring data to decisions rather than being told the answer upfront
 
 ## Using This in Applications
-- **Cover letters:** [HOW_TO_WEAVE_IN_BEHAVIORAL_STRENGTHS]
-- **CV:** [WHAT_TO_EMPHASIZE]
-- **Interviews:** [WHAT_STAR_EXAMPLES_TO_USE]
-- **Don't overstate:** [WHAT_NOT_TO_CLAIM]
+- **Cover letters:** Lead with the collaborative, evidence-driven working style when the posting emphasizes cross-functional or fast-moving teams
+- **CV:** Emphasize measurable, benchmarked outcomes (p95 latency, cost cuts, mAP/MOTA scores) as evidence of the evidence-driven behavior pattern
+- **Interviews:** Use the Belle Epoque STAR examples to demonstrate stakeholder/team management; use the Nannie.ai RAG and dissertation STAR examples to demonstrate data-driven iteration
+- **Don't overstate:** Do not claim deep large-scale distributed-systems expertise this profile does not yet support

--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -44,9 +44,9 @@ How well do the required/preferred skills align with the candidate's capabilitie
 | 40-59 | Partial match, significant upskilling needed |
 | 0-39 | Fundamental mismatch |
 
-**Strong match areas:** [YOUR_PRIMARY_SKILLS]
-**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
-**Weak match areas:** [SKILLS_YOU_LACK]
+**Strong match areas:** Python, PyTorch, LangChain, RAG pipelines, OpenAI/Gemini APIs, AI agents, LLMOps, Hugging Face Transformers, vector search, FastAPI, Docker, Kubernetes, Terraform, GCP, AWS
+**Moderate match areas:** SQL, MongoDB, CI/CD (Jenkins, GitLab), Power BI, data pipelines, robotics/sensor fusion (from MSc dissertation), Agile/Scrum delivery
+**Weak match areas:** Large-scale distributed systems at senior-platform-engineer depth; roles requiring deep experience with ML frameworks/tools not yet used in production (e.g. Spark, Kafka, or other big-data stacks not listed above)
 
 ### 2. Experience Match (0-100)
 Does work history align with what they're looking for?
@@ -58,9 +58,9 @@ Does work history align with what they're looking for?
 | 40-59 | Adjacent experience, would need to make the case |
 | 0-39 | Unrelated experience |
 
-**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
-**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
-**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+**Strong:** AI/ML engineering, RAG pipeline development, agentic AI workflows, cloud-native AI deployment
+**Moderate:** Robotics/autonomous systems (research-level, from MSc), general cloud/DevOps engineering, technical project delivery and stakeholder management (from Belle Epoque)
+**Entry-level:** Roles requiring several years of large-scale distributed-systems or platform-engineering experience specifically
 
 ### 3. Behavioral/Culture Fit (0-100)
 Does the role and company culture match the behavioral profile?
@@ -91,19 +91,19 @@ Does this role advance career goals and contain tasks that energize?
 | 0-39 | Dead end or backwards step |
 
 **Career goals:**
-- [YOUR_CAREER_GOAL_1]
-- [YOUR_CAREER_GOAL_2]
-- [YOUR_CAREER_GOAL_3]
+- Grow as an AI/ML engineer building production RAG pipelines and agentic AI systems
+- Deepen cloud infrastructure and MLOps skills (deployment, scaling, CI/CD for ML systems)
+- Build toward roles combining AI engineering with cloud-native infrastructure ownership
 
 **Motivation filter:** Evaluate not just whether you *can* do the tasks, but whether the tasks will *energize* you. Consider:
-- Tasks that energize: [YOUR_ENERGIZING_TASKS]
-- Tasks that drain: [YOUR_DRAINING_TASKS]
-- Non-task factors: leadership style, department culture, company values, degree of autonomy
+- Tasks that energize: Building and shipping RAG/LLM systems and AI agents; cloud deployment and MLOps work; research-leaning exploratory problems
+- Tasks that drain: Pure generalist software engineering with no AI/ML/cloud surface; highly ambiguous environments with no process
+- Non-task factors: cross-functional stakeholder contact, some structure/process, room to bring data to decisions
 
 **Life situation alignment:** Consider personal constraints:
-- **Security**: [YOUR_FINANCIAL_SITUATION_CONTEXT]
-- **Flexibility**: [YOUR_SCHEDULE_CONSTRAINTS]
-- **Professional development**: [YOUR_GROWTH_PRIORITIES]
+- **Security**: On a UK Graduate visa - roles that explicitly require citizenship/PR fail the eligibility gate; roles silent on sponsorship should be flagged and checked, not auto-skipped
+- **Flexibility**: Based in London; prefers London-based or UK-wide remote roles, open to relocation for the right opportunity
+- **Professional development**: Wants to build deeper distributed-systems/platform-engineering depth alongside continuing AI/ML and cloud work
 
 ### 6. Salary Benchmark (Optional)
 

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -43,18 +43,18 @@ Expected output: `Output written on main_<company>_<role>.pdf (2 pages, ...)`. A
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Srija Chakraborty - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.77]{geometry}
 \usepackage{import}
 
 % Personal data
-\name{[FIRST_NAME]}{[LAST_NAME]}
-\address{[YOUR_ADDRESS]}{}{}
-\phone[mobile]{[YOUR_PHONE]}
-\email{[YOUR_EMAIL]}
-\extrainfo{\href{[YOUR_LINKEDIN_URL]}{LinkedIn}, \href{[YOUR_GITHUB_URL]}{GitHub}}
+\name{Srija}{Chakraborty}
+\address{London, UK}{}{}
+\phone[mobile]{07546526104}
+\email{chakrabortysrija073@gmail.com}
+\extrainfo{\href{https://linkedin.com/in/chakraborty-srija}{LinkedIn}, \href{https://github.com/srija-chakraborty}{GitHub}}
 
 \begin{document}
 \makecvtitle
@@ -116,11 +116,11 @@ When the role sits outside your home domain, **lead with the domain-transfer arg
 **Create 2-3 profile statement templates for your main role types:**
 
 <!-- SETUP: These are populated based on your background -->
-**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+**For AI Engineer / Agentic AI roles:**
+> AI Engineer with hands-on experience building production RAG pipelines and agentic AI workflows, currently at Nannie.ai. Skilled in Python, PyTorch, LangChain, and vector search, with a track record of cutting inference latency (p95 to 5s) and cost (75%) while reducing hallucinations through grounding guardrails and QA regression checks. Backed by an MSc in Robotics, AI & Autonomous Systems and hands-on cloud deployment experience (GCP, AWS, Docker, Kubernetes).
 
-**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+**For Cloud / DevOps Engineer roles:**
+> AI & Cloud Engineer with production experience deploying containerised, API-based AI services on GCP and AWS. Skilled in Docker, Kubernetes, Terraform, and CI/CD (Jenkins, GitLab), with a track record of building modular, API-based serving patterns for faster iteration. Combines infrastructure fundamentals with hands-on ML/AI systems experience, bringing a practical understanding of what production AI workloads need from the platforms they run on.
 
 Statements labeled *[Used for: <company>_<role>]* were extracted from archived application drafts by `/setup` Path A. They are **phrasing references, never fact sources**: when drafting from one, every factual claim still comes from `01-candidate-profile.md` - a past tailored draft does not vouch for its own accuracy.
 

--- a/.claude/skills/job-application-assistant/07-interview-prep.md
+++ b/.claude/skills/job-application-assistant/07-interview-prep.md
@@ -39,6 +39,70 @@ Keep answers to 1-2 minutes. Be specific. End with what you learned or would do 
 
 <!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
 
+## STAR Candidates (Complete Manually)
+
+<!-- Extracted from CV bullets by /setup Path A. Fill in S/T/A/R details before using in an interview. -->
+
+### RAG workflow latency & cost reduction (Nannie.ai)
+**Source:** CV - AI Engineer, Nannie.ai
+**What happened:** Built a RAG workflow that brought p95 response time to 5s and cut cost by 75%, resolving context window failures and reducing hallucinations with grounding guardrails and QA regression checks.
+**Why it matters:** Strong answer for "tell me about a time you optimized a system" or "how do you approach reliability in AI systems"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Gemini-powered legal automation workflow (Nannie.ai)
+**Source:** CV - AI Engineer, Nannie.ai
+**What happened:** Led development of a workflow integrating web intake, Gmail API ingestion, classification, and AI-assisted response drafting, cutting turnaround time from hours to 5 minutes.
+**Why it matters:** Good for "describe a project you led" or "how have you used AI to automate a business process"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Hybrid Hospital RAG Chatbot
+**Source:** CV - Independent Project
+**What happened:** Built and shipped a 3-service hospital QA system with a Neo4j ETL pipeline and a hybrid RAG pipeline routing across graph reasoning, semantic retrieval, and operational lookup tools.
+**Why it matters:** Good for "walk me through a project end to end" or technical deep-dive questions on RAG/knowledge graph design
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Camera-LiDAR sensor fusion dissertation
+**Source:** CV - MSc Dissertation
+**What happened:** Trained and evaluated JMODT on KITTI (82% mAP, 91.37% MOTA) with cross-dataset validation on NuScenes Mini, analysing failure modes like occlusion and dense scenes.
+**Why it matters:** Good for "describe a research project" or "how do you handle a result that doesn't generalize"
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Belle Epoque operations turnaround
+**Source:** CV - Business Manager, Belle Epoque Patisserie
+**What happened:** Directed daily operations and shift execution, increasing monthly income by 18% and average daily footfall by 15% through improved staffing, service flow, and upsell routines.
+**Why it matters:** Good for "tell me about a time you improved a process" or leadership/ownership questions - especially useful for bridging non-technical experience into a technical role narrative
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Hiring & onboarding process improvement (Belle Epoque)
+**Source:** CV - Business Manager, Belle Epoque Patisserie
+**What happened:** Owned hiring and onboarding (CV screening, interviews, training), reducing time to productivity by 30% with structured training checklists and coaching.
+**Why it matters:** Good for "tell me about a time you mentored or trained someone" or questions about building repeatable processes
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
 ## Common Tough Questions
 
 ### "Why did you leave [previous company]?"

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -8,68 +8,72 @@
 
 The `site:` query templates in this file are the **WebSearch fallback** — for portals without a CLI, company career pages, or when a CLI fails.
 
+**Note:** The Danish portal demos (`jobindex-search`, `jobnet-search`, `jobdanmark-search`, `jobbank-search`) are disabled (`enabled: false`) for this profile since the target market is London, UK, not Denmark. `linkedin-search` and `freehire-search` remain enabled. Consider running `/add-portal` to scaffold a UK-specific board (e.g. Indeed, Reed, CWJobs) when convenient.
+
 ## Search Sites
 
-Primary (your market's job boards - scaffold one with `/add-portal`):
-- **[YOUR_JOB_BOARD]** - your market's largest general job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY]); also covered by `linkedin-search` CLI
-- **[YOUR_INDUSTRY_JOB_BOARD]** - a niche/industry board for your field (optional)
-- **[YOUR_ADDITIONAL_JOB_BOARD]** - another major board for your market (optional)
+Primary:
+- **linkedin.com/jobs** - LinkedIn job listings (filter: United Kingdom / London); covered by the `linkedin-search` CLI
+- **indeed.co.uk** - UK's largest general job board (WebSearch fallback until a CLI is scaffolded via `/add-portal`)
+- **reed.co.uk** - major UK job board (WebSearch fallback)
 
 Secondary (company career pages via Google):
 - Direct Google searches with `site:` filters for known target companies
 
 ## Query Categories
 
-Queries are grouped by priority. Each query should be combined with your location terms (e.g. your city, region, or metro area) where the site supports it.
+Queries are grouped by priority. Each query should be combined with location terms (London, UK, or "remote UK") where the site supports it.
 
-### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+### Priority 1: AI Engineer / Agentic AI
 
-These match your strongest and most desired career direction.
-
-```
-site:[YOUR_JOB_BOARD] "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
-```
-
-### Priority 2: [YOUR_DOMAIN_EXPERTISE]
-
-These match your domain expertise.
+These match the strongest and most desired career direction: production RAG pipelines, agentic AI workflows, LLM engineering.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+site:indeed.co.uk "AI Engineer" London
+site:indeed.co.uk "RAG" OR "LLM engineer" London OR remote
+site:linkedin.com/jobs "AI Engineer" United Kingdom
+site:linkedin.com/jobs "Agentic AI" OR "AI Agents" United Kingdom
+site:reed.co.uk "AI Engineer" London
 ```
 
-### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
+### Priority 2: Cloud / DevOps Engineer
 
-Adjacent roles you could pivot into.
-
-```
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
-```
-
-### Priority 4: Broader Technical / Consulting
-
-Wider net for general technical roles.
+Roles leaning on GCP/AWS/Kubernetes/Terraform and cloud-native AI deployment.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_KEY_SKILL] developer [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+site:indeed.co.uk "Cloud Engineer" London OR remote
+site:indeed.co.uk "MLOps Engineer" London OR "United Kingdom"
+site:linkedin.com/jobs "Cloud Engineer" AI OR ML United Kingdom
+site:reed.co.uk "DevOps Engineer" London
+```
+
+### Priority 3: ML Engineer / Robotics-Adjacent
+
+Adjacent roles drawing on the MSc in Robotics, AI & Autonomous Systems and applied ML background.
+
+```
+site:indeed.co.uk "Machine Learning Engineer" London
+site:linkedin.com/jobs "ML Engineer" Python United Kingdom
+site:indeed.co.uk "Computer Vision Engineer" London OR remote
+```
+
+### Priority 4: Broader Technical / AI-Adjacent
+
+Wider net for general AI/cloud-adjacent technical roles.
+
+```
+site:indeed.co.uk Python developer AI London
+site:linkedin.com/jobs "Python developer" RAG OR LangChain United Kingdom
+site:indeed.co.uk "AI solutions" consultant London
 ```
 
 ## Location Filter
 
-When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
-- [YOUR_CITY] and surrounding areas
-- [ACCEPTABLE_AREA_1]
-- [ACCEPTABLE_AREA_2]
-- [BORDERLINE_AREA] (borderline - ~X min by transit)
-- [TOO_FAR_AREA] (too far)
+When evaluating results, verify the job location is within reasonable commute distance or is remote-eligible:
+- London and Greater London - ideal
+- Remote (UK-wide) - ideal
+- Other UK cities (Manchester, Birmingham, Cambridge, etc.) - acceptable if hybrid/remote-friendly or the role is strong enough to justify relocation
+- Outside the UK - only if the posting explicitly welcomes international applicants or offers visa sponsorship (see the eligibility gate in `04-job-evaluation.md` - Srija is on a UK Graduate visa and needs future sponsorship)
 
 ## Date Filter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
-# Job Application Assistant for [YOUR_NAME]
+# Job Application Assistant for Srija Chakraborty
 
 <!-- SETUP: This file is populated by running /setup -->
 <!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
 
 ## Role
-This repo is a job application workspace. Claude acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+This repo is a job application workspace. Claude acts as a career advisor and application assistant for Srija Chakraborty, helping with:
 1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
 2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
 3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
@@ -16,67 +16,75 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 <!-- This section is auto-populated by /setup. You can also fill it in manually. -->
 
 ### Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
-- **Languages:** [YOUR_LANGUAGES]
-- **CV language:** [YOUR_CV_LANGUAGE] <!-- English unless your market expects otherwise; /setup asks -->
+- **Name:** Srija Chakraborty
+- **Location:** London, UK (open to relocation for the right role; priority is London-based or UK-wide remote roles first)
+- **Languages:** Bengali (native), English (fluent), Hindi (fluent)
+- **CV language:** English <!-- default; /setup can revisit with --section search -->
 
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+- **Status:** Available immediately
+- **Work permit:** UK Graduate visa - will need employer sponsorship (Skilled Worker visa or equivalent) to remain in the UK long-term
+- **LinkedIn headline:** "AI & Cloud Engineer"
 
 ### Education
 <!-- List your degrees, most recent first -->
-- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
-  - Thesis: "[THESIS_TITLE]"
-  - Topics: [KEY_TOPICS]
+- **MSc in Robotics, AI & Autonomous Systems** (Oct 2023-Nov 2024) - City, University of London, UK (2:1, 70%)
+  - Thesis: "Study of Camera-LiDAR Fusion Techniques for Detection, Tracking & Mapping in Autonomous Vehicles"
+  - Topics: Machine Learning, Robotics, Imaging, Vision, AI for Engineering Design, Advanced Signal Processing
+- **BTech in Electronics & Communication Engineering** (Aug 2019-Aug 2023) - Techno India University (GPA: 8.77)
+  - Topics: Computer Networks & Network Theory (OSI model, routing, latency/bandwidth analysis), Digital Electronics & Microprocessors (logic design, system-level thinking)
 
 ### Professional Experience
 <!-- List your roles, most recent first -->
-- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
-  - [KEY_RESPONSIBILITY_1]
-  - [KEY_RESPONSIBILITY_2]
-  - [KEY_ACHIEVEMENT]
+- **AI Engineer** (Sep 2025 - Present) - **Nannie.ai** (London, UK)
+  - Frontier AI research using computer vision to identify animal body language and behaviour to improve wellbeing
+  - Built a RAG workflow bringing p95 response time to 5s and cutting cost by 75%; resolved context window failures and reduced hallucinations with grounding guardrails and QA regression checks
+  - Led development of a Gemini-powered legal automation workflow (web intake, Gmail API ingestion, classification, AI-assisted drafting), reducing turnaround time from hours to 5 minutes
+- **Business Manager** (Jan 2024 - Sep 2025) - **Belle Epoque Patisserie** (London, UK)
+  - Directed daily operations and shift execution, increasing monthly income by 18% and average daily footfall by 15%
+  - Owned hiring and onboarding, reducing time to productivity by 30% with structured training checklists and coaching
 
 ### Technical Skills
-- **Primary:** [YOUR_PRIMARY_SKILLS]
-- **Secondary:** [YOUR_SECONDARY_SKILLS]
-- **Domain:** [YOUR_DOMAIN_EXPERTISE]
-- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+- **Primary:** Python, PyTorch, LangChain, RAG pipelines, OpenAI/Gemini APIs, AI agents, LLMOps, Hugging Face Transformers, vector search/vector DBs
+- **Secondary:** FastAPI, REST APIs, Docker, Kubernetes, Terraform, Jenkins, GitLab CI/CD, GCP (Cloud Run, Compute Engine, IAM), AWS, SQL, MongoDB
+- **Domain:** AI/ML engineering, agentic AI, RAG pipeline engineering, cloud infrastructure, robotics/autonomous systems (sensor fusion, detection, tracking)
+- **Software:** Pandas, NumPy, Power BI, Jupyter Notebook, Linux/Unix
 
 ### Certifications
 <!-- List relevant certifications with dates -->
-- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+- **Associate Google Cloud Digital Leader (GCP)** - completed 2025
 
 ### Publications
 <!-- List peer-reviewed publications, if any -->
-- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+None yet.
 
 ### Awards
 <!-- List relevant awards, hackathons, competitions -->
-- [AWARD_NAME] - [EVENT] ([YEAR])
+- Global STEM Master's Leadership Scholarship - City, University of London (awarded to top 2% of applicants) (2023)
 
 ### Behavioral Profile
 <!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
-- **[TRAIT_1]** - [DESCRIPTION]
-- **[TRAIT_2]** - [DESCRIPTION]
-- **Strengths:** [YOUR_STRENGTHS]
-- **Growth areas:** [YOUR_GROWTH_AREAS]
-- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+<!-- Self-reported via /setup - no formal assessment (PI/DISC/MBTI) on file -->
+- **Structured collaborator** - Thrives in teams with clear process, but is equally comfortable in cross-functional roles with heavy stakeholder contact and in research-leaning, exploratory work
+- **Evidence-driven iterator** - Moves fast and ships, but backs decisions with data/benchmarks (QA regression checks, cross-dataset validation) rather than shipping blind
+- **Strengths:** Direct, concise communication; comfortable checking in frequently and collaboratively; bridges technical and non-technical stakeholders (reinforced by Belle Epoque management background)
+- **Growth areas:** Still building depth in large-scale distributed systems - strong cloud-native fundamentals (GCP, AWS, Kubernetes, Terraform) but less exposure than a senior platform engineer to very large-scale distributed infrastructure
+- **Thrives in:** Structured teams with clear process; cross-functional roles with real stakeholder contact; some room for exploratory/research work alongside delivery work
 
 ### What Excites You
 <!-- What motivates you professionally -->
-- [PASSION_1]
-- [PASSION_2]
+- Building production RAG/LLM systems and AI agents
+- Cloud infrastructure & MLOps - deployment, scaling, and infra for ML/AI systems
+- Agentic AI and applied AI engineering more broadly
 
 ### Target Sectors
 <!-- Industries and companies you're targeting -->
-- [SECTOR_1]: [EXAMPLE_COMPANIES]
-- [SECTOR_2]: [EXAMPLE_COMPANIES]
+- **Target role directions:** AI Engineer, Cloud/DevOps Engineer, Agentic AI roles
+- No specific target companies yet - open to broad search across AI/cloud engineering employers
 
 ### Deal-breakers
 <!-- Hard constraints on job search -->
-- [DEALBREAKER_1]
-- [DEALBREAKER_2]
+- Roles that explicitly require citizenship/PR with no sponsorship path (hard eligibility-gate failure - see `04-job-evaluation.md`)
+- Flag (do not auto-skip) roles silent on visa sponsorship, and roles that are purely generalist software engineering with no AI/ML/cloud surface - surface these so Srija can decide case by case rather than filtering them out automatically
 
 ## Repo Structure
 - `cv/` - LaTeX CV variants (moderncv template, banking style)

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -1,4 +1,4 @@
-%% Example CV - [YOUR_NAME]
+%% Example CV - Srija Chakraborty
 %% Comprehensive overview of all competencies, experience, and achievements.
 %% Use as a master reference when tailoring role-specific CVs.
 %%
@@ -24,18 +24,19 @@
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Srija Chakraborty - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}
+\usepackage{needspace}
 
 % personal data
-\name{[First]}{[Last]}
-\address{[Your Address, City, Country]}{}{}
-\phone[mobile]{[+XX XXXXXXXXXX]}
-\email{[your.email@example.com]}
-\extrainfo{\href{[https://linkedin.com/in/your-profile]}{LinkedIn}, \href{[https://github.com/your-username]}{GitHub}}
+\name{Srija}{Chakraborty}
+\address{London, UK}{}{}
+\phone[mobile]{07546526104}
+\email{chakrabortysrija073@gmail.com}
+\extrainfo{\href{https://linkedin.com/in/chakraborty-srija}{LinkedIn}, \href{https://github.com/srija-chakraborty}{GitHub}}
 
 \begin{document}
 
@@ -46,7 +47,7 @@
 % ============================================================
 
 \vspace{6pt}
-\small{[Write a 3-5 line profile statement tailored to the role you're applying for. Focus on what makes you uniquely qualified. Example: "Data scientist with a PhD in [field] and X years of industry experience. Combines deep domain expertise in [domain] with strong applied machine learning and Python development skills. Experienced in developing end-to-end ML pipelines, from data ingestion to stakeholder-facing dashboards."]}
+\small{AI \& Cloud Engineer with experience building RAG pipelines, agentic AI workflows, and scalable cloud infrastructure across research and operational environments. Skilled in Python, vector search, ML systems, and cloud deployment, with a track record of improving inference performance, reducing operational costs, and building production-ready AI solutions. MSc in Robotics, AI \& Autonomous Systems from City, University of London.}
 
 % ============================================================
 %     CORE COMPETENCIES
@@ -56,15 +57,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item \textbf{[Skill Category 1]}: [Specific skills, frameworks, tools. Be concrete.]
+\item \textbf{AI \& ML}: Python, PyTorch, OpenAI APIs, Gemini APIs, LangChain, Vector DB, Prompt \& Context Engineering, AI Agents, LLMOps, Hugging Face Transformers, Model Eval, ML Inference, RAG Pipelines
 
-\item \textbf{[Skill Category 2]}: [Specific skills, frameworks, tools.]
+\item \textbf{Backend \& Cloud}: FastAPI, REST APIs, Docker, Kubernetes, Terraform, Jenkins, GitLab CI/CD, GCP, AWS, Cloud Run, Compute Engine, IAM, Linux/Unix
 
-\item \textbf{[Skill Category 3]}: [Specific skills, frameworks, tools.]
+\item \textbf{Data \& Analytics}: SQL, MongoDB, Pandas, NumPy, Power BI, Jupyter Notebook, Data Pipelines
 
-\item \textbf{[Skill Category 4]}: [Domain expertise, methods, approaches.]
+\item \textbf{Robotics \& Autonomous Systems}: Sensor fusion, object detection and tracking, evaluation-loop design (KITTI, NuScenes)
 
-\item \textbf{[Skill Category 5]}: [Tools, platforms, software.]
+\item \textbf{Delivery \& Collaboration}: Agile Methodologies, Scrum, Project Coordination, Documentation, Process Improvement, Technical Training, Operational Support
 
 \end{itemize}
 
@@ -77,32 +78,50 @@
 \begin{itemize}
 
 % --- Most Recent Role ---
-\item{\cventry{[YYYY--Present]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{2025--Present}{AI Engineer}{Nannie.ai}{London, UK}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1 - be specific, use numbers where possible]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
-    \item [Achievement or responsibility 4]
+    \item Frontier AI research using computer vision to identify animal body language and behaviour to improve wellbeing, contributing to AI-driven monitoring solutions
+    \item Built a RAG workflow, bringing p95 response time to 5s and cutting cost by 75\%; resolved context window failures and materially reduced hallucinations with grounding guardrails and QA regression checks
+    \item Led development of a Gemini-powered legal automation workflow integrating web intake, Gmail API ingestion, classification, and AI-assisted response drafting, reducing turnaround time from hours to 5 minutes
+    \item Created a prototype for containers and microservices to implement modular, API-based serving patterns for faster iteration, with documentation and written training modules to onboard new engineers
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Previous Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\needspace{5\baselineskip}
+\item{\cventry{2024--2025}{Business Manager}{Belle Epoque Patisserie}{London, UK}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
+    \item Directed daily operations and shift execution, increasing monthly income by 18\% and average daily footfall by 15\% through improved staffing, service flow, and upsell routines
+    \item Owned hiring and onboarding (CV screening, interviews, training), reducing time to productivity by 30\% with structured training checklists and coaching
 \end{itemize}}}
+
+\end{itemize}
+
+% ============================================================
+%     PROJECTS
+% ============================================================
+
+\section{Projects}
+\vspace{1pt}
+\begin{itemize}
+
+\item{\cventry{}{FastAPI, Neo4j, Streamlit, Docker}{Hybrid Hospital RAG Chatbot}{}{}{\vspace{1pt}
+Built and shipped a 3-service hospital QA system with a Neo4j ETL pipeline loading 6 CSV datasets into a connected graph, fully Dockerised with Compose. Hybrid RAG pipeline routes queries across graph reasoning, semantic review retrieval, and operational lookup tools, supporting 14 benchmark query types.
+}}
 
 \vspace{3pt}
 
-% --- Earlier Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
-\begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-\end{itemize}}}
+\item{\cventry{}{MSc Dissertation}{Camera-LiDAR Sensor Fusion for Autonomous Driving}{}{}{\vspace{1pt}
+Trained and evaluated JMODT on the KITTI dataset, achieving 82\% mAP and 91.37\% MOTA; cross-dataset validation on NuScenes Mini reached 76\% mAP and 85\% MOTA. Built a repeatable evaluation loop to compare detection/tracking performance and analysed failure modes.
+}}
+
+\vspace{3pt}
+
+\item{\cventry{}{Genetic Algorithm, Ant Colony Optimisation}{Robotic Task Optimisation using TSP}{}{}{\vspace{1pt}
+Simulated robotic path planning as a Travelling Salesman Problem and benchmarked heuristic optimisers on instances up to 100 cities, achieving within 2\% of the optimality gap against an exact brute-force baseline.
+}}
 
 \end{itemize}
 
@@ -114,14 +133,14 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-Thesis: ``[Thesis Title].'' [Brief description of research focus.]
+\item{\cventry{2023--2024}{MSc Robotics, AI \& Autonomous Systems (2:1, 70\%)}{City, University of London}{UK}{}{\vspace{1pt}
+Thesis: ``Study of Camera-LiDAR Fusion Techniques for Detection, Tracking \& Mapping in Autonomous Vehicles.'' Key modules: Machine Learning, Robotics, Imaging, Vision, AI for Engineering Design, Advanced Signal Processing.
 }}
 
 \vspace{3pt}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-[Brief description or key topics.]
+\item{\cventry{2019--2023}{BTech Electronics \& Communication Engineering (GPA: 8.77)}{Techno India University}{}{}{\vspace{1pt}
+Key modules: Computer Networks \& Network Theory, Digital Electronics \& Microprocessors.
 }}
 
 \end{itemize}
@@ -133,17 +152,7 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Languages}
 \vspace{1pt}
 \begin{itemize}
-\item [Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).
-\end{itemize}
-
-% ============================================================
-%     PUBLICATIONS (optional)
-% ============================================================
-
-\section{Publications}
-\vspace{1pt}
-\begin{itemize}
-\item [Author(s)] ([Year]). [Title]. [Journal/Conference]. \href{[DOI_URL]}{DOI link}
+\item Bengali (native), English (fluent), Hindi (fluent).
 \end{itemize}
 
 % ============================================================
@@ -153,7 +162,8 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Honors and Awards}
 \vspace{1pt}
 \begin{itemize}
-\item{\textbf{[Award Name]} -- [Event/Organization] ([Year]).}
+\item{\textbf{Associate Google Cloud Digital Leader (GCP)} -- Certification (2025).}
+\item{\textbf{Global STEM Master's Leadership Scholarship} -- City, University of London, awarded to top 2\% of applicants (2023).}
 \end{itemize}
 
 % ============================================================


### PR DESCRIPTION
## Summary
- Runs `/setup` Path A from the CV in `documents/cv/`, plus follow-up interview questions for career goals, behavioral profile, and job search configuration
- Populates `CLAUDE.md`, all seven `job-application-assistant` skill files, and `cv/main_example.tex`
- Disables the four Danish portal CLIs (jobindex, jobnet, jobdanmark, jobbank) since the target market is London, UK — `linkedin-search` and WebSearch fallback remain enabled until a UK portal is scaffolded via `/add-portal`

## Note
This branch was built in an isolated worktree while another session/process was concurrently editing the same files directly in the main checkout with some different answers (e.g. visa expiry date, employment status, location priority). Per your instruction, this PR uses the answers gathered in this conversation as authoritative. Please review against whatever is currently uncommitted in your main checkout before merging — there may be conflicting local changes to resolve or discard.

## Test plan
- [x] `cv/main_example.tex` compiled with lualatex — 2 pages, no errors
- [x] Visually inspected both pages — no orphaned entries, clean layout
- [x] ATS text-layer check via `pdftotext -layout` — email/phone extract as literal text, reading order matches visual order
- [ ] Review candidate profile facts (visa status, employment status, location preference) for accuracy before relying on this for real applications
- [ ] Run `/scrape` against the new profile to confirm search queries work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)