### PR TITLE
ci: run dependency-review on forks too, not just upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,14 @@ jobs:
       - run: python -m unittest discover -s tests -t . -v
 
   dependency-review:
-    name: Dependency review (upstream PRs only)
-    # Requires the repo's Dependency graph, which forks never inherit and
-    # which may be disabled upstream - so: upstream PRs only, and the
-    # graph is probed first. If it is unavailable, the job warns and
-    # passes instead of hard-failing (the same graceful-skip pattern the
-    # workflow uses for optional tools). Enabling Dependency graph under
-    # Settings -> Advanced Security activates the real check.
-    if: github.event_name == 'pull_request' && github.repository == 'MadsLorentzen/ai-job-search'
+    name: Dependency review
+    # Requires the repo's Dependency graph, which not every repo (upstream or
+    # fork) has enabled - so the graph is probed first, and the job warns and
+    # passes instead of hard-failing if it's unavailable (the same
+    # graceful-skip pattern the workflow uses for optional tools), rather than
+    # being gated to a specific repository. Enabling Dependency graph under
+    # Settings -> Advanced Security activates the real check on any repo.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
The `dependency-review` job is gated with `github.repository == 'MadsLorentzen/ai-job-search'` on top of `pull_request`, so it never runs on any fork — including ones already listed in this repo's community fork-index (discussion #78).

Repro on a currently-listed fork:

    gh api repos/chenyuan99/ai-job-search/actions/runs/29461249388/jobs \
      --jq '.jobs[] | select(.name | contains("Dependency")) | .conclusion'
    # skipped

This is a `pull_request` run, so the job's own dependency-graph probe never even executes — `github.repository` fails first. The probe (hits the dependency-graph/sbom endpoint, warns-and-passes on anything but 200) already handles "this repo doesn't have Dependency graph enabled," making the repository allowlist redundant.

Fix: drop that clause, leaving `if: github.event_name == 'pull_request'`. Also reworded the job's `name:` (was `Dependency review (upstream PRs only)`) and its comment, since both asserted "upstream-only" and would contradict the loosened condition. Nothing else changes — one job, its `name`, comment, and `if:` line.

Verification:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses clean
- `git diff upstream/master -- .github/workflows/ci.yml` is exactly this 8-line change
-  Same fix is already green on a fork pull_request run (frJEN/ai-job-search-au-starter, run 30449177305): `Dependency review` now actually runs instead of being skipped, probes for Dependency graph support, then warns-and-passes when the graph is not enabled.

No local run against upstream itself is possible pre-PR; this is a strict subset of what's already validated on that fork.