### PR TITLE
fix(cli): detect JobPosting JSON-LD with array @type

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -174,7 +174,10 @@ function findJobPosting(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object") return null
 
   const record = value as Record<string, unknown>
-  if (record["@type"] === "JobPosting") return record
+  const type = record["@type"]
+  if (type === "JobPosting" || (Array.isArray(type) && type.includes("JobPosting"))) {
+    return record
+  }
 
   return findJobPosting(record["@graph"])
 }

--- a/.agents/skills/jobbank-search/cli/tests/detail-jsonld.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/detail-jsonld.test.ts
@@ -37,4 +37,16 @@ describe("parseJobPostingJsonLd", () => {
   test("returns null when no JobPosting exists", () => {
     expect(parseJobPostingJsonLd(script('{"@graph":[{"@type":"WebPage"}]}'))).toBeNull()
   })
+
+  test("finds a JobPosting whose @type is an array (valid JSON-LD)", () => {
+    const html = script(
+      JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": ["JobPosting"],
+        title: "Data Engineer",
+      }),
+    )
+
+    expect(parseJobPostingJsonLd(html)?.title).toBe("Data Engineer")
+  })
 })


### PR DESCRIPTION
## Summary

`findJobPosting` in the **jobbank-search** CLI only recognized a JobPosting when `@type` was a plain string:

```ts
if (record["@type"] === "JobPosting") return record
```

JSON-LD (per the [JSON-LD 1.1 spec](https://www.w3.org/TR/json-ld11/#specifying-the-type) and schema.org markup emitted by many CMSes) allows `@type` to be an **array**, e.g. `"@type": ["JobPosting"]`. In that case the strict `===` comparison missed the node, the recursion found no `@graph` sibling, and `parseJobPostingJsonLd` returned `null` — so `jobdetail` reported the posting as missing even though the page's JSON-LD contained it.

## Reproduction

Before (current code):

```ts
const html = `<script type="application/ld+json">${JSON.stringify({
  "@context": "https://schema.org",
  "@type": ["JobPosting"],
  title: "Data Engineer",
})}</script>`

parseJobPostingJsonLd(html) // null  ← JobPosting not detected
```

With this change it returns the posting node.

## Change

- `jobbank-search/cli/src/helpers.ts`: accept `@type` as a string or as an array containing `"JobPosting"` (recursion already covers nested arrays, `@graph`, and top-level arrays).
- `jobbank-search/cli/tests/detail-jsonld.test.ts`: new regression test "finds a JobPosting whose @type is an array (valid JSON-LD)" — failing on `master`, passing with the fix.
