### PR TITLE
chore(setup): populate candidate profile via /setup

### DIFF
--- a/.claude/skills/job-application-assistant/01-candidate-profile.md
+++ b/.claude/skills/job-application-assistant/01-candidate-profile.md
@@ -4,61 +4,93 @@ framework_version: 1.0.0
 
 # Candidate Profile
 
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all sections will be filled with your actual information -->
-
 ## Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_ADDRESS]
-- **Phone:** [YOUR_PHONE]
-- **Email:** [YOUR_EMAIL]
-- **LinkedIn:** [YOUR_LINKEDIN_URL]
-- **GitHub:** [YOUR_GITHUB_URL]
-- **Languages:** [YOUR_LANGUAGES with proficiency levels]
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **Constraints:** [YOUR_COMMUTE_OR_LOCATION_CONSTRAINTS]
+- **Name:** Kyrylo Lubynets
+- **Location:** Poulton-le-Fylde, UK
+- **Phone:** +44 7342675330
+- **Email:** dev.lubinets@gmail.com
+- **LinkedIn:** https://www.linkedin.com/in/mrlubynets/
+- **GitHub:** https://github.com/devlubinets
+- **Languages:** English (B2-C1), Ukrainian (native), Russian (native)
+- **Status:** Employed, open to new opportunities
+- **Constraints:** UK-wide search, remote only for now
 
 ## Education
 
 | Degree | Period | Institution | Key Topics |
 |--------|--------|-------------|------------|
-| [DEGREE] | [YEARS] | [INSTITUTION] | [TOPICS] |
+| Master of Engineering, Intelligent Computer Management Systems | 2017-2019 | Odessa National Polytechnic University | Intelligent control systems |
+| Bachelor of Engineering, System Engineering | 2013-2017 | Odessa National Polytechnic University | Systems engineering, automated process control, programming |
 
 ## Professional Experience
 
-### [JOB_TITLE] - [COMPANY] ([START] - [END])
-[LOCATION]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_1]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_2]
-- [RESPONSIBILITY_OR_ACHIEVEMENT_3]
+### Full Stack Developer - Ideal4Finance (January 2023 - Present)
+- Development of database structure
+- Support of existing projects
+- Developed new module in Laminas MVC
+- Took part in design decisions; created architecture for new features
+- Performed sprint planning, demos, inter-team communications
+- Implemented unit tests
+- Technologies: PHP, Docker, MySQL, LAMP, Traefik, PipeDrive, Companies House API, Microsoft Graph, Laminas, Unleash feature toggle, Propel
 
-<!-- Add more roles as needed -->
+### Full Stack Developer - Corposoft.io (April 2022 - October 2022)
+- Development of database structure
+- Project deployment on DigitalOcean via SSH
+- Support of existing projects
+- Set up and integrated the Stripe payment system
+- Set up and integrated Shopify, Etsy, Ebay APIs
+- File handling with dropzone.js and spatie laravel-medialibrary
+- Built front-end components in Vue
+- File/gallery/user builder, archive preparation
+- Content access control via spatie laravel-permission
+- Technologies: PHP, Vue, Laravel, Docker, MySQL, LAMP
+
+### PHP Web Developer - Golden Age (August 2021 - April 2022)
+One of the largest jewelry manufacturers in Ukraine
+- Created data access points for API
+- Customized admin panel based on the Orchid package
+- Built artisan console commands for routine tasks
+- Wrote code for handling Excel documents
+- Created tests based on PHPUnit
+- Technologies: PHP, Laravel, Docker, MySQL, MongoDB, LAMP
 
 ## Independent Projects
-<!-- Projects outside of employment: freelance, open source, personal -->
-- **[PROJECT_NAME]**: [DESCRIPTION]
+- **Google Search Console API integration**: Google Cloud project using the Search Console API
 
 ## Technical Skills
 
-### Programming & ML
-- **[LANGUAGE]** ([PROFICIENCY]): [FRAMEWORKS_AND_LIBRARIES]
-- [OTHER_SKILLS]
+### Programming
+- **PHP** (professional): Laravel, Laminas/Zend, Symfony
+- **JavaScript**: Vue.js
+- **SQL**: MySQL, MongoDB
 
 ### Domain Expertise
-- [DOMAIN_1]
-- [DOMAIN_2]
+- SME web applications and CRM systems
+- Fintech backend integrations (Companies House API, PipeDrive)
+- E-commerce integrations (Stripe, Shopify, Etsy, Ebay)
 
 ### Software & Tools
-- [TOOL_LIST]
+- Docker, LAMP, DigitalOcean, Traefik
+- Microsoft Graph API, Unleash feature toggle, Propel ORM
+- spatie/laravel-medialibrary, spatie/laravel-permission, dropzone.js
+- PHPUnit, Orchid CMS
+- Google Cloud Platform
+
+## Certifications
+- **Google Cloud Fundamentals: Core Infrastructure**
+- **Google Cloud Essentials**
+- **Baseline: Infrastructure Google Cloud**
+- **Build a Website on Google Cloud**
+- **Create and Manage Cloud Resources**
+- **Perform Foundational Infrastructure Tasks in Google Cloud**
+- **Managing Linux Systems**
+- **Learning How to Learn: Powerful mental tools to help you master tough subjects**
 
 ## Publications
-<!-- List peer-reviewed publications, if any -->
-1. [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL]. [DOI_LINK]
+<!-- None -->
 
 ## Awards
-- [AWARD] - [EVENT] ([YEAR])
+<!-- None -->
 
 ## References
-- [NAME], [TITLE], [COMPANY] ([EMAIL], [PHONE])
-
 More references available upon request.

--- a/.claude/skills/job-application-assistant/02-behavioral-profile.md
+++ b/.claude/skills/job-application-assistant/02-behavioral-profile.md
@@ -4,51 +4,44 @@ framework_version: 1.0.0
 
 # Behavioral Profile
 
-<!-- SETUP: This file is populated by running /setup -->
-<!-- You can use results from PI, DISC, Myers-Briggs, StrengthsFinder, or a self-assessment -->
+<!-- No formal assessment (PI/DISC/Myers-Briggs) on file. Populated from CV self-description and /setup interview answers. -->
 
 ## Overview
-[YOUR_NAME]'s behavioral assessment identifies them as a **[PROFILE_TYPE]** pattern. [1-2 SENTENCE_SUMMARY].
+No formal behavioral assessment on file. Kyrylo describes himself, in his own CV summary, as results-oriented, creative/innovative, and a hard-working team player who is always willing to learn. *[Inferred from CV self-description - review before relying on this]*
 
 ## Core Behavioral Drives
-
-| Drive | Level | Meaning |
-|-------|-------|---------|
-| [DRIVE_1] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_2] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_3] | [LEVEL] | [DESCRIPTION] |
-| [DRIVE_4] | [LEVEL] | [DESCRIPTION] |
+<!-- No formal assessment data available. Add here if you complete one. -->
 
 ## Strongest Behaviors
-- **[BEHAVIOR_1]:** [DESCRIPTION]
-- **[BEHAVIOR_2]:** [DESCRIPTION]
-- **[BEHAVIOR_3]:** [DESCRIPTION]
+- **Results orientation:** "Always oriented to the results expected by your business" - self-described focus on business outcomes over process. *[Inferred from CV self-description]*
+- **Broad ownership:** "Able to create and maintain any features and solutions your business needs" - comfortable owning a feature end-to-end (DB structure through UI) across every role to date. *[Inferred from CV self-description and work history]*
+- **Continuous learner:** Consistently adds certifications outside core job scope (8 Google Cloud certs, a "Learning How to Learn" course) alongside full-time work. *[Inferred from CV certifications list]*
 
 ## How You Work Best
-- [ENVIRONMENT_PREFERENCE_1]
-- [ENVIRONMENT_PREFERENCE_2]
-- [ENVIRONMENT_PREFERENCE_3]
+- Individual-contributor track: wants to keep growing technically rather than move into people management
+- Aiming toward a Lead Developer role - technical leadership and architecture ownership, not direct reports
+- Remote work
 
 ## Growth Areas (frame positively in applications)
-- **[AREA_1]:** [HOW_TO_FRAME_IT_POSITIVELY]
-- **[AREA_2]:** [HOW_TO_FRAME_IT_POSITIVELY]
+<!-- None identified yet - revisit after a few interview cycles or a formal assessment. -->
 
 ## Mapping to Job Posting Language
 
 When a job posting mentions these keywords, it's a **strong behavioral fit**:
-- [KEYWORD_OR_PHRASE_THAT_MATCHES_YOUR_STYLE]
-- [ANOTHER_KEYWORD]
+- "Lead Developer" / "Senior Developer" with a technical (not managerial) track
+- "own features end-to-end", "architecture", "technical ownership"
+- Remote-first or remote-friendly
 
 When a job posting mentions these, flag as **potential friction** (not deal-breaker):
-- [KEYWORD_OR_PHRASE_THAT_MIGHT_CLASH]
-- [ANOTHER_KEYWORD]
+- "team lead" or "engineering manager" roles requiring people management / direct reports
+- Office-mandatory or hybrid-with-minimum-days roles (current search is remote-only)
 
 ## Management Style Preferences
-- [WHAT_MANAGEMENT_STYLE_WORKS_FOR_YOU]
-- [WHAT_DOESN'T_WORK]
+- Prefers to stay technical rather than manage people directly
+- Open to mentoring/technical leadership within an IC track
 
 ## Using This in Applications
-- **Cover letters:** [HOW_TO_WEAVE_IN_BEHAVIORAL_STRENGTHS]
-- **CV:** [WHAT_TO_EMPHASIZE]
-- **Interviews:** [WHAT_STAR_EXAMPLES_TO_USE]
-- **Don't overstate:** [WHAT_NOT_TO_CLAIM]
+- **Cover letters:** Lean on the "owns a feature end-to-end" pattern (DB design through front-end through deployment) as evidence of readiness for a Lead Developer track
+- **CV:** Emphasize architecture/design-decision bullets (already present at Ideal4Finance) over routine maintenance bullets
+- **Interviews:** Use the Ideal4Finance architecture/design-decision involvement as the primary example of technical ownership
+- **Don't overstate:** No formal people-management or team-lead title held yet - "Lead Developer" is a stated career goal, not current experience. Do not imply prior management experience.

--- a/.claude/skills/job-application-assistant/04-job-evaluation.md
+++ b/.claude/skills/job-application-assistant/04-job-evaluation.md
@@ -44,9 +44,9 @@ How well do the required/preferred skills align with the candidate's capabilitie
 | 40-59 | Partial match, significant upskilling needed |
 | 0-39 | Fundamental mismatch |
 
-**Strong match areas:** [YOUR_PRIMARY_SKILLS]
-**Moderate match areas:** [YOUR_SECONDARY_SKILLS]
-**Weak match areas:** [SKILLS_YOU_LACK]
+**Strong match areas:** PHP, Laravel, Laminas/Zend, Symfony, MySQL, Docker, REST API integrations
+**Moderate match areas:** Vue.js, MongoDB, Google Cloud Platform, payment/e-commerce integrations (Stripe, Shopify, Etsy, Ebay), CRM integrations (PipeDrive)
+**Weak match areas:** Formal team leadership/people management, languages outside the PHP/JS ecosystem (e.g. Python, Go, Java), advanced DevOps/CI-CD beyond Docker basics
 
 ### 2. Experience Match (0-100)
 Does work history align with what they're looking for?
@@ -58,9 +58,9 @@ Does work history align with what they're looking for?
 | 40-59 | Adjacent experience, would need to make the case |
 | 0-39 | Unrelated experience |
 
-**Strong:** [YOUR_DIRECT_EXPERIENCE_DOMAINS]
-**Moderate:** [YOUR_ADJACENT_EXPERIENCE]
-**Entry-level:** [ROLES_WITH_LIMITED_EXPERIENCE]
+**Strong:** SME web application / CRM backend development, fintech backend integrations, e-commerce integrations
+**Moderate:** Enterprise LAMP-stack roles, front-end (Vue) work alongside backend
+**Entry-level:** Lead Developer / technical leadership roles (aspirational career direction, not yet held)
 
 ### 3. Behavioral/Culture Fit (0-100)
 Does the role and company culture match the behavioral profile?
@@ -91,19 +91,19 @@ Does this role advance career goals and contain tasks that energize?
 | 0-39 | Dead end or backwards step |
 
 **Career goals:**
-- [YOUR_CAREER_GOAL_1]
-- [YOUR_CAREER_GOAL_2]
-- [YOUR_CAREER_GOAL_3]
+- Grow as a software developer on an individual-contributor track
+- Progress toward a Lead Developer role (technical leadership, not people management)
+- Deepen backend/architecture ownership within the PHP ecosystem
 
 **Motivation filter:** Evaluate not just whether you *can* do the tasks, but whether the tasks will *energize* you. Consider:
-- Tasks that energize: [YOUR_ENERGIZING_TASKS]
-- Tasks that drain: [YOUR_DRAINING_TASKS]
-- Non-task factors: leadership style, department culture, company values, degree of autonomy
+- Tasks that energize: hands-on coding, architecture and design decisions, owning a feature end-to-end
+- Tasks that drain: formal people management / having direct reports
+- Non-task factors: remote-first culture, degree of technical autonomy
 
 **Life situation alignment:** Consider personal constraints:
-- **Security**: [YOUR_FINANCIAL_SITUATION_CONTEXT]
-- **Flexibility**: [YOUR_SCHEDULE_CONSTRAINTS]
-- **Professional development**: [YOUR_GROWTH_PRIORITIES]
+- **Security**: Currently employed; searching from a position of choice, not urgency
+- **Flexibility**: UK-wide search, remote only for now
+- **Professional development**: Wants growth toward Lead Developer without moving into management
 
 ### 6. Salary Benchmark (Optional)
 

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -115,12 +115,11 @@ When the role sits outside your home domain, **lead with the domain-transfer arg
 
 **Create 2-3 profile statement templates for your main role types:**
 
-<!-- SETUP: These are populated based on your background -->
-**For [YOUR_PRIMARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_1]
+**For PHP / Full Stack Developer roles:**
+> Full stack PHP developer with experience building and maintaining CRM, fintech, and e-commerce web applications across Laravel, Laminas, and Symfony. Comfortable owning a feature end-to-end, from database design through to deployment, and has taken part in architecture and design decisions on production systems. Uses tools like Claude Code to move faster on repetitive implementation work while keeping design decisions in hand.
 
-**For [YOUR_SECONDARY_ROLE_TYPE] roles:**
-> [YOUR_PROFILE_STATEMENT_TEMPLATE_2]
+**For Lead Developer roles:**
+> Full stack PHP developer moving into technical leadership, with three years across fintech, e-commerce, and SME CRM platforms (Laravel, Laminas, Symfony). Has already taken part in architecture and design decisions rather than pure feature delivery, and is looking to extend that into ownership of a codebase's technical direction.
 
 Statements labeled *[Used for: <company>_<role>]* were extracted from archived application drafts by `/setup` Path A. They are **phrasing references, never fact sources**: when drafting from one, every factual claim still comes from `01-candidate-profile.md` - a past tailored draft does not vouch for its own accuracy.
 

--- a/.claude/skills/job-application-assistant/07-interview-prep.md
+++ b/.claude/skills/job-application-assistant/07-interview-prep.md
@@ -12,30 +12,49 @@ Structure answers as: **Situation** (context), **Task** (your responsibility), *
 
 Keep answers to 1-2 minutes. Be specific. End with what you learned or would do differently.
 
-## Ready-Made STAR Examples
+## STAR Candidates (Complete Manually)
 
-<!-- These are populated by /setup from your actual experience. Below are templates showing the format. -->
+<!-- Extracted from CV bullets - no detailed narrative or metrics available yet. Fill in S/T/A/R specifics before using in an interview. -->
 
-### 1. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
-**S:** [CONTEXT - what was happening, what was the problem]
-**T:** [YOUR RESPONSIBILITY - what you specifically needed to do]
-**A:** [WHAT YOU DID - specific actions, tools, methods]
-**R:** [OUTCOME - measurable results, adoption, impact]
-**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+### New Laminas MVC module - Ideal4Finance
+**Source:** CV - Ideal4Finance, Full Stack Developer
+**What happened:** Developed a new module in Laminas MVC and took part in the design decisions/architecture behind it.
+**Why it matters:** Answers "tell me about a time you owned a feature end-to-end" or "tell me about a design decision you made" - directly supports the Lead Developer narrative.
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
-### 2. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
-**S:** [CONTEXT]
-**T:** [YOUR RESPONSIBILITY]
-**A:** [WHAT YOU DID]
-**R:** [OUTCOME]
-**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+### Stripe payment integration - Corposoft.io
+**Source:** CV - Corposoft.io, Full Stack Developer
+**What happened:** Set up and integrated the Stripe payment system into a client's Laravel application.
+**Why it matters:** Answers "tell me about integrating a third-party API/payment system" or "how do you handle sensitive data (payments)".
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
-### 3. [PROJECT_NAME] ([SKILL_DEMONSTRATED])
-**S:** [CONTEXT]
-**T:** [YOUR RESPONSIBILITY]
-**A:** [WHAT YOU DID]
-**R:** [OUTCOME]
-**Use for:** "[QUESTION_TYPE_1]", "[QUESTION_TYPE_2]"
+### Admin panel customization on Orchid - Golden Age
+**Source:** CV - Golden Age, PHP Web Developer
+**What happened:** Customized an admin panel built on the Orchid package for one of Ukraine's largest jewelry manufacturers, including artisan console commands and Excel document handling.
+**Why it matters:** Answers "tell me about working with an unfamiliar framework/package" or "tell me about automating a manual process".
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
+
+### Multi-marketplace integration - Corposoft.io
+**Source:** CV - Corposoft.io, Full Stack Developer
+**What happened:** Integrated Shopify, Etsy, and Ebay APIs into a single client platform.
+**Why it matters:** Answers "tell me about a time you worked with multiple external APIs" or "how do you handle integration complexity".
+**S/T/A/R stub:**
+- Situation:
+- Task:
+- Action:
+- Result:
 
 <!-- Add more STAR examples as needed. Aim for 4-6 covering different competencies. -->
 

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -1,7 +1,5 @@
 # Search Queries for Job Scraper
 
-<!-- SETUP: Customize these queries based on your skills, target roles, and location -->
-
 ## Installed portal CLIs (primary for `/scrape`)
 
 `/scrape` discovers every portal skill under `.agents/skills/*/SKILL.md` and runs its CLI first. Shipped country-agnostic CLIs include `linkedin-search` and `freehire-search`; Danish demos and any skill you add with `/add-portal` are included the same way. You do **not** need a matching `site:` line below for those CLIs to run.
@@ -10,66 +8,59 @@ The `site:` query templates in this file are the **WebSearch fallback** — for 
 
 ## Search Sites
 
-Primary (your market's job boards - scaffold one with `/add-portal`):
-- **[YOUR_JOB_BOARD]** - your market's largest general job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY]); also covered by `linkedin-search` CLI
-- **[YOUR_INDUSTRY_JOB_BOARD]** - a niche/industry board for your field (optional)
-- **[YOUR_ADDITIONAL_JOB_BOARD]** - another major board for your market (optional)
+Primary:
+- **linkedin.com/jobs** - LinkedIn job listings (filter: UK, remote); also covered by `linkedin-search` CLI
+- Also covered by `freehire-search` CLI
 
 Secondary (company career pages via Google):
-- Direct Google searches with `site:` filters for known target companies
+- Direct Google searches with `site:` filters, WebSearch fallback for UK boards without a CLI (Indeed, CWJobs, Reed, Otta) - `/add-portal` can scaffold a dedicated one later if needed
 
 ## Query Categories
 
-Queries are grouped by priority. Each query should be combined with your location terms (e.g. your city, region, or metro area) where the site supports it.
+Queries are grouped by priority. Every query should be filtered to remote / UK-wide - this candidate is not commuting to an office.
 
-### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+### Priority 1: PHP Developer roles
 
-These match your strongest and most desired career direction.
-
-```
-site:[YOUR_JOB_BOARD] "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE]" [YOUR_COUNTRY]
-```
-
-### Priority 2: [YOUR_DOMAIN_EXPERTISE]
-
-These match your domain expertise.
+These match the strongest and most desired career direction.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+site:linkedin.com/jobs "PHP Developer" remote UK
+site:linkedin.com/jobs "Full Stack Developer" PHP remote UK
+site:linkedin.com/jobs "Laravel Developer" remote UK
 ```
 
-### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
-
-Adjacent roles you could pivot into.
+### Priority 2: Domain expertise (fintech / e-commerce / SME SaaS)
 
 ```
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
+site:linkedin.com/jobs "Backend Developer" PHP remote UK
+site:linkedin.com/jobs PHP fintech remote UK
+site:linkedin.com/jobs PHP e-commerce remote UK
 ```
 
-### Priority 4: Broader Technical / Consulting
+### Priority 3: Lead Developer (career-direction stretch)
 
-Wider net for general technical roles.
+Adjacent role the candidate is growing toward - technical leadership, not people management.
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_KEY_SKILL] developer [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+site:linkedin.com/jobs "Lead Developer" PHP remote UK
+site:linkedin.com/jobs "Senior PHP Developer" remote UK
+```
+
+### Priority 4: Broader Web Developer
+
+Wider net for general PHP/web roles.
+
+```
+site:linkedin.com/jobs "Web Developer" PHP remote UK
+site:linkedin.com/jobs PHP developer remote UK
 ```
 
 ## Location Filter
 
-When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
-- [YOUR_CITY] and surrounding areas
-- [ACCEPTABLE_AREA_1]
-- [ACCEPTABLE_AREA_2]
-- [BORDERLINE_AREA] (borderline - ~X min by transit)
-- [TOO_FAR_AREA] (too far)
+Candidate is based in Poulton-le-Fylde, UK, and is searching remote-only for now.
+- Remote (UK-wide): PASS
+- Hybrid with a mandatory office presence: FLAG (discuss with user - not remote-only)
+- On-site only: FAIL (does not match current search constraint)
 
 ## Date Filter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,7 @@
-# Job Application Assistant for [YOUR_NAME]
-
-<!-- SETUP: This file is populated by running /setup -->
-<!-- After running /setup, all [PLACEHOLDER] tokens will be replaced with your actual information -->
+# Job Application Assistant for Kyrylo Lubynets
 
 ## Role
-This repo is a job application workspace. Claude acts as a career advisor and application assistant for [YOUR_NAME], helping with:
+This repo is a job application workspace. Claude acts as a career advisor and application assistant for Kyrylo Lubynets, helping with:
 1. **Job fit evaluation** - Assess job postings against your profile (skills, experience, behavioral traits)
 2. **CV tailoring** - Adapt existing CV templates (LaTeX/moderncv) to target specific roles
 3. **Cover letter writing** - Draft targeted cover letters using existing templates (LaTeX)
@@ -13,70 +10,67 @@ This repo is a job application workspace. Claude acts as a career advisor and ap
 
 ## Candidate Profile
 
-<!-- This section is auto-populated by /setup. You can also fill it in manually. -->
-
 ### Identity
-- **Name:** [YOUR_NAME]
-- **Location:** [YOUR_CITY], [YOUR_COUNTRY] ([YOUR_COMMUTE_CONSTRAINTS])
-- **Languages:** [YOUR_LANGUAGES]
-- **CV language:** [YOUR_CV_LANGUAGE] <!-- English unless your market expects otherwise; /setup asks -->
+- **Name:** Kyrylo Lubynets
+- **Location:** Poulton-le-Fylde, UK (remote-only search, UK-wide)
+- **Languages:** English (B2-C1), Ukrainian (native), Russian (native)
+- **CV language:** English
 
-- **Status:** [YOUR_EMPLOYMENT_STATUS]
-- **LinkedIn headline:** "[YOUR_LINKEDIN_HEADLINE]"
+- **Status:** Employed, open to new opportunities
+- **LinkedIn headline:** "Software engineer"
 
 ### Education
-<!-- List your degrees, most recent first -->
-- **[DEGREE_LEVEL] in [FIELD]** ([YEAR_START]-[YEAR_END]) - [INSTITUTION]
-  - Thesis: "[THESIS_TITLE]"
-  - Topics: [KEY_TOPICS]
+- **Master of Engineering in Intelligent Computer Management Systems** (2017-2019) - Odessa National Polytechnic University
+- **Bachelor of Engineering in System Engineering** (2013-2017) - Odessa National Polytechnic University
 
 ### Professional Experience
-<!-- List your roles, most recent first -->
-- **[JOB_TITLE]** ([START_DATE] - [END_DATE]) - **[COMPANY]** ([LOCATION])
-  - [KEY_RESPONSIBILITY_1]
-  - [KEY_RESPONSIBILITY_2]
-  - [KEY_ACHIEVEMENT]
+- **Full Stack Developer** (January 2023 - Present) - **Ideal4Finance**
+  - Developed a new module in Laminas MVC; took part in design decisions and architecture
+  - Database structure, sprint planning/demos, unit tests
+  - Stack: PHP, Laminas, Docker, MySQL, PipeDrive, Companies House API, Microsoft Graph
+- **Full Stack Developer** (April 2022 - October 2022) - **Corposoft.io**
+  - Integrated Stripe payments and Shopify/Etsy/Ebay APIs; built Vue front-end components
+  - Stack: PHP, Laravel, Vue, Docker, MySQL
+- **PHP Web Developer** (August 2021 - April 2022) - **Golden Age**
+  - Customized an Orchid-based admin panel; built API access points and PHPUnit tests
+  - Stack: PHP, Laravel, Docker, MySQL, MongoDB
 
 ### Technical Skills
-- **Primary:** [YOUR_PRIMARY_SKILLS]
-- **Secondary:** [YOUR_SECONDARY_SKILLS]
-- **Domain:** [YOUR_DOMAIN_EXPERTISE]
-- **Software:** [YOUR_TOOLS_AND_SOFTWARE]
+- **Primary:** PHP (Laravel, Laminas/Zend, Symfony)
+- **Secondary:** JavaScript/Vue.js, MySQL, MongoDB
+- **Domain:** SME web/CRM platforms, fintech backend integrations, e-commerce integrations
+- **Software:** Docker, LAMP, DigitalOcean, Google Cloud Platform, PHPUnit, Orchid CMS
 
 ### Certifications
-<!-- List relevant certifications with dates -->
-- **[CERTIFICATION_NAME]** - [HOURS]h - completed [DATE]
+- **Google Cloud Fundamentals: Core Infrastructure**, **Google Cloud Essentials**, **Baseline: Infrastructure Google Cloud**, **Build a Website on Google Cloud**, **Create and Manage Cloud Resources**, **Perform Foundational Infrastructure Tasks in Google Cloud**, **Managing Linux Systems**, **Learning How to Learn**
 
 ### Publications
-<!-- List peer-reviewed publications, if any -->
-- [AUTHOR_LIST] ([YEAR]). [TITLE]. [JOURNAL].
+<!-- None -->
 
 ### Awards
-<!-- List relevant awards, hackathons, competitions -->
-- [AWARD_NAME] - [EVENT] ([YEAR])
+<!-- None -->
 
 ### Behavioral Profile
-<!-- Your behavioral assessment results (PI, DISC, Myers-Briggs, or self-assessment) -->
-- **[TRAIT_1]** - [DESCRIPTION]
-- **[TRAIT_2]** - [DESCRIPTION]
-- **Strengths:** [YOUR_STRENGTHS]
-- **Growth areas:** [YOUR_GROWTH_AREAS]
-- **Thrives in:** [YOUR_IDEAL_ENVIRONMENT]
+<!-- No formal assessment on file; see 02-behavioral-profile.md for CV-inferred traits -->
+- **Results-oriented** - self-described focus on business outcomes
+- **End-to-end ownership** - comfortable owning a feature from DB design through deployment
+- **Strengths:** Continuous learner (self-driven certifications alongside full-time work), broad feature ownership
+- **Growth areas:** No formal team-lead/management experience yet
+- **Thrives in:** Individual-contributor, remote-first environments with technical autonomy
 
 ### What Excites You
-<!-- What motivates you professionally -->
-- [PASSION_1]
-- [PASSION_2]
+- Growing as a software developer on an IC track, without moving into people management
+- Progressing toward a Lead Developer role - technical leadership and architecture ownership
 
 ### Target Sectors
-<!-- Industries and companies you're targeting -->
-- [SECTOR_1]: [EXAMPLE_COMPANIES]
-- [SECTOR_2]: [EXAMPLE_COMPANIES]
+- Fintech: companies like Ideal4Finance
+- E-commerce / SME SaaS: companies like Corposoft.io, Golden Age
+- Open to any UK-remote company matching PHP/Laravel/Laminas skill set (no specific target list)
 
 ### Deal-breakers
-<!-- Hard constraints on job search -->
-- [DEALBREAKER_1]
-- [DEALBREAKER_2]
+- Fewer than 25 days annual holiday
+- Salary below the £35k-£45k baseline
+- Not fully remote (current search is remote-only)
 
 ## Repo Structure
 - `cv/` - LaTeX CV variants (moderncv template, banking style)

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -1,8 +1,7 @@
-%% Example CV - [YOUR_NAME]
+%% Example CV - Kyrylo Lubynets
 %% Comprehensive overview of all competencies, experience, and achievements.
 %% Use as a master reference when tailoring role-specific CVs.
 %%
-%% SETUP: Run /setup to populate this with your actual information.
 %% Compile with: lualatex main_example.tex
 %% (pdflatex often fails on modern MiKTeX with fontawesome5 font-expansion errors.)
 
@@ -24,18 +23,18 @@
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
-    pdftitle={[YOUR_NAME] - CV},
+    pdftitle={Kyrylo Lubynets - CV},
     pdfpagemode=FullScreen,
 }
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}
 
 % personal data
-\name{[First]}{[Last]}
-\address{[Your Address, City, Country]}{}{}
-\phone[mobile]{[+XX XXXXXXXXXX]}
-\email{[your.email@example.com]}
-\extrainfo{\href{[https://linkedin.com/in/your-profile]}{LinkedIn}, \href{[https://github.com/your-username]}{GitHub}}
+\name{Kyrylo}{Lubynets}
+\address{Poulton-le-Fylde, UK}{}{}
+\phone[mobile]{+44 7342675330}
+\email{dev.lubinets@gmail.com}
+\extrainfo{\href{https://www.linkedin.com/in/mrlubynets/}{LinkedIn}, \href{https://github.com/devlubinets}{GitHub}}
 
 \begin{document}
 
@@ -46,7 +45,7 @@
 % ============================================================
 
 \vspace{6pt}
-\small{[Write a 3-5 line profile statement tailored to the role you're applying for. Focus on what makes you uniquely qualified. Example: "Data scientist with a PhD in [field] and X years of industry experience. Combines deep domain expertise in [domain] with strong applied machine learning and Python development skills. Experienced in developing end-to-end ML pipelines, from data ingestion to stakeholder-facing dashboards."]}
+\small{Full stack PHP developer with experience building and maintaining CRM, fintech, and e-commerce web applications across Laravel, Laminas, and Symfony. Comfortable owning a feature end-to-end, from database design through to deployment, and has taken part in architecture and design decisions on production systems.}
 
 % ============================================================
 %     CORE COMPETENCIES
@@ -56,15 +55,15 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item \textbf{[Skill Category 1]}: [Specific skills, frameworks, tools. Be concrete.]
+\item \textbf{PHP frameworks}: Laravel, Laminas/Zend, Symfony
 
-\item \textbf{[Skill Category 2]}: [Specific skills, frameworks, tools.]
+\item \textbf{Front-end}: JavaScript, Vue.js
 
-\item \textbf{[Skill Category 3]}: [Specific skills, frameworks, tools.]
+\item \textbf{Databases}: MySQL, MongoDB
 
-\item \textbf{[Skill Category 4]}: [Domain expertise, methods, approaches.]
+\item \textbf{Integrations}: Stripe, Shopify, Etsy, Ebay, Companies House API, Microsoft Graph, PipeDrive
 
-\item \textbf{[Skill Category 5]}: [Tools, platforms, software.]
+\item \textbf{Infrastructure}: Docker, LAMP, DigitalOcean, Traefik, Google Cloud Platform
 
 \end{itemize}
 
@@ -77,31 +76,31 @@
 \begin{itemize}
 
 % --- Most Recent Role ---
-\item{\cventry{[YYYY--Present]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\item{\cventry{2023--Present}{Full Stack Developer}{Ideal4Finance}{UK}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1 - be specific, use numbers where possible]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
-    \item [Achievement or responsibility 4]
+    \item Developed a new module in Laminas MVC; took part in design decisions and created architecture for new features
+    \item Designed and maintained database structure; implemented unit tests
+    \item Performed sprint planning, demos, and inter-team communications
+    \item Stack: PHP, Docker, MySQL, LAMP, Traefik, PipeDrive, Companies House API, Microsoft Graph, Laminas, Unleash, Propel
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Previous Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\item{\cventry{2022}{Full Stack Developer}{Corposoft.io}{Remote}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
-    \item [Achievement or responsibility 3]
+    \item Set up and integrated the Stripe payment system, and the Shopify, Etsy, and Ebay APIs
+    \item Deployed projects on DigitalOcean via SSH; built front-end components in Vue
+    \item Implemented file handling (dropzone.js, spatie laravel-medialibrary) and access control (spatie laravel-permission)
 \end{itemize}}}
 
 \vspace{3pt}
 
 % --- Earlier Role ---
-\item{\cventry{[YYYY--YYYY]}{[Job Title]}{[Company]}{[City, Country]}{}{\vspace{1pt}
+\item{\cventry{2021--2022}{PHP Web Developer}{Golden Age}{Ukraine}{}{\vspace{1pt}
 \begin{itemize}
-    \item [Achievement or responsibility 1]
-    \item [Achievement or responsibility 2]
+    \item Customized an admin panel based on the Orchid package for one of Ukraine's largest jewelry manufacturers
+    \item Built artisan console commands, Excel document handling, and PHPUnit tests
 \end{itemize}}}
 
 \end{itemize}
@@ -114,14 +113,14 @@
 \vspace{1pt}
 \begin{itemize}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-Thesis: ``[Thesis Title].'' [Brief description of research focus.]
+\item{\cventry{2017--2019}{Master of Engineering in Intelligent Computer Management Systems}{Odessa National Polytechnic University}{Odessa, Ukraine}{}{\vspace{1pt}
+Intelligent control systems.
 }}
 
 \vspace{3pt}
 
-\item{\cventry{[YYYY--YYYY]}{[Degree] in [Field]}{[Institution]}{[City, Country]}{}{\vspace{1pt}
-[Brief description or key topics.]
+\item{\cventry{2013--2017}{Bachelor of Engineering in System Engineering}{Odessa National Polytechnic University}{Odessa, Ukraine}{}{\vspace{1pt}
+Systems engineering, automated process control, programming.
 }}
 
 \end{itemize}
@@ -133,27 +132,19 @@ Thesis: ``[Thesis Title].'' [Brief description of research focus.]
 \section{Languages}
 \vspace{1pt}
 \begin{itemize}
-\item [Language 1] (native), [Language 2] (fluent), [Language 3] (intermediate).
+\item Ukrainian (native), Russian (native), English (B2-C1).
 \end{itemize}
 
 % ============================================================
-%     PUBLICATIONS (optional)
+%     CERTIFICATIONS
 % ============================================================
 
-\section{Publications}
+\section{Certifications}
 \vspace{1pt}
 \begin{itemize}
-\item [Author(s)] ([Year]). [Title]. [Journal/Conference]. \href{[DOI_URL]}{DOI link}
-\end{itemize}
-
-% ============================================================
-%     HONORS AND AWARDS (optional)
-% ============================================================
-
-\section{Honors and Awards}
-\vspace{1pt}
-\begin{itemize}
-\item{\textbf{[Award Name]} -- [Event/Organization] ([Year]).}
+\item Google Cloud Fundamentals: Core Infrastructure; Google Cloud Essentials; Baseline: Infrastructure Google Cloud
+\item Build a Website on Google Cloud; Create and Manage Cloud Resources; Perform Foundational Infrastructure Tasks in Google Cloud
+\item Managing Linux Systems; Learning How to Learn
 \end{itemize}
 
 % ============================================================


### PR DESCRIPTION
## Summary
- Ran `/setup` Path A: read `documents/cv/WebCV.pdf` and diploma/certificate files, cross-referenced them, and resolved gaps via follow-up Q&A
- Populated `CLAUDE.md`, all seven `.claude/skills/job-application-assistant/*.md` files, `cv/main_example.tex`, and `.claude/skills/job-scraper/search-queries.md` with Kyrylo Lubynets's real profile

## Notes
- Professional Experience intentionally starts at Golden Age (Aug 2021) onward per user choice — DAP IT (2017-2018) and an ASU TP / industrial-automation role evidenced by the Siemens/Yokogawa/GOST34 certs (2019, NGH Servis) were left out for now
- No LaTeX toolchain available in this environment — `cv/main_example.tex` was **not** compiled/visually verified; please compile with `lualatex` and check the 2-page layout before relying on it
- Behavioral profile and STAR examples are thin (CV self-description only, no LinkedIn About or reference letters) — STAR entries are left as stubs to fill in manually

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01RCxW5bowfS4S2T8Y5moKsK