### PR TITLE
docs(scraper): drop the phantom 'evaluated' status from seen_jobs.json vocabulary

### DIFF
--- a/.claude/commands/rank.md
+++ b/.claude/commands/rank.md
@@ -23,7 +23,7 @@ Follow these steps **in order**.
 
 1. Read `job_scraper/seen_jobs.json`. If the file is missing or has no entries, tell the user to run `/scrape` first and stop.
 2. Read `job_search_tracker.csv`. Build the exclusion set: any company+role already in the tracker is out of scope regardless of flags - it has been applied to or consciously tracked.
-3. Select candidates: entries with status `new` (or all non-applied entries with `--all`), minus the exclusion set, filtered by the focus area if one was given.
+3. Select candidates: entries with status `new` (or entries of any status with `--all`), minus the exclusion set, filtered by the focus area if one was given.
 4. If no candidates remain, say so ("Nothing new to rank - run /scrape to find fresh postings") and stop.
 5. Read the scoring framework and profile **once**:
    - `.claude/skills/job-application-assistant/04-job-evaluation.md`

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -136,7 +136,7 @@ For each new job, do a rapid fit check (NOT the full evaluation from `04-job-eva
       "url": "...",
       "first_seen": "YYYY-MM-DD",
       "fit": "high/medium/low",
-      "status": "new/skipped/evaluated/ranked/expired",
+      "status": "new/skipped/ranked/expired",
       "portal": "<source portal skill, e.g. jobindex-search>"
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@ per-file diff commands.
 
 ### Fixed
 
+- **Dropped the phantom `evaluated` value from `seen_jobs.json`'s status vocabulary** (#315).
+  The schema block in the job-scraper skill documented `new/skipped/evaluated/ranked/expired`,
+  but `evaluated` has had no writer and no reader since the initial release - `new`/`skipped`
+  come from `/scrape`, `ranked`/`expired` from `/rank`, and nothing ever set or selected
+  `evaluated`. Post-#269 the tracker owns all lifecycle state after drafting, so the value had
+  no future role either; it is now removed rather than wired up. `/rank` Step 1's `--all`
+  wording ("all non-applied entries") leaned on an `applied` status the schema deliberately
+  lacks and now names what it means: entries of any status, minus the tracker exclusion set.
+  Forks that wrote their own tooling against the documented vocabulary should note the value
+  was never produced by any shipped command.
+
 - **`/apply` archives the job posting while it still holds it** (#306). `/apply` drafted two
   documents and a tracker row from the full posting, then let the text die with the session;
   `/outcome` Step 3.2 tried to recover it by re-fetching a `source` URL the spec itself expects


### PR DESCRIPTION
## What changed and why

Implements the fix proposed in #315. The `seen_jobs.json` schema block in the job-scraper skill documented the status vocabulary as `new/skipped/evaluated/ranked/expired`, but `evaluated` has never been written or read by anything: `new`/`skipped` come from `/scrape` Step 4, `ranked`/`expired` from `/rank` Step 4, and a repo-wide search finds no writer, no reader, and no selection anywhere — since the initial-release commit. Post-#269 the tracker explicitly owns all lifecycle state after drafting (`apply.md` rule 6: "Do not modify `job_scraper/seen_jobs.json`"), so the value has no future role waiting for it either. Removed rather than wired up.

Same-concern tightening, flagged as a footnote in #315: `/rank` Step 1's `--all` clause read "all non-applied entries", leaning on an `applied` status this schema deliberately lacks (per your #269 comment). It now says "entries of any status", which is what it always meant — the very next clause ("minus the exclusion set") already removes applied-to jobs, so behavior is unchanged. Happy to drop this hunk if you'd rather it travel separately.

Three-file diff: the vocabulary line, the `--all` wording, and a CHANGELOG entry under Unreleased noting for forks that the value was never produced by any shipped command. `job-scraper/SKILL.md` and `rank.md` are outside the framework-versioned set (`check_framework_version.py` covers `job-application-assistant/*.md` + `AGENTS.md`), so no version bump applies.

## Failing case / reproduction (for fixes)

Documentation defect, so the "failing case" is the contradiction itself, all on current master: the schema names five statuses; `git grep evaluated` (excluding `node_modules`) returns exactly the vocabulary line; `git log -S '\"evaluated\"'` finds no commit that ever added a writer; and even the initial release's `apply.md` never referenced `seen_jobs.json`. Full evidence trail in #315.

## Verification

- `python3 tools/lint_skills.py` — OK (9 skills, 12 commands, settings.json)
- `python3 tools/check_framework_version.py` — OK
- `python3 tools/security_guards.py` — OK
- `python3 -m unittest discover -s tests -t .` — OK (includes the v1.4.0 vocab suite, which pins tracker statuses and is untouched by this change)
- Post-edit greps confirm no remaining reference to `evaluated` or to the old five-value vocabulary anywhere in `.claude/`