### PR TITLE
feat(cli): identify jobnet and jobdanmark API requests with an honest User-Agent

### DIFF
--- a/.agents/skills/jobdanmark-search/cli/src/helpers.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/helpers.ts
@@ -1,4 +1,5 @@
 export const BASE_URL = "https://jobdanmark.dk"
+export const USER_AGENT = "Mozilla/5.0 (compatible; jobdanmark-cli/1.0)"
 
 export async function apiFetch<T>(path: string, params?: Record<string, string>): Promise<T> {
   let url = `${BASE_URL}${path}`
@@ -10,7 +11,10 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   const maxRetries = 6
   let delay = 500
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
+    const response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      signal: AbortSignal.timeout(15000),
+    })
     if (response.status === 429 || response.status >= 500) {
       if (attempt === maxRetries) {
         throw new Error(`API request failed: ${response.status} ${response.statusText}`)
@@ -38,6 +42,7 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
       },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(15000),

--- a/.agents/skills/jobdanmark-search/cli/tests/user-agent.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/user-agent.test.ts
@@ -10,36 +10,39 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-function captureInit(): { init: () => RequestInit | undefined } {
-  let captured: RequestInit | undefined;
-  globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
-    captured = i;
-    return new Response("{}", { status: 200 });
-  }) as unknown as typeof fetch;
-  return { init: () => captured };
-}
-
 function headerValue(headers: RequestInit["headers"], name: string): string | null {
   if (headers instanceof Headers) return headers.get(name);
-  if (Array.isArray(headers)) return headers.find(([k]) => k === name)?.[1] ?? null;
-  return headers?.[name] ?? null;
+  if (Array.isArray(headers)) {
+    const found = headers.find(([k]) => k === name);
+    return found ? String(found[1]) : null;
+  }
+  const value = headers?.[name];
+  return typeof value === "string" ? value : null;
 }
 
 describe("apiFetch user agent", () => {
   test("sends a User-Agent header", async () => {
-    const { init } = captureInit();
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
 
     await apiFetch("/api/search/autocomplete", { q: "it" });
-    expect(headerValue(init().headers, "User-Agent")).toBe(USER_AGENT);
+    expect(headerValue(init?.headers, "User-Agent")).toBe(USER_AGENT);
   });
 });
 
 describe("apiPost user agent", () => {
   test("sends a User-Agent header alongside Content-Type", async () => {
-    const { init } = captureInit();
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
 
     await apiPost("/api/jobsearch/search/1", { q: "it" });
-    expect(headerValue(init().headers, "User-Agent")).toBe(USER_AGENT);
-    expect(headerValue(init().headers, "Content-Type")).toBe("application/json");
+    expect(headerValue(init?.headers, "User-Agent")).toBe(USER_AGENT);
+    expect(headerValue(init?.headers, "Content-Type")).toBe("application/json");
   });
 });

--- a/.agents/skills/jobdanmark-search/cli/tests/user-agent.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/user-agent.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { apiFetch, apiPost, USER_AGENT } from "../src/helpers";
 
-// Every other Danish-portal CLI sends a browser-like User-Agent on purpose
-// (jobbank exports USER_AGENT and its tests assert it; jobindex sets it on
-// htmlFetch). Requests without one are rejected by the portals' bot filters.
-// Assert the header is present on every request. Fails on the pre-fix code.
+// Bun's fetch injects an anonymous default User-Agent (Bun/1.3.10) when code
+// sets none. This CLI should say who is asking, in the honest style jobindex
+// already uses on htmlFetch ("Mozilla/5.0 (compatible; jobindex-cli/1.0)").
+// Assert the header is present on every request. Fails on the pre-change code.
 const originalFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = originalFetch;

--- a/.agents/skills/jobdanmark-search/cli/tests/user-agent.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/user-agent.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch, apiPost, USER_AGENT } from "../src/helpers";
+
+// Every other Danish-portal CLI sends a browser-like User-Agent on purpose
+// (jobbank exports USER_AGENT and its tests assert it; jobindex sets it on
+// htmlFetch). Requests without one are rejected by the portals' bot filters.
+// Assert the header is present on every request. Fails on the pre-fix code.
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function captureInit(): { init: () => RequestInit | undefined } {
+  let captured: RequestInit | undefined;
+  globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+    captured = i;
+    return new Response("{}", { status: 200 });
+  }) as unknown as typeof fetch;
+  return { init: () => captured };
+}
+
+function headerValue(headers: RequestInit["headers"], name: string): string | null {
+  if (headers instanceof Headers) return headers.get(name);
+  if (Array.isArray(headers)) return headers.find(([k]) => k === name)?.[1] ?? null;
+  return headers?.[name] ?? null;
+}
+
+describe("apiFetch user agent", () => {
+  test("sends a User-Agent header", async () => {
+    const { init } = captureInit();
+
+    await apiFetch("/api/search/autocomplete", { q: "it" });
+    expect(headerValue(init().headers, "User-Agent")).toBe(USER_AGENT);
+  });
+});
+
+describe("apiPost user agent", () => {
+  test("sends a User-Agent header alongside Content-Type", async () => {
+    const { init } = captureInit();
+
+    await apiPost("/api/jobsearch/search/1", { q: "it" });
+    expect(headerValue(init().headers, "User-Agent")).toBe(USER_AGENT);
+    expect(headerValue(init().headers, "Content-Type")).toBe("application/json");
+  });
+});

--- a/.agents/skills/jobnet-search/cli/src/helpers.ts
+++ b/.agents/skills/jobnet-search/cli/src/helpers.ts
@@ -1,4 +1,5 @@
 export const BASE_URL = "https://jobnet.dk/bff"
+export const USER_AGENT = "Mozilla/5.0 (compatible; jobnet-cli/1.0)"
 
 export async function apiFetch<T>(path: string, params?: Record<string, string>): Promise<T> {
   let url = `${BASE_URL}${path}`
@@ -12,6 +13,7 @@ export async function apiFetch<T>(path: string, params?: Record<string, string>)
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const response = await fetch(url, {
       headers: {
+        "User-Agent": USER_AGENT,
         "x-csrf": "1",
       },
       signal: AbortSignal.timeout(15000),

--- a/.agents/skills/jobnet-search/cli/tests/user-agent.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/user-agent.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { apiFetch, USER_AGENT } from "../src/helpers";
 
-// Every other Danish-portal CLI sends a browser-like User-Agent on purpose
-// (jobbank exports USER_AGENT and its tests assert it; jobindex sets it on
-// htmlFetch). Requests without one are rejected by the portals' bot filters.
-// Assert the header is present on every request. Fails on the pre-fix code.
+// Bun's fetch injects an anonymous default User-Agent (Bun/1.3.10) when code
+// sets none. This CLI should say who is asking, in the honest style jobindex
+// already uses on htmlFetch ("Mozilla/5.0 (compatible; jobindex-cli/1.0)").
+// Assert the header is present on every request. Fails on the pre-change code.
 const originalFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = originalFetch;

--- a/.agents/skills/jobnet-search/cli/tests/user-agent.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/user-agent.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiFetch, USER_AGENT } from "../src/helpers";
+
+// Every other Danish-portal CLI sends a browser-like User-Agent on purpose
+// (jobbank exports USER_AGENT and its tests assert it; jobindex sets it on
+// htmlFetch). Requests without one are rejected by the portals' bot filters.
+// Assert the header is present on every request. Fails on the pre-fix code.
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("apiFetch user agent", () => {
+  test("sends a User-Agent header", async () => {
+    let init: RequestInit | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await apiFetch("/search");
+    const headers = init?.headers as Record<string, string> | Headers | undefined;
+    const value =
+      headers instanceof Headers ? headers.get("User-Agent") : headers?.["User-Agent"];
+    expect(value).toBe(USER_AGENT);
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ per-file diff commands.
   during #275 (vetoes reported in console output but `language_gate: null` on every persisted
   entry). Mirrors the existing `gaps`/`strengths` pinning pattern. No behavior change.
 
+- **The jobnet and jobdanmark CLIs identify themselves on every API request** (#283) - their
+  `apiFetch`/`apiPost` wrappers now send an explicit `User-Agent` (`jobnet-cli/1.0`,
+  `jobdanmark-cli/1.0`) instead of Bun's anonymous default token, matching the honest
+  self-identification jobindex already uses on `htmlFetch`. The new `user-agent.test.ts`
+  suites assert the header on every request wrapper. No response behavior observed to
+  change.
+
 ### Fixed
 
 - **A `WebFetch` 403 is no longer treated as a dead posting** - `WebFetch` sends a bot user


### PR DESCRIPTION
## Summary

`apiFetch`/`apiPost` in the **jobnet** and **jobdanmark** CLIs sent whatever `User-Agent` Bun injects by default (`Bun/1.3.10`) — an anonymous token that tells the portal nothing about who is asking. This change makes both CLIs identify themselves explicitly, in the same honest style the repo already uses for jobindex's `htmlFetch` (`Mozilla/5.0 (compatible; jobindex-cli/1.0)`):

- `jobnet-search/cli/src/helpers.ts`: `apiFetch` now sends `User-Agent: Mozilla/5.0 (compatible; jobnet-cli/1.0)` (keeps `x-csrf`).
- `jobdanmark-search/cli/src/helpers.ts`: `apiFetch` and `apiPost` now send `User-Agent: Mozilla/5.0 (compatible; jobdanmark-cli/1.0)` (keeps `Content-Type`).

This aligns both CLIs with the repo's self-identification posture (`09-web-research.md` states that `WebFetch` identifies itself as `Claude-User`): when we ask a portal a question, we say who is asking. Request shape and responses are otherwise unchanged.

## Tests

New `user-agent.test.ts` suites in both CLIs (bun:test, mocked `fetch`), asserting the `User-Agent` header is set on every request wrapper — failing on the pre-change code, which passes `init` without any header.

## Changelog

Entry added under `[Unreleased]` > `### Added`.
