### PR TITLE
docs(setup): show git remote add upstream in section 8

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -293,6 +293,7 @@ Upstream keeps improving the methodology files your fork has personalized, so pl
 1. **Commit your personalization - but know where those commits land.** `/setup` edits CLAUDE.md and the profile skill files in place; those edits are *yours*, and committing them is what lets updates merge cleanly. But a GitHub **fork of this repo is public** - forks of public repositories cannot be made private - so anything you commit *and push to a fork* is visible to anyone. If you want your profile in a remote at all, don't push it to a fork: create a **private** repository, push there, and add this repo as the `upstream` remote (`git remote add upstream https://github.com/MadsLorentzen/ai-job-search.git`) to keep receiving updates. Committing locally without pushing is also fine. The genuinely sensitive files (tracker, salary data, `documents/`, application archives) are gitignored and never enter git either way. An uncommitted working tree is the most common reason `git pull` refuses to merge at all (`Your local changes ... would be overwritten`).
 2. **Preview what changed before pulling:**
    ```bash
+   git remote add upstream https://github.com/MadsLorentzen/ai-job-search.git   # first time only, if you cloned your own fork
    git fetch upstream    # or origin, if you cloned the template directly
    python3 tools/check_upstream_updates.py
    ```


### PR DESCRIPTION
Follow-up on #265, per the maintainer's review note: SETUP.md section 8 tells users to `git fetch upstream` but never shows how to add that remote first.

## Problem

A user who cloned their own fork (the `CONTRIBUTING.md`-documented fork flow) has no `upstream` remote configured. Section 8's steps said `git fetch upstream` - which fails with `fatal: 'upstream' does not appear to be a git repository` - and gave no setup step. `tools/check_upstream_updates.py` was the first place in the repo to spell out `git remote add upstream ...` (in the warning added by #265).

## Fix

One line added to SETUP.md section 8, step 2:

```bash
git remote add upstream https://github.com/MadsLorentzen/ai-job-search.git   # first time only, if you cloned your own fork
git fetch upstream    # or origin, if you cloned the template directly
python3 tools/check_upstream_updates.py
```

Docs-only change; no code or tests touched.
