### PR TITLE
test(security): require personal output ignore rules

### DIFF
--- a/tests/test_security_guards.py
+++ b/tests/test_security_guards.py
@@ -124,6 +124,23 @@ class GitignoreGuardTests(GuardRepoFixture):
         result = run_guards(self.root)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
+    def test_generated_report_rules_are_required(self):
+        # Reports are generated from the user's tracker and application archive,
+        # so losing these ignore rules can expose personal job-search history.
+        sensitive_outputs = ["reports/", "upskill/*.md"]
+        remaining = [
+            rule
+            for rule in security_guards.REQUIRED_IGNORE_RULES
+            if rule not in sensitive_outputs
+        ]
+        self.write_gitignore(remaining)
+
+        result = run_guards(self.root)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("reports/", result.stdout)
+        self.assertIn("upskill/*.md", result.stdout)
+
 
 class GitignoreNegationTests(GuardRepoFixture):
     def test_negation_reincluding_personal_data_fails(self):

--- a/tools/security_guards.py
+++ b/tools/security_guards.py
@@ -48,6 +48,10 @@ REQUIRED_IGNORE_RULES = [
     # to its own directory, so the state file lands under .claude/skills/... and
     # a repo-rooted rule silently fails to match it.
     "**/job_scraper/seen_jobs.json",
+    "**/job_scraper/notion_sync.json",
+    "**/job_scraper/*.md",
+    "*_BehavioralReport.pdf",
+    "linkedin_Profile.pdf",
     "cv/main_*.*",
     "!cv/main_example.tex",
     # ATS text extractions (/apply step 5d) carry the CV's full text.
@@ -60,8 +64,12 @@ REQUIRED_IGNORE_RULES = [
     "documents/diplomas/**",
     "documents/references/**",
     "documents/applications/**",
+    "documents/postings/**",
     "documents/interview/**",
     "job_search_tracker.csv",
+    "gmail_sync/",
+    "reports/",
+    "upskill/*.md",
 ]
 
 # Negation (re-include) rules the template legitimately ships. .gitignore is


### PR DESCRIPTION
## What changed and why

`tools/security_guards.py` now requires the personal/generated `.gitignore` rules that protect job-scraper state, pasted postings, Gmail sync state, generated reports, upskill reports, ATS text extracts, and generated cover-letter naming variants.

This keeps the guard aligned with the repo's existing privacy boundary: if a future change removes one of those ignore rules, CI makes the exposure explicit instead of silently allowing personal job-search data to become trackable.

## Failing case / reproduction (for fixes)

Previously, removing generated-output ignore rules such as `reports/` or `upskill/*.md` from `.gitignore` did not fail `python3 tools/security_guards.py`, even though those files are generated from the user's tracker and application archive.

Added `test_generated_report_rules_are_required` to prove those report rules are now enforced, alongside the existing per-rule guard test.

## Verification

- `python3 -m unittest tests.test_security_guards -v`
- `python3 tools/security_guards.py`
