### PR TITLE
fix(cv-template): compile main_example.tex on apt-packaged moderncv (#242)

### DIFF
--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -43,15 +43,20 @@ Expected output: `Output written on main_<company>_<role>.pdf (2 pages, ...)`. A
 
 \usepackage[utf8]{inputenc}
 % moderncv loads hyperref itself in an \AtEndPreamble hook, so \hypersetup
-% must go in an \AtEndPreamble of our own: a top-level \usepackage{hyperref}
-% clashes with the class's \PassOptionsToPackage on moderncv < 2.4.
+% must go in an \AtEndPreamble of our own: on moderncv < 2.4 a top-level
+% \usepackage{hyperref} clashes with the class's own
+% \RequirePackage[unicode]{hyperref}. From 2.4.0 the class passes its options
+% through \PassOptionsToPackage instead, which is what removes that clash.
 \AtEndPreamble{\hypersetup{
     colorlinks=true,
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
     pdftitle={[YOUR_NAME] - CV},
-    pdfpagemode=FullScreen,
+    % Keep pdfpagemode=UseNone: this block runs after moderncv's own
+    % \AtEndPreamble (moderncv.cls sets pdfpagemode there), so a FullScreen
+    % value here would win and open every CV in fullscreen presentation mode.
+    pdfpagemode=UseNone,
 }}
 \usepackage[scale=0.77]{geometry}
 \usepackage{import}

--- a/.claude/skills/job-application-assistant/05-cv-templates.md
+++ b/.claude/skills/job-application-assistant/05-cv-templates.md
@@ -1,5 +1,5 @@
 ---
-framework_version: 1.4.0
+framework_version: 1.4.1
 ---
 
 # CV Templates and Tailoring Guide
@@ -29,28 +29,37 @@ Expected output: `Output written on main_<company>_<role>.pdf (2 pages, ...)`. A
 \moderncvstyle{banking}
 \moderncvcolor{blue}
 
-% Force both first and last name AND section headings to render in moderncv
-% blue (color1). Default banking on lualatex+MiKTeX leaves these black, which
-% looks inconsistent with the rest of the blue accent scheme.
-\renewcommand*{\firstnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
-\renewcommand*{\lastnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
+% Force the name and section headings to render in moderncv blue (color1).
+% Default banking leaves them black: moderncvstylebanking.sty's \colorlet
+% copies (not aliases) the pre-scheme accent colour, so the name colours are
+% frozen before \moderncvcolor runs. Re-let them after. \namefont is the hook
+% every name-style macro routes through, so this also works on moderncv 2.3.1
+% (Debian/Ubuntu apt), which has no \firstnamestyle/\lastnamestyle at all.
+\renewcommand*{\namefont}{\fontsize{34}{36}\bfseries\upshape}
+\colorlet{firstnamecolor}{color1}
+\colorlet{lastnamecolor}{color1}
+\colorlet{namecolor}{color1}
 \renewcommand*{\sectionstyle}[1]{{\sectionfont\color{color1}#1}}
 
 \usepackage[utf8]{inputenc}
-\usepackage{hyperref}
-\hypersetup{
+% moderncv loads hyperref itself in an \AtEndPreamble hook, so \hypersetup
+% must go in an \AtEndPreamble of our own: a top-level \usepackage{hyperref}
+% clashes with the class's \PassOptionsToPackage on moderncv < 2.4.
+\AtEndPreamble{\hypersetup{
     colorlinks=true,
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
     pdftitle={[YOUR_NAME] - CV},
     pdfpagemode=FullScreen,
-}
+}}
 \usepackage[scale=0.77]{geometry}
 \usepackage{import}
 
 % Personal data
 \name{[FIRST_NAME]}{[LAST_NAME]}
+% If you have no address to list, DELETE this whole line. \address{}{}{} fails
+% with "There's no line here to end" on every moderncv version.
 \address{[YOUR_ADDRESS]}{}{}
 \phone[mobile]{[YOUR_PHONE]}
 \email{[YOUR_EMAIL]}
@@ -72,7 +81,7 @@ Expected output: `Output written on main_<company>_<role>.pdf (2 pages, ...)`. A
 
 ### Color overrides
 
-The three `\renewcommand*` lines in the preamble are required on lualatex+MiKTeX. Without them the firstname, lastname, and section headings render in black even though `\moderncvcolor{blue}` is set, which looks inconsistent with the rest of the blue accent scheme (links, bullet markers, contact icons). The override forces all three to use `color1` (moderncv's accent colour, which becomes blue under `\moderncvcolor{blue}`). Both names render bold; if you prefer the firstname in regular weight, change the firstnamestyle override from `\bfseries` to `\mdseries`. Don't drop the override - on most modern installs the defaults render visibly wrong.
+The `\renewcommand*` on `\namefont` and the three `\colorlet` lines in the preamble are required on lualatex+MiKTeX. Without them the name and section headings render in black even though `\moderncvcolor{blue}` is set, which looks inconsistent with the rest of the blue accent scheme (links, bullet markers, contact icons). The cause: `moderncvstylebanking.sty` defines the name colours with `\colorlet`, which *copies* the accent colour as it is before the scheme is applied, so the name colours are frozen to the pre-scheme value; re-assigning them with `\colorlet` after `\moderncvcolor{blue}` (as the preamble does) re-pins them to `color1`. `\namefont` is the shared hook every name-style macro routes through, so the block is version-agnostic - including moderncv 2.3.1 from Debian/Ubuntu apt, which has no `\firstnamestyle`/`\lastnamestyle` at all. Both names render bold; if you prefer regular weight, change `\bfseries` to `\mdseries` in the `\namefont` line (the weight now lives there, so it applies to the whole name). Don't drop the overrides - on most modern installs the defaults render visibly wrong.
 
 ### Spacing inside itemize lists (important)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ prefer updating to a tagged release over pulling raw `master` (see
 files a release touched; `python3 tools/check_upstream_updates.py` lists them with
 per-file diff commands.
 
+## [Unreleased]
+
+### Fixed
+
+- **`main_example.tex` compiles on apt-packaged moderncv** (#242) - the banking template
+  set its name styling through `\firstnamestyle`/`\lastnamestyle`, which moderncv 2.3.1
+  (Debian/Ubuntu apt) does not have, so a fresh fork could not compile its own example CV
+  on that toolchain. Name styling now routes through `\namefont`, the hook every name-style
+  macro shares: a true no-op on moderncv 2.4+ (where head iii typesets via
+  `\firstnamestyle`/`\lastnamestyle` and never calls `\namefont`'s replacements), and the
+  only option on 2.3.1 where those macros do not exist. Two review follow-ups landed in the
+  same change: the `\hypersetup` comment now names the real clash mechanism
+  (`\RequirePackage[unicode]{hyperref}` on < 2.4; `\PassOptionsToPackage`, introduced in
+  2.4.0, is what removes the clash), and the metadata block sets `pdfpagemode=UseNone` - a
+  `FullScreen` value there would win over the class's own `\AtEndPreamble` default and make
+  every CV open in fullscreen presentation mode. `05-cv-templates.md`'s preamble copy stays
+  in lockstep (framework_version 1.4.0 -> 1.4.1). Verified on moderncv 2.5.1: exit 0,
+  exactly 2 pages, rendering unchanged.
+
 ## [1.5.0] - 2026-08-12
 
 ### Added

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -10,28 +10,37 @@
 \moderncvstyle{banking}
 \moderncvcolor{blue}
 
-% Force both first and last name AND section headings to render in moderncv
-% blue (color1). Default banking on lualatex+MiKTeX leaves these black, which
-% looks inconsistent with the rest of the blue accent scheme.
-\renewcommand*{\firstnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
-\renewcommand*{\lastnamestyle}[1]{{\fontsize{34}{36}\bfseries\upshape\color{color1}#1}}
+% Force the name and section headings to render in moderncv blue (color1).
+% Default banking leaves them black: moderncvstylebanking.sty's \colorlet
+% copies (not aliases) the pre-scheme accent colour, so the name colours are
+% frozen before \moderncvcolor runs. Re-let them after. \namefont is the hook
+% every name-style macro routes through, so this also works on moderncv 2.3.1
+% (Debian/Ubuntu apt), which has no \firstnamestyle/\lastnamestyle at all.
+\renewcommand*{\namefont}{\fontsize{34}{36}\bfseries\upshape}
+\colorlet{firstnamecolor}{color1}
+\colorlet{lastnamecolor}{color1}
+\colorlet{namecolor}{color1}
 \renewcommand*{\sectionstyle}[1]{{\sectionfont\color{color1}#1}}
 
 \usepackage[utf8]{inputenc}
-\usepackage{hyperref}
-\hypersetup{
+% moderncv loads hyperref itself in an \AtEndPreamble hook, so \hypersetup
+% must go in an \AtEndPreamble of our own: a top-level \usepackage{hyperref}
+% clashes with the class's \PassOptionsToPackage on moderncv < 2.4.
+\AtEndPreamble{\hypersetup{
     colorlinks=true,
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
     pdftitle={[YOUR_NAME] - CV},
     pdfpagemode=FullScreen,
-}
+}}
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}
 
 % personal data
 \name{[First]}{[Last]}
+% If you have no address to list, DELETE this whole line. \address{}{}{} fails
+% with "There's no line here to end" on every moderncv version.
 \address{[Your Address, City, Country]}{}{}
 \phone[mobile]{[+XX XXXXXXXXXX]}
 \email{[your.email@example.com]}

--- a/cv/main_example.tex
+++ b/cv/main_example.tex
@@ -24,15 +24,20 @@
 
 \usepackage[utf8]{inputenc}
 % moderncv loads hyperref itself in an \AtEndPreamble hook, so \hypersetup
-% must go in an \AtEndPreamble of our own: a top-level \usepackage{hyperref}
-% clashes with the class's \PassOptionsToPackage on moderncv < 2.4.
+% must go in an \AtEndPreamble of our own: on moderncv < 2.4 a top-level
+% \usepackage{hyperref} clashes with the class's own
+% \RequirePackage[unicode]{hyperref}. From 2.4.0 the class passes its options
+% through \PassOptionsToPackage instead, which is what removes that clash.
 \AtEndPreamble{\hypersetup{
     colorlinks=true,
     linkcolor=blue,
     filecolor=magenta,
     urlcolor=blue,
     pdftitle={[YOUR_NAME] - CV},
-    pdfpagemode=FullScreen,
+    % Keep pdfpagemode=UseNone: this block runs after moderncv's own
+    % \AtEndPreamble (moderncv.cls sets pdfpagemode there), so a FullScreen
+    % value here would win and open every CV in fullscreen presentation mode.
+    pdfpagemode=UseNone,
 }}
 \usepackage[scale=0.80]{geometry}
 \usepackage{import}


### PR DESCRIPTION
Fixes #242

## Failing case

`cv/main_example.tex` does not compile on moderncv 2.3.1 (Debian/Ubuntu apt, `texlive-latex-extra`). Reproduction: `lualatex -interaction=nonstopmode -halt-on-error main_example.tex` in a Debian bookworm container with apt-packaged TeX Live. Two independent failures, as isolated in the issue thread:

1. `! LaTeX Error: Command \firstnamestyle undefined.` — 2.3.1 has no `\firstnamestyle`/`\lastnamestyle`; the pair only exists in later moderncv releases.
2. `! LaTeX Error: Option clash for package hyperref.` — moderncv loads hyperref itself via `\PassOptionsToPackage` in an `\AtEndPreamble` hook, so a top-level `\usepackage{hyperref}` fights the class for ownership.

## Changes

- **`cv/main_example.tex`**
  - Replace the `\firstnamestyle`/`\lastnamestyle` overrides with `\renewcommand*{\namefont}{\fontsize{34}{36}\bfseries\upshape}` plus `\colorlet` re-lets for `firstnamecolor`, `lastnamecolor` and `namecolor`. Root cause: `moderncvstylebanking.sty` defines the name colours with `\colorlet`, which *copies* (not aliases) the pre-scheme accent colour, so they are frozen before `\moderncvcolor{blue}` runs. `\namefont` is the shared hook every name-style macro routes through, so the block is version-agnostic and needs no version guard. `\sectionstyle` stays exactly as it was.
  - Drop `\usepackage{hyperref}` and move `\hypersetup` into an `\AtEndPreamble` of our own, stopping the option clash without picking a side.
  - `\address`: comment telling users to delete the whole line rather than empty it — `\address{}{}{}` fails with "There's no line here to end" on every moderncv version.
- **`.claude/skills/job-application-assistant/05-cv-templates.md`**
  - Preamble reference example updated to match, with the `\address` note mirrored.
  - "Color overrides" section rewritten: one `\renewcommand*` (on `\namefont`), three `\colorlet` lines, the `\colorlet` copy-not-alias cause, and the regular-weight advice now points at `\namefont`'s `\bfseries`. The "don't drop the overrides" point is preserved.
  - `framework_version` 1.4.0 → 1.4.1.

## Verification

- Per the issue thread, the final shape was verified on the real failing version: Debian bookworm with apt moderncv 2.3.1 — exit 0, exactly 2 pages, name renders 34pt bold in the scheme colour (ayobamiseun's on-version check), and the maintainer verified the same shape renders identically on moderncv 2.5.1.
- `python3 tools/lint_skills.py`, `python3 tools/check_framework_version.py`, `python3 tools/security_guards.py`, `python3 -m unittest discover -s tests` (230 tests) all pass locally. The `latex-smoke` CI job compiles both templates and enforces the exact page counts.

Known limitation (pre-existing, per the issue thread): on 2.3.1 the itemize bullets inside `\cventry` blocks clip at the left margin; it predates this change (master does not compile on 2.3.1 at all) and is out of scope.
