### PR TITLE
ci: discover portal CLIs dynamically so fork-added portals get checked

### DIFF
--- a/.claude/commands/add-portal.md
+++ b/.claude/commands/add-portal.md
@@ -127,6 +127,7 @@ Do not proceed to Step 5 until search, detail, and tests all pass.
    ```
    (Skip if the skill is zero-dependency and they don't care about typecheck types.)
 3. Note that the skill auto-triggers from its `SKILL.md` description - no other wiring is needed.
+4. CI coverage is also automatic: the `cli-checks` job discovers every `.agents/skills/*/cli/package.json`, so the new CLI's `typecheck` and `test` scripts run on every push to the fork without editing the workflow.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,19 +150,33 @@ jobs:
             --contains 'your.email@example.com' \
             --contains 'Dear [Hiring Manager / Team]'
 
+  discover-clis:
+    # The matrix is discovered, not hardcoded, so a portal CLI added in a fork
+    # (the /add-portal path) gets typechecked and tested without the fork
+    # having to edit this workflow - the same reason security-guards globs
+    # .agents/**/package.json instead of naming the shipped portals.
+    name: Discover portal CLIs
+    runs-on: ubuntu-latest
+    outputs:
+      tools: ${{ steps.list.outputs.tools }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - id: list
+        run: |
+          tools=$(find .agents/skills -mindepth 3 -maxdepth 3 -path '*/cli/package.json' \
+            | cut -d/ -f3 | sort | jq -R . | jq -cs .)
+          echo "Discovered portal CLIs: $tools"
+          echo "tools=$tools" >> "$GITHUB_OUTPUT"
+
   cli-checks:
     name: CLI checks ${{ matrix.tool }}
+    needs: discover-clis
+    if: needs.discover-clis.outputs.tools != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        tool:
-          - freehire-search
-          - jobbank-search
-          - jobdanmark-search
-          - jobindex-search
-          - jobnet-search
-          - linkedin-search
+        tool: ${{ fromJSON(needs.discover-clis.outputs.tools) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2


### PR DESCRIPTION
## What changed and why

The `cli-checks` matrix hardcodes the six shipped portals. But the repo's central path is fork-and-adapt: `/add-portal` scaffolds a new portal skill whose `package.json` ships `typecheck` and `test` scripts — and on a fork, CI never runs either, because the matrix silently skips anything not in the hardcoded list. Meanwhile `security_guards.py` already globs `.agents/**/package.json`, so the security guard covers a fork-added portal automatically while the correctness checks don't. This PR closes that asymmetry:

- A `discover-clis` job emits the matrix from `find .agents/skills -mindepth 3 -maxdepth 3 -path '*/cli/package.json'` (anchored on `package.json` so a discovered entry is always `bun install`-able). `cli-checks` consumes it via `fromJSON`, with a graceful skip if the list is ever empty — the same pattern the workflow uses for optional tools.
- `/add-portal`'s Register step gains one line telling fork users their new CLI is CI-covered automatically. (`add-portal.md` is not framework-versioned, so no version bump applies.)

One concern only: no changes to what the checks themselves run.

## Failing case / reproduction (for fixes)

On any fork, run `/add-portal`, commit the generated skill, push. Actual: the `cli-checks` job runs only the six upstream portals; the new CLI's `typecheck`/`test` scripts never execute, so a portal skill can land broken with green CI. Demonstrated locally with the discovery command:

- On current master it resolves to exactly the six shipped portals — upstream coverage is byte-identical:
  `["freehire-search","jobbank-search","jobdanmark-search","jobindex-search","jobnet-search","linkedin-search"]`
- After scaffolding a seventh skill dir with a `cli/package.json`, the same command emits it with no workflow edit:
  `["example-portal-search","freehire-search",...]`

## Verification

- `python3 tools/lint_skills.py` — OK (9 skills, 12 commands, settings.json)
- `python3 tools/check_framework_version.py` — OK
- `python3 tools/security_guards.py` — OK
- `python3 -m unittest discover -s tests -t .` — 210 tests, OK
- Workflow YAML parses (`yaml.safe_load`); `needs`/`fromJSON` wiring checked; discovery command tested for both the upstream and fork-added cases as above