### PR TITLE
fix(check_upstream_updates): warn when the check falls back to a fork's own origin

### DIFF
--- a/tests/test_check_upstream_updates.py
+++ b/tests/test_check_upstream_updates.py
@@ -1,0 +1,119 @@
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "check_upstream_updates.py"
+
+TEMPLATE_URL = "https://github.com/MadsLorentzen/ai-job-search.git"
+FORK_URL = "https://github.com/octocat/ai-job-search.git"
+
+FRAMEWORK_FILES = [
+    ".claude/skills/job-application-assistant/01-candidate-profile.md",
+    ".claude/skills/job-application-assistant/02-behavioral-profile.md",
+    ".claude/skills/job-application-assistant/03-writing-style.md",
+    ".claude/skills/job-application-assistant/04-job-evaluation.md",
+    ".claude/skills/job-application-assistant/05-cv-templates.md",
+    ".claude/skills/job-application-assistant/06-cover-letter-templates.md",
+    ".claude/skills/job-application-assistant/07-interview-prep.md",
+    ".claude/skills/job-application-assistant/08-application-forms.md",
+    ".claude/skills/job-application-assistant/SKILL.md",
+    "AGENTS.md",
+]
+
+FRONTMATTER = "---\nframework_version: 1.0.0\n---\n"
+
+
+class UpstreamCheckerRepoFixture(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+        tools = self.root / "tools"
+        tools.mkdir()
+        shutil.copy(SCRIPT, tools / "check_upstream_updates.py")
+
+        for rel in FRAMEWORK_FILES:
+            path = self.root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(FRONTMATTER, encoding="utf-8")
+
+        subprocess.run(["git", "init", "-b", "master"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(["git", "add", "-A"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=self.root, check=True, capture_output=True)
+
+    def add_remote(self, name: str, url: str) -> None:
+        subprocess.run(["git", "remote", "add", name, url], cwd=self.root, check=True, capture_output=True)
+
+    def materialize_remote_ref(self, name: str) -> None:
+        subprocess.run(
+            ["git", "update-ref", f"refs/remotes/{name}/master", "HEAD"],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+        )
+
+    def run_checker(self, *args) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(self.root / "tools" / "check_upstream_updates.py"), "--no-fetch", *args],
+            cwd=self.root,
+            capture_output=True,
+            text=True,
+        )
+
+
+class ForkWithoutUpstreamRemoteTests(UpstreamCheckerRepoFixture):
+    def setUp(self):
+        super().setUp()
+        self.add_remote("origin", FORK_URL)
+        self.materialize_remote_ref("origin")
+
+    def test_fork_fallback_warns_that_check_is_against_own_fork(self):
+        result = self.run_checker("--remote", "upstream")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Falling back to 'origin'", result.stdout)
+        self.assertIn("does not point to the ai-job-search template repo", result.stdout)
+        self.assertNotIn("up to date with upstream!", result.stdout)
+        self.assertIn("up to date with origin/master", result.stdout)
+
+
+class DirectCloneFallbackTests(UpstreamCheckerRepoFixture):
+    def setUp(self):
+        super().setUp()
+        self.add_remote("origin", TEMPLATE_URL)
+        self.materialize_remote_ref("origin")
+
+    def test_clone_of_template_falls_back_without_fork_warning(self):
+        result = self.run_checker("--remote", "upstream")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Falling back to 'origin'", result.stdout)
+        self.assertNotIn("does not point to the ai-job-search template repo", result.stdout)
+        self.assertIn("up to date with origin/master", result.stdout)
+
+
+class UpstreamRemotePresentTests(UpstreamCheckerRepoFixture):
+    def setUp(self):
+        super().setUp()
+        self.add_remote("origin", FORK_URL)
+        self.add_remote("upstream", TEMPLATE_URL)
+        self.materialize_remote_ref("upstream")
+
+    def test_explicit_upstream_remote_is_used_without_warning(self):
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotIn("Falling back to 'origin'", result.stdout)
+        self.assertNotIn("does not point to the ai-job-search template repo", result.stdout)
+        self.assertIn("up to date with upstream/master", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_upstream_updates.py
+++ b/tools/check_upstream_updates.py
@@ -33,9 +33,15 @@ FRAMEWORK_FILES = [
     "AGENTS.md",
 ]
 
+UPSTREAM_REPO_SLUG = "MadsLorentzen/ai-job-search"
+
 def run_git(args: list[str]) -> tuple[int, str, str]:
     res = subprocess.run(["git"] + args, cwd=str(ROOT), capture_output=True, text=True)
     return res.returncode, res.stdout, res.stderr
+
+def get_remote_url(remote_name: str) -> str:
+    rc, stdout, _ = run_git(["remote", "get-url", remote_name])
+    return stdout.strip() if rc == 0 else ""
 
 def get_framework_version_from_text(text: str) -> str | None:
     if not text.startswith("---\n"):
@@ -75,6 +81,18 @@ def main() -> int:
         else:
             print("Error: No git remotes found.")
             return 1
+
+    # A fork's own 'origin' can never reveal upstream updates: warn so the
+    # user is not misled by the final '[OK]' line below. (Direct clones of
+    # the template repo have origin == the upstream repo, so no warning.)
+    if remote != args.remote and UPSTREAM_REPO_SLUG not in get_remote_url(remote):
+        print(
+            f"Warning: Remote '{remote}' does not point to the ai-job-search "
+            f"template repo ({UPSTREAM_REPO_SLUG}), so this check compares your "
+            f"fork against itself and will never report upstream updates. "
+            f"Add the template repo as a remote to track upstream changes, e.g.:\n"
+            f"  git remote add upstream https://github.com/{UPSTREAM_REPO_SLUG}.git"
+        )
 
     if not args.no_fetch:
         print(f"Fetching latest from remote '{remote}'...")
@@ -143,7 +161,7 @@ def main() -> int:
         print("Review these changes to see if they fit your personalized fork!")
         return 0
     else:
-        print("[OK] All framework files are up to date with upstream!")
+        print(f"[OK] All framework files are up to date with {ref}!")
         return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`tools/check_upstream_updates.py` silently falls back to `origin` when the requested remote does not exist (`tools/check_upstream_updates.py:71-74`), and the final message hardcodes the word *upstream* regardless of what was actually compared (`line 146`).

In a fork without an `upstream` remote - exactly the setup `CONTRIBUTING.md` section 3 recommends ("Run the framework update checker ... in your fork") - the script compares the fork against itself and always prints:

```
[OK] All framework files are up to date with upstream!
```

This is a false positive: a fork is always up to date with itself, so real upstream updates are never detected. In this repo right now, `upstream/master` is 18 commits ahead of `origin/master`, yet the checker reports everything up to date when it falls back to `origin`.

## Reproduction

On master, in a fork whose only remote is `origin`:

```
$ python tools/check_upstream_updates.py --no-fetch --remote nonexistent-remote
Warning: Remote 'nonexistent-remote' not found. Falling back to 'origin'.
Comparing local files against upstream 'origin/master'...

[OK] All framework files are up to date with upstream!   <- misleading
```

## Fix

- When the fallback remote does not point at the ai-job-search template repo, print an actionable warning: the comparison is fork-vs-self, it will never report upstream updates, and show the command to add the template as a remote.
- The final OK line now names the ref it actually compared against (`origin/master` / `upstream/master`) instead of hardcoding "upstream".

## After the fix

```
$ python tools/check_upstream_updates.py --no-fetch --remote nonexistent-remote
Warning: Remote 'nonexistent-remote' not found. Falling back to 'origin'.
Warning: Remote 'origin' does not point to the ai-job-search template repo (MadsLorentzen/ai-job-search), so this check compares your fork against itself and will never report upstream updates. Add the template repo as a remote to track upstream changes, e.g.:
  git remote add upstream https://github.com/MadsLorentzen/ai-job-search.git
Comparing local files against upstream 'origin/master'...

[OK] All framework files are up to date with origin/master!
```

Direct clones (origin == the template repo) fall back silently, as before, with the corrected message.

## Verification

New `tests/test_check_upstream_updates.py` (following the subprocess + temp-git-repo pattern of `test_lint_skills.py`):

- 3 scenarios: fork without upstream remote, direct clone falling back, upstream remote present.
- All 3 **fail on master** and **pass with the fix**.

Ran what CI runs: `python -m unittest discover -s tests -t .` (135 tests OK), `python tools/lint_skills.py` OK, `python tools/check_framework_version.py` OK.
