### PR TITLE
feat(linkedin-search): add --jobage-minutes for sub-day freshness windows

### DIFF
--- a/.agents/skills/linkedin-search/SKILL.md
+++ b/.agents/skills/linkedin-search/SKILL.md
@@ -50,6 +50,7 @@ Key flags:
 - `--location <text>` / `-l <text>` — **required.** A LinkedIn place string, e.g. `"Mumbai, Maharashtra, India"`, `"Berlin, Germany"`, `"London, United Kingdom"`, or `"Remote"`.
 - `--query <text>` / `-q <text>` — keyword search (title, skill, role). Recommended.
 - `--jobage <days>` — posted within N days: `1`, `7`, `14`, `30`. Omit for all postings.
+- `--jobage-minutes <n>` — posted within N minutes (sub-day precision, e.g. `30`). Conflicts with `--jobage` — pass only one.
 - `--remote <mode>` — `remote`, `hybrid`, or `onsite` (workplace-type filter).
 - `--page <n>` — page number (1-indexed, 10 results per page).
 - `--limit <n>` / `-n <n>` — cap total results emitted (client-side).
@@ -76,6 +77,9 @@ bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "product manager
 
 # Any role, fully remote
 bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "paralegal" -l "Remote" --format table
+
+# Engineer roles, remote, posted in the last 30 minutes
+bun run .agents/skills/linkedin-search/cli/src/cli.ts search -q "engineer" -l "Remote" --jobage-minutes 30 --format table
 
 # Full details for a specific job
 bun run .agents/skills/linkedin-search/cli/src/cli.ts detail 4426311357 --format plain

--- a/.agents/skills/linkedin-search/cli/src/cli.ts
+++ b/.agents/skills/linkedin-search/cli/src/cli.ts
@@ -47,6 +47,7 @@ SEARCH FLAGS
                           "Berlin, Germany", "London, United Kingdom", or "Remote".
   --query, -q <text>      Keywords (job title, skill, or role). Recommended.
   --jobage <days>         Posted within N days: 1, 7, 14, 30. Default: all.
+  --jobage-minutes <n>    Posted within N minutes (sub-day precision). Conflicts with --jobage.
   --remote <mode>         remote | hybrid | onsite. Filter by workplace type.
   --page <n>              1-indexed page (10 results/page). Default 1.
   --limit, -n <n>         Cap results emitted (client-side).
@@ -56,6 +57,7 @@ EXAMPLES
   bun run src/cli.ts search -q "data engineer" -l "Bengaluru, Karnataka, India" --jobage 30 --format table
   bun run src/cli.ts search -q "product manager" -l "Berlin, Germany" --remote remote --format table
   bun run src/cli.ts search -q "paralegal" -l "Remote" --format table
+  bun run src/cli.ts search -q "engineer" -l "Remote" --jobage-minutes 30 --format table
   bun run src/cli.ts detail 4300011451 --format plain
 
 Personal use only — uses LinkedIn's public pages; keep volume low (LinkedIn ToS).
@@ -84,6 +86,16 @@ async function main(): Promise<number> {
     }
     const fmt = (flags.format as string) || "json"
 
+    if (flags.jobage !== undefined && flags["jobage-minutes"] !== undefined) {
+      process.stderr.write(
+        JSON.stringify({
+          error: "--jobage and --jobage-minutes both set a freshness window; pass only one",
+          code: "CONFLICTING_AGE_FLAGS",
+        }) + "\n",
+      )
+      return 1
+    }
+
     const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
       const val = parseInt(raw as string, 10)
       if (isNaN(val)) {
@@ -97,6 +109,18 @@ async function main(): Promise<number> {
       const v = parseIntFlag("jobage", flags.jobage)
       if (v === null) return 1
       flags.jobage = String(v)
+    }
+    if (flags["jobage-minutes"] !== undefined) {
+      const raw = flags["jobage-minutes"]
+      const v = parseIntFlag("jobage-minutes", raw)
+      if (v === null) return 1
+      if (v <= 0) {
+        process.stderr.write(
+          JSON.stringify({ error: `--jobage-minutes must be a positive number, got "${raw}"`, code: "BAD_ARG" }) + "\n",
+        )
+        return 1
+      }
+      flags["jobage-minutes"] = String(v)
     }
     if (flags.page !== undefined) {
       const v = parseIntFlag("page", flags.page)
@@ -113,6 +137,7 @@ async function main(): Promise<number> {
       query: typeof flags.query === "string" ? flags.query : undefined,
       location,
       jobage: flags.jobage ? parseInt(flags.jobage as string, 10) : 9999,
+      jobageMinutes: flags["jobage-minutes"] ? parseInt(flags["jobage-minutes"] as string, 10) : undefined,
       remote: typeof flags.remote === "string" ? flags.remote : undefined,
       page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
       limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,

--- a/.agents/skills/linkedin-search/cli/src/commands/search.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/search.ts
@@ -3,6 +3,7 @@ import {
   htmlFetch,
   parseJobCards,
   jobageToTPR,
+  minutesToTPR,
   workTypeFlag,
   writeError,
   type JobCard,
@@ -12,6 +13,7 @@ export interface SearchOpts {
   query?: string
   location: string
   jobage: number
+  jobageMinutes?: number
   remote?: string // "remote" | "hybrid" | "onsite"
   page: number
   limit?: number
@@ -22,7 +24,7 @@ function buildUrl(opts: SearchOpts): string {
   const params = new URLSearchParams()
   if (opts.query) params.set("keywords", opts.query)
   if (opts.location) params.set("location", opts.location)
-  const tpr = jobageToTPR(opts.jobage)
+  const tpr = opts.jobageMinutes !== undefined ? minutesToTPR(opts.jobageMinutes) : jobageToTPR(opts.jobage)
   if (tpr) params.set("f_TPR", tpr)
   const wt = workTypeFlag(opts.remote)
   if (wt) params.set("f_WT", wt)

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -256,6 +256,12 @@ export function jobageToTPR(days: number): string | null {
   return `r${days * 86400}`
 }
 
+/** Convert a job-age in minutes to LinkedIn's f_TPR seconds value (sub-day precision). */
+export function minutesToTPR(minutes: number): string | null {
+  if (!minutes || minutes <= 0) return null
+  return `r${minutes * 60}`
+}
+
 /** Workplace-type flag: on-site=1, remote=2, hybrid=3. */
 export function workTypeFlag(mode: string | undefined): string | null {
   switch ((mode || "").toLowerCase()) {

--- a/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
@@ -47,6 +47,48 @@ describe("LinkedIn CLI flag validation", () => {
     });
   });
 
+  describe("--jobage-minutes validation", () => {
+    test("non-numeric string exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "foo"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage-minutes/);
+    });
+
+    test("zero exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "0"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage-minutes/);
+    });
+
+    test("negative value is parsed as a missing value and exits 1 with BAD_ARG", async () => {
+      // parseFlags in cli.ts treats a next-token starting with "-" as absent
+      // (`next.startsWith("-")` → flag becomes boolean `true`), and there is no
+      // `--flag=value` syntax. So "-5" never reaches --jobage-minutes as a value;
+      // parseInt("true") is NaN, and BAD_ARG comes from the NaN branch, not the
+      // `v <= 0` guard. Negatives are unreachable through the CLI as currently parsed.
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "-5"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage-minutes/);
+    });
+  });
+
+  describe("--jobage / --jobage-minutes conflict", () => {
+    test("both set exits 1 with CONFLICTING_AGE_FLAGS", async () => {
+      const result = await runCLI([
+        "search", "-l", LOCATION, "--jobage", "7", "--jobage-minutes", "30",
+      ]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("CONFLICTING_AGE_FLAGS");
+    });
+  });
+
   describe("--page NaN validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--page", "abc"]);

--- a/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { parseJobCards, parseJobDetail, extractDivContent } from "../src/helpers";
+import { parseJobCards, parseJobDetail, extractDivContent, minutesToTPR } from "../src/helpers";
 
 // Minimal search-card markup: parseJobCards splits on the job-posting URN and
 // needs an id, a base-search-card__title, and a full-link. Everything else is
@@ -109,5 +109,18 @@ describe("extractDivContent", () => {
     expect(job.description).toContain("5 years Python");
     expect(job.description).toContain("About Us:");
     expect(job.description).toContain("We are hiring!");
+  });
+});
+
+describe("minutesToTPR", () => {
+  test("converts minutes to an f_TPR seconds window", () => {
+    expect(minutesToTPR(30)).toBe("r1800");
+    expect(minutesToTPR(1)).toBe("r60");
+    expect(minutesToTPR(1440)).toBe("r86400"); // matches jobageToTPR(1)
+  });
+
+  test("returns null for non-positive input", () => {
+    expect(minutesToTPR(0)).toBeNull();
+    expect(minutesToTPR(-5)).toBeNull();
   });
 });

--- a/.agents/skills/linkedin-search/cli/tests/search.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/search.test.ts
@@ -39,4 +39,23 @@ describe("runSearch", () => {
     expect(code).toBe(0);
     expect(JSON.parse(stdout).results).toHaveLength(0);
   });
+
+  test("--jobage-minutes 30 constructs f_TPR=r1800 in the request URL", async () => {
+    let capturedUrl = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      capturedUrl = typeof input === "string" ? input : input.toString();
+      return new Response("");
+    }) as typeof fetch;
+
+    const code = await runSearch({
+      location: "Remote",
+      jobage: 9999,
+      jobageMinutes: 30,
+      page: 1,
+      format: "json",
+    });
+
+    expect(code).toBe(0);
+    expect(capturedUrl).toContain("f_TPR=r1800");
+  });
 });


### PR DESCRIPTION
# Add `--jobage-minutes` for sub-day freshness windows

## Problem

`jobageToTPR()` in `helpers.ts` guards `days <= 0` and only ever emits whole-day
`f_TPR` windows (`r86400`, `r604800`, ...). There's no way to ask `linkedin-search`
for postings from just the last N minutes — sub-day freshness is currently
inexpressible through the CLI.

## Evidence

Two live probes against LinkedIn's public `jobs-guest` search endpoint
(`keywords=engineer&location=Remote`), captured **2026-08-06, ~17:55–17:56 IST**:

```bash
UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
BASE='https://www.linkedin.com/jobs-guest/jobs/api/seeMoreJobPostings/search'

curl -sS -A "$UA" -H 'X-Requested-With: XMLHttpRequest' \
  "$BASE?keywords=engineer&location=Remote&f_TPR=r1800&start=0" -o r1800.html
curl -sS -A "$UA" -H 'X-Requested-With: XMLHttpRequest' \
  "$BASE?keywords=engineer&location=Remote&f_TPR=r86400&start=0" -o r86400.html
```

**Invariant observed:** every card returned for window `W` is newer than `W`.

- `f_TPR=r1800` (30 min): every returned card's relative age (read from the
  `<time>` element's inner text body) was ≤ 24 minutes.
- `f_TPR=r86400` (24 h): every returned card's relative age was ≤ 23 hours.

No card in the 30-minute sample was older than 30 minutes; no card in the
24-hour sample was older than 24 hours. **Conclusion: LinkedIn filters `f_TPR`
server-side at second-level granularity**, not just whole-day buckets — so this
is a pure window-construction change, with no HTML parsing change required.

The `datetime` attribute on `job-search-card__listdate` is date-only
(`datetime="2026-08-06"`, confirmed in the same capture); the relative-minute
precision lives only in the element's text body, which `parseJobCards()`
doesn't read (it only captures the attribute). That's why the fix lives
entirely in URL construction, not in the parser — the server already does the
filtering, so nothing needs to be extracted from the response to make it work.

## What changed

- `helpers.ts`: new `minutesToTPR(minutes)`, structurally mirroring
  `jobageToTPR(days)` (`r${minutes * 60}` for positive input, `null`
  otherwise). `jobageToTPR` itself is untouched — byte-identical.
- `cli.ts`: new `--jobage-minutes <n>` flag.
  - Non-numeric → `BAD_ARG` (existing `parseIntFlag` pattern).
  - `<= 0` → `BAD_ARG` (`--jobage-minutes must be a positive number, got "..."`).
    This is stricter than `--jobage`, which silently treats non-positive as
    "unfiltered" — intentional, since a minute-precision flag has no sensible
    "unlimited" reading of zero/negative.
  - `--jobage` + `--jobage-minutes` together → `CONFLICTING_AGE_FLAGS`, exit 1
    (see precedence decision below).
- `search.ts`: `SearchOpts.jobageMinutes?: number`; `buildUrl` uses
  `minutesToTPR(opts.jobageMinutes)` when set, else falls back to
  `jobageToTPR(opts.jobage)`.
- `SKILL.md`: flag documented in "Key flags", one country-agnostic usage
  example added (`Remote`, generic `engineer` query).
- Tests (`.agents/skills/linkedin-search/cli/tests/`, network-free):
  - `cli-flag-validation.test.ts`: non-numeric / zero → `BAD_ARG`; both flags
    set → `CONFLICTING_AGE_FLAGS`. A negative-value case is also covered, with
    a caveat — see "Coverage gap" below on what it actually proves.
  - `parsing.test.ts`: unit tests for `minutesToTPR` (`30→r1800`, `1→r60`,
    `1440→r86400` pinned against `jobageToTPR(1)` at the day boundary so a
    future divergence between the two helpers fails loudly; non-positive →
    `null`).
  - `search.test.ts`: a fetch recorder (stubs `globalThis.fetch`, captures the
    requested URL, returns an empty body, restored by the file's existing
    module-level `afterEach`) asserts `f_TPR=r1800` is constructed for
    `jobageMinutes: 30`, driven through `runSearch` — the real code path, not
    a reimplemented `buildUrl`.

No parser fixtures were added: `parseJobCards`/`parseJobDetail` are unchanged
by this PR, so a parsing fixture is out of scope for this single-concern
change. The date-only-`datetime`-attribute observation is recorded above as
prose evidence instead.

## Design decision: `--jobage`/`--jobage-minutes` precedence

Two options considered:

1. **"Narrower window wins"** — compare `jobage * 86400` seconds against
   `jobageMinutes * 60` seconds and silently use whichever is smaller.
2. **Explicit conflict error** (chosen) — reject with `CONFLICTING_AGE_FLAGS`
   when both are set.

Rejected (1) because it introduces a new kind of implicit behavior this CLI
doesn't otherwise have: every other invalid/ambiguous input in `cli.ts` is
rejected outright (NaN → `BAD_ARG`, missing `--location` → `NO_LOCATION`, etc.)
rather than resolved by guessing. "Narrower wins" would require comparing two
flags expressed in different units with no natural tie-break, and a caller
who leaves a stale `--jobage 7` in a saved script while adding
`--jobage-minutes 30` would get
silently different behavior than they typed, with no signal anything was
ignored. An explicit error is deterministic, trivially testable, and
consistent with the existing error contract.

## Naming rationale

`--jobage-minutes` rather than `--max-age-minutes`, because it matches the
existing `--jobage` naming and makes the mutual-exclusion rule self-evident
from the names alone — `--jobage` vs. `--jobage-minutes`, same concept at two
granularities.

## Coverage gap

No test covers the seam where the CLI string `"30"` becomes
`jobageMinutes: 30` on `SearchOpts` — i.e., the `parseInt` conversion inside
`main()` between flag parsing and options construction. The conflict test
proves the flag is read (it inspects the error path, not the value); the
`search.test.ts` fetch-recorder test proves the numeric opt is used correctly
once constructed. The join between "CLI accepted the string" and "the number
that reaches `SearchOpts` is correct" is inferred, not directly tested.
Closing it properly would need a way to run the real `main()` end-to-end
against a stubbed base URL (a testing override for `SEARCH_URL`), which is
scope creep for a single-concern PR — happy to follow up separately if
maintainers want it closed.

Related caveat on the negative-value test: it passes, but not for the reason
its name used to imply. `parseFlags` in `cli.ts` treats any token starting
with `-` as a missing value (`next.startsWith("-")` → the flag becomes boolean
`true`), and there's no `--flag=value` syntax. So `--jobage-minutes -5` never
delivers `-5` to the flag; `parseInt("true")` is `NaN`, and the `BAD_ARG`
comes from the NaN branch, not the `v <= 0` guard added in this PR. Negative
values are unreachable through the CLI as currently parsed. The test is
renamed and commented to state this accurately rather than implying the `<= 0`
guard was exercised. Fixing `parseFlags` to support `--flag=value` (which
would make negatives reachable) is out of scope here — a separate concern.

## Verification

```
$ python3 tools/lint_skills.py
lint_skills: OK (9 skills, 12 commands, settings.json)

$ python3 tools/security_guards.py
security_guards: OK (permissions allowlist, gitignore rules, package manifests)

$ python3 -m unittest discover -s tests
Ran 187 tests in 12.034s

OK

$ cd .agents/skills/linkedin-search/cli && bun run typecheck
$ tsc --noEmit
(no errors)

$ bun test
bun test v1.3.14 (0d9b296a)
{
  "meta": { "count": 0, "page": 1 },
  "results": []
}

 35 pass
 0 fail
 61 expect() calls
Ran 35 tests across 5 files. [4.82s]
```

No test added by this PR touches the network. (An earlier revision of this branch
included a live-request acceptance test for `--jobage-minutes`; it was removed
because the extra request triggered rate-limiting, `htmlFetch` backed off, and the
neighbouring pre-existing test timed out. Acceptance is covered offline by the
`search.test.ts` fetch recorder instead.)

## Live demonstration

```
bun run .agents/skills/linkedin-search/cli/src/cli.ts \
  search -q "engineer" -l "Remote" --jobage-minutes 30 --format table
```

- **On `upstream/master` (cffacfd):** `--jobage-minutes` is silently ignored
  (parsed as a generic flag but never read); results are unfiltered and
  include postings back to **2026-03-13** — five months old.
- **On this branch:** every one of the 10 results is dated **2026-08-06**
  (today), consistent with the 30-minute window being applied server-side.

## Scope

Single concern: sub-day freshness for `linkedin-search` only. No
applicant-count filter, no other portal skills touched, no `.claude/` changes.

Separately: the pre-existing `--jobage` acceptance tests in
`cli-flag-validation.test.ts` make live LinkedIn requests and vary between 0.8s
and 3.8s across runs on clean master. Happy to open a follow-up converting them
to the same offline fetch-recorder pattern used here, if that's wanted.
