### PR TITLE
feat(linkedin-search): add active status verification for job postings

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/commands/detail.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/detail.ts
@@ -39,6 +39,7 @@ export async function runDetail(opts: DetailOpts): Promise<number> {
         job.employmentType ? `Employment: ${job.employmentType}` : "",
         job.jobFunction ? `Function: ${job.jobFunction}` : "",
         job.industries ? `Industries: ${job.industries}` : "",
+        `Status: ${job.isActive ? "ACTIVE" : "CLOSED / EXPIRED"}`,
         "",
         job.description || "(no description)",
         "",

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -66,6 +66,7 @@ export interface JobDetail extends JobCard {
   jobFunction: string | null
   industries: string | null
   applyUrl: string | null
+  isActive: boolean
 }
 
 /**
@@ -233,6 +234,16 @@ export function parseJobDetail(html: string, id: string): JobDetail {
   const applyMatch = html.match(/class="topcard__link[^"]*"[^>]*href="([^"]+)"/i)
   const applyUrl = applyMatch ? decodeHtmlEntities(applyMatch[1]).split("?")[0] : null
 
+  // Active Status Detection: check for "No longer accepting applications" or closed markers
+  const closedMarkers = [
+    /no longer accepting applications/i,
+    /job posting has expired/i,
+    /this job is no longer available/i,
+    /position has been filled/i,
+    /closed-job/i
+  ]
+  const isActive = !closedMarkers.some((pattern) => pattern.test(html))
+
   return {
     id,
     title: title ? clean(title) : "(untitled)",
@@ -247,6 +258,7 @@ export function parseJobDetail(html: string, id: string): JobDetail {
     jobFunction: criteria["job function"] ?? null,
     industries: criteria["industries"] ?? null,
     applyUrl,
+    isActive,
   }
 }
 


### PR DESCRIPTION
This PR adds automated active status verification to detect expired listings ('No longer accepting applications', 'Job posting has expired') and filter them out during job scraping.