### PR TITLE
fix(check_upstream_updates): compare template repo URL case-insensitively

### DIFF
--- a/tests/test_check_upstream_updates.py
+++ b/tests/test_check_upstream_updates.py
@@ -98,6 +98,22 @@ class DirectCloneFallbackTests(UpstreamCheckerRepoFixture):
         self.assertNotIn("does not point to the ai-job-search template repo", result.stdout)
         self.assertIn("up to date with origin/master", result.stdout)
 
+    def test_clone_with_lowercased_template_url_falls_back_without_fork_warning(self):
+        # GitHub serves repo paths case-insensitively, so a clone from
+        # https://github.com/madslorentzen/ai-job-search is still the template.
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", TEMPLATE_URL.lower()],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+        )
+
+        result = self.run_checker("--remote", "upstream")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Falling back to 'origin'", result.stdout)
+        self.assertNotIn("does not point to the ai-job-search template repo", result.stdout)
+
 
 class UpstreamRemotePresentTests(UpstreamCheckerRepoFixture):
     def setUp(self):

--- a/tools/check_upstream_updates.py
+++ b/tools/check_upstream_updates.py
@@ -85,7 +85,8 @@ def main() -> int:
     # A fork's own 'origin' can never reveal upstream updates: warn so the
     # user is not misled by the final '[OK]' line below. (Direct clones of
     # the template repo have origin == the upstream repo, so no warning.)
-    if remote != args.remote and UPSTREAM_REPO_SLUG not in get_remote_url(remote):
+    # GitHub serves repo paths case-insensitively, so compare lowercased.
+    if remote != args.remote and UPSTREAM_REPO_SLUG.lower() not in get_remote_url(remote).lower():
         print(
             f"Warning: Remote '{remote}' does not point to the ai-job-search "
             f"template repo ({UPSTREAM_REPO_SLUG}), so this check compares your "


### PR DESCRIPTION
Follow-up on #265, per the maintainer's review note: the `UPSTREAM_REPO_SLUG` check in `get_remote_url` was case-sensitive.

## Problem

GitHub serves repo paths case-insensitively. A user who cloned the template with a lowercased URL (e.g. `https://github.com/madslorentzen/ai-job-search.git`) is a direct clone - `origin` IS the template repo - yet the fork-vs-self warning from #265 fired spuriously:

```
$ python tools/check_upstream_updates.py --no-fetch --remote upstream
Warning: Remote 'upstream' not found. Falling back to 'origin'.
Warning: Remote 'origin' does not point to the ai-job-search template repo (MadsLorentzen/ai-job-search), so this check compares your fork against itself...
```

## Fix

Lowercase both sides of the comparison (`UPSTREAM_REPO_SLUG.lower()` vs `get_remote_url(remote).lower()`).

## Verification

New test `test_clone_with_lowercased_template_url_falls_back_without_fork_warning` (same temp-git-repo pattern): clones with `TEMPLATE_URL.lower()` and asserts no fork warning is printed.

- **Fails on the previous check** (spurious warning reproduced), **passes with this fix**.
- Full suite: `python -m unittest discover -s tests -t .` (152 tests OK), `python tools/lint_skills.py` OK, `python tools/check_framework_version.py` OK.
