### PR TITLE
China fork — BOSS直聘 (zhipin.com) portal skill

### DIFF
--- a/.agents/skills/zhipin-search/SKILL.md
+++ b/.agents/skills/zhipin-search/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: zhipin-search
+version: 1.0.0
+description: >
+  Search BOSS直聘 (zhipin.com) job listings in China through the user's own
+  logged-in Chrome session (Chrome DevTools Protocol), read-only. Use when the
+  user wants to find or read Chinese job postings on BOSS直聘 by keyword or city.
+  Trigger phrases: BOSS直聘, boss zhipin, boss直聘岗位, 找工作, zhipin jobs,
+  find a job on boss, 搜职位, BOSS直聘招聘. Requires Chrome launched with
+  --remote-debugging-port=9222 and logged into BOSS直聘.
+context: fork
+enabled: true  # requires Chrome CDP running; set false to have /scrape skip it
+allowed-tools: Bash(bun run .agents/skills/zhipin-search/cli/src/cli.ts *)
+---
+
+# zhipin-search Skill
+
+Search BOSS直聘 job listings through **your own logged-in Chrome session** via
+the Chrome DevTools Protocol (CDP). BOSS直聘 is login-walled and anti-bot
+protected, so this skill does not scrape an anonymous endpoint — it drives a real
+Chrome window you are logged into and reads the rendered page. Read-only.
+
+## ⚠️ Personal use only
+
+This drives your own BOSS直聘 account through your own browser. Keep volume low,
+read listings as you would manually, and do not use it to automate applications.
+Run it on your own responsibility.
+
+## Prerequisite (run once)
+
+Launch Chrome with remote debugging enabled and log into BOSS直聘:
+
+```bash
+open -a "Google Chrome" --args --remote-debugging-port=9222 \
+    --remote-allow-origins=* --user-data-dir="$HOME/zhipin-chrome-profile"
+```
+
+- `--remote-allow-origins=*` is required on Chrome 111+ (CDP WebSocket rejects
+  connections without it).
+- `--user-data-dir` isolates this session; reuse the same dir next time to stay
+  logged in.
+
+## When to use this skill
+
+- Search BOSS直聘 openings by keyword (job title / skill), optionally scoped to a city
+- Read a specific posting's full description
+- Feed `/scrape` a BOSS直聘 source (the CLI is auto-discovered like other portal skills)
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run .agents/skills/zhipin-search/cli/src/cli.ts search [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q <text>` — keyword search (title / skill). Recommended.
+- `--location <name|code>` / `-l <...>` — city name (`上海`, `北京`, `杭州`, …) or
+  raw city code (e.g. `101020100`). Optional; omit to search nationwide. See
+  `url-reference.md` for the code table.
+- `--page <n>` — 1-indexed page. Default 1.
+- `--limit <n>` / `-n <n>` — cap results emitted (client-side).
+- `--format json|table|plain` — default `json`.
+
+> **Recency note:** BOSS直聘's search URL has no simple posted-within-N-days
+> parameter, so there is no `--jobage` flag. Results follow BOSS直聘's default sort.
+
+### Fetch full job detail
+
+```bash
+bun run .agents/skills/zhipin-search/cli/src/cli.ts detail <id|url> [--format json|plain]
+```
+
+`id` is the `/job_detail/<id>` segment of a listing URL (a long mixed-case token),
+or a full `https://www.zhipin.com/job_detail/<id>.html` URL.
+
+## Usage examples
+
+```bash
+# 算法工程师 jobs in Shanghai
+bun run .agents/skills/zhipin-search/cli/src/cli.ts search -q "算法工程师" -l 上海 --format table
+
+# AI平台 jobs nationwide, JSON, capped at 20
+bun run .agents/skills/zhipin-search/cli/src/cli.ts search -q "AI平台" --limit 20 --format json
+
+# Full detail for a specific job
+bun run .agents/skills/zhipin-search/cli/src/cli.ts detail f902a6107a7a3a6b0nF839q0GVBW --format plain
+```
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use (`{ meta, results }`) |
+| `table` | Quick human-readable scanning |
+| `plain` | Reading a single job's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the
+process exits with code `1`.
+
+## Notes
+
+- Data comes from your logged-in BOSS直聘 session via CDP; there is no anonymous
+  API to fall back to. If the CLI cannot reach Chrome, it exits non-zero with a
+  clear message — start Chrome per the prerequisite above.
+- **Search-list salary is obfuscated.** BOSS直聘 renders salary digits through a
+  custom font, so `search` results show garbled glyphs for `salary`. The `detail`
+  page is clean — run `detail <id>` to get the real salary (and full description).
+- If the DOM selectors in `src/helpers.ts` stop matching (BOSS直聘 changes its
+  markup), `search` returns zero results rather than crashing. Update the
+  selectors together with `url-reference.md`.
+- Read-only: no `apply` command. Use the results to apply manually.

--- a/.agents/skills/zhipin-search/cli/README.md
+++ b/.agents/skills/zhipin-search/cli/README.md
@@ -1,0 +1,42 @@
+# zhipin-search CLI
+
+Search BOSS直聘 (zhipin.com) through **your own logged-in Chrome session** via the
+Chrome DevTools Protocol (CDP). Read-only: `search` and `detail`.
+
+Unlike the other portal CLIs in this repo, this one does **not** scrape an
+anonymous HTTP endpoint. BOSS直聘 is login-walled and anti-bot protected, so the
+CLI drives a real Chrome window you have already logged into, and reads the
+rendered page. Zero runtime dependencies: just `bun`, which supplies `fetch` and
+`WebSocket`.
+
+## Prerequisite
+
+Launch Chrome with remote debugging enabled, logged into BOSS直聘:
+
+```bash
+open -a "Google Chrome" --args --remote-debugging-port=9222 \
+    --remote-allow-origins=* --user-data-dir="$HOME/zhipin-chrome-profile"
+```
+
+- `--remote-allow-origins=*` is required on Chrome 111+ (CDP WebSocket rejects
+  connections without it).
+- `--user-data-dir` isolates this session from your daily profile so you don't
+  clobber your normal tabs; use the same dir next time to stay logged in.
+
+## Usage
+
+```bash
+bun run src/cli.ts search -q "算法工程师" -l 上海 --format table
+bun run src/cli.ts search -q "AI平台" -l 101020100 --limit 20 --format json
+bun run src/cli.ts detail f902a6107a7a3a6b0nF839q0GVBW --format plain
+```
+
+## Notes
+
+- **Read-only.** There is no `apply` command and none is planned; use it to find
+  and read postings, then apply manually.
+- Keep volume low. This uses your own account; treat it as you would manual
+  browsing.
+- If the DOM selectors in `src/helpers.ts` stop matching (BOSS直聘 changes its
+  markup), the CLI returns zero results rather than crashing. Update the
+  selectors and `url-reference.md` together.

--- a/.agents/skills/zhipin-search/cli/package.json
+++ b/.agents/skills/zhipin-search/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "zhipin-cli",
+  "version": "1.0.0",
+  "description": "CLI for searching BOSS直聘 through your logged-in Chrome session (CDP) — read-only, zero runtime dependencies. Personal use only.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "zhipin-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "1.3.14"
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/cdp.ts
+++ b/.agents/skills/zhipin-search/cli/src/cdp.ts
@@ -1,0 +1,153 @@
+// Minimal Chrome DevTools Protocol (CDP) client over bun's native WebSocket.
+//
+// This skill reads BOSS直聘 through the user's OWN logged-in Chrome session, so
+// it can see listings behind BOSS直聘's login wall. Read-only: search + detail.
+//
+// Prerequisite — launch Chrome with remote debugging enabled AND logged into
+// BOSS直聘, e.g.:
+//   open -a "Google Chrome" --args --remote-debugging-port=9222 \
+//       --remote-allow-origins=* --user-data-dir="$HOME/zhipin-chrome-profile"
+// Chrome 111+ rejects CDP WebSocket connections unless --remote-allow-origins=*.
+
+export interface CDPTarget {
+  id: string
+  type: string
+  title: string
+  url: string
+  webSocketDebuggerUrl: string
+}
+
+export const CDP_HTTP_URL =
+  process.env.ZHIPIN_CDP_URL || "http://127.0.0.1:9222"
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms))
+
+async function httpJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${CDP_HTTP_URL}${path}`, init)
+  if (!res.ok) {
+    throw new Error(
+      `CDP ${path} failed: HTTP ${res.status}. ` +
+        `Is Chrome running with --remote-debugging-port=9222?`,
+    )
+  }
+  return (await res.json()) as T
+}
+
+export async function listTargets(): Promise<CDPTarget[]> {
+  return httpJson<CDPTarget[]>("/json/list")
+}
+
+export async function newTab(url = "about:blank"): Promise<CDPTarget> {
+  const res = await fetch(`${CDP_HTTP_URL}/json/new?${encodeURIComponent(url)}`, {
+    method: "PUT",
+  })
+  if (!res.ok) {
+    throw new Error(
+      `Could not open a Chrome tab via CDP (HTTP ${res.status}). ` +
+        `Start Chrome with --remote-debugging-port=9222 and log into BOSS直聘 first.`,
+    )
+  }
+  return (await res.json()) as CDPTarget
+}
+
+export async function closeTab(id: string): Promise<void> {
+  await fetch(`${CDP_HTTP_URL}/json/close/${id}`).catch(() => {})
+}
+
+/**
+ * Reuse an existing page tab (a human browses in one tab, not by opening and
+ * closing a tab per request — rapid open/close trips BOSS直聘's risk control).
+ * Falls back to opening a new tab when none exists yet.
+ */
+export async function getPageTab(): Promise<CDPTarget> {
+  const targets = await listTargets()
+  for (const t of targets) {
+    if (t.type === "page" && !t.url.startsWith("devtools://")) return t
+  }
+  return newTab()
+}
+
+interface Pending {
+  resolve: (v: unknown) => void
+  reject: (e: Error) => void
+}
+
+export class CDPSession {
+  private ws: WebSocket
+  private nextId = 0
+  private pending = new Map<number, Pending>()
+
+  private constructor(ws: WebSocket) {
+    this.ws = ws
+    ws.onmessage = (event: MessageEvent) => {
+      let msg: { id?: number; error?: { message: string }; result?: unknown }
+      try {
+        msg = JSON.parse(String(event.data))
+      } catch {
+        return
+      }
+      if (msg.id === undefined) return
+      const p = this.pending.get(msg.id)
+      if (!p) return
+      this.pending.delete(msg.id)
+      if (msg.error) p.reject(new Error(msg.error.message))
+      else p.resolve(msg.result)
+    }
+  }
+
+  static async connect(wsUrl: string): Promise<CDPSession> {
+    const ws = new WebSocket(wsUrl)
+    const opened = new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve()
+      ws.onerror = () =>
+        reject(
+          new Error(
+            "Could not connect to Chrome over WebSocket. Relaunch Chrome with " +
+              "--remote-allow-origins=* (Chrome 111+ blocks CDP WebSocket " +
+              "connections without it).",
+          ),
+        )
+    })
+    await Promise.race([
+      opened,
+      sleep(10000).then(() => {
+        throw new Error("Timed out connecting to Chrome CDP")
+      }),
+    ])
+    return new CDPSession(ws)
+  }
+
+  send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const id = ++this.nextId
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      this.ws.send(JSON.stringify({ id, method, params }))
+    })
+  }
+
+  async evaluate(expression: string): Promise<unknown> {
+    const res = (await this.send("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    })) as {
+      exceptionDetails?: { text?: string }
+      result?: { value?: unknown }
+    }
+    if (res.exceptionDetails) {
+      throw new Error(
+        `Page evaluation failed: ${res.exceptionDetails.text || "exception"}`,
+      )
+    }
+    return res.result?.value
+  }
+
+  async navigate(url: string): Promise<void> {
+    await this.send("Page.navigate", { url })
+  }
+
+  close(): void {
+    this.ws.close()
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/cli.ts
+++ b/.agents/skills/zhipin-search/cli/src/cli.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+// CLI for searching BOSS直聘 through the user's logged-in Chrome session (CDP).
+// Read-only (search + detail). Zero runtime dependencies beyond bun.
+//
+// Personal use only: drives your own logged-in session to read listings.
+// Keep volume low; do not use it to automate applications.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", l: "location", n: "limit" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `zhipin-cli — search BOSS直聘 through your logged-in Chrome session (read-only)
+
+USAGE
+  bun run src/cli.ts search -q "<keywords>" [-l <city|code>] [flags]
+  bun run src/cli.ts detail <id|url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>    Keywords (job title / skill). Recommended.
+  --location, -l <...>  City name (上海/北京/杭州/...) or raw city code
+                        (e.g. 101020100). Optional; omit to search nationwide.
+  --page <n>            1-indexed page. Default 1.
+  --limit, -n <n>       Cap results emitted (client-side).
+  --format <fmt>        json (default) | table | plain.
+
+REQUIRES
+  Chrome running with remote debugging AND logged into BOSS直聘, e.g.:
+    open -a "Google Chrome" --args --remote-debugging-port=9222 \\
+        --remote-allow-origins=* --user-data-dir="$HOME/zhipin-chrome-profile"
+
+EXAMPLES
+  bun run src/cli.ts search -q "算法工程师" -l 上海 --format table
+  bun run src/cli.ts search -q "AI平台" -l 101020100 --limit 20 --format json
+  bun run src/cli.ts detail f902a6107a7a3a6b0nF839q0GVBW --format plain
+
+Personal use only — read-only search through your own session. No auto-apply.
+`
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return 0
+  }
+  if (!cmd) {
+    process.stdout.write(HELP)
+    return 1
+  }
+
+  const parseNum = (
+    name: string,
+    raw: string | boolean | string[],
+  ): number | null => {
+    const v = parseInt(raw as string, 10)
+    if (isNaN(v)) {
+      process.stderr.write(
+        JSON.stringify({
+          error: `--${name} must be a number, got "${raw}"`,
+          code: "BAD_ARG",
+        }) + "\n",
+      )
+      return null
+    }
+    return v
+  }
+
+  if (cmd === "search") {
+    const fmt = (flags.format as string) || "json"
+    if (flags.page !== undefined) {
+      const v = parseNum("page", flags.page)
+      if (v === null) return 1
+      flags.page = String(v)
+    }
+    if (flags.limit !== undefined) {
+      const v = parseNum("limit", flags.limit)
+      if (v === null) return 1
+      flags.limit = String(v)
+    }
+    const opts: SearchOpts = {
+      query: typeof flags.query === "string" ? flags.query : undefined,
+      location:
+        typeof flags.location === "string" ? flags.location : undefined,
+      page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
+      limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,
+      format: (["json", "table", "plain"].includes(fmt)
+        ? fmt
+        : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(
+        JSON.stringify({ error: "detail requires an <id|url>", code: "NO_ID" }) +
+          "\n",
+      )
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      id,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(
+    JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) +
+      "\n",
+  )
+  return 1
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write(
+      JSON.stringify({
+        error: e instanceof Error ? e.message : String(e),
+        code: "INTERNAL_ERROR",
+      }) + "\n",
+    )
+    process.exit(1)
+  })

--- a/.agents/skills/zhipin-search/cli/src/commands/detail.ts
+++ b/.agents/skills/zhipin-search/cli/src/commands/detail.ts
@@ -1,0 +1,47 @@
+import { detailPage, writeError } from "../helpers.js"
+
+export interface DetailOpts {
+  id: string
+  format: "json" | "plain"
+}
+
+/** Accept a raw job id, or a full BOSS直聘 job_detail URL. */
+function normalizeId(input: string): string | null {
+  const url = input.match(/\/job_detail\/([^/?#]+)/)
+  if (url) return url[1]
+  // BOSS直聘 job ids are long mixed-case alphanumeric tokens (e.g. f902a6107a7a3a6b0nF839q0GVBW).
+  if (/^[A-Za-z0-9_-]{12,}$/.test(input)) return input
+  return null
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const id = normalizeId(opts.id)
+  if (!id) {
+    writeError(`Could not parse a job id from "${opts.id}"`, "BAD_ID")
+    return 1
+  }
+  try {
+    const job = await detailPage(id)
+    if (!job) {
+      writeError("Job not found (or the detail page did not render)", "NOT_FOUND")
+      return 1
+    }
+    if (opts.format === "plain") {
+      const lines = [
+        job.title,
+        `${job.company || "—"} · ${job.location || "—"} · ${job.salary || "—"}`,
+        "",
+        job.description || "(no description)",
+        "",
+        `URL: ${job.url}`,
+      ]
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/commands/search.ts
+++ b/.agents/skills/zhipin-search/cli/src/commands/search.ts
@@ -1,0 +1,69 @@
+import {
+  searchPage,
+  writeError,
+  type JobCard,
+} from "../helpers.js"
+
+export interface SearchOpts {
+  query?: string
+  location?: string
+  page: number
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+
+function renderTable(cards: JobCard[]): string {
+  if (cards.length === 0) return "No results."
+  const rows = cards.map((c) => {
+    const id = (c.id || "").slice(0, 12).padEnd(12)
+    const title = (c.title || "").slice(0, 34).padEnd(34)
+    const company = (c.company || "—").slice(0, 20).padEnd(20)
+    const loc = (c.location || "—").slice(0, 16).padEnd(16)
+    const salary = (c.salary || "—").slice(0, 14).padEnd(14)
+    return `${id} ${title} ${company} ${loc} ${salary}`
+  })
+  const header =
+    "ID".padEnd(12) +
+    " " +
+    "TITLE".padEnd(34) +
+    " " +
+    "COMPANY".padEnd(20) +
+    " " +
+    "LOCATION".padEnd(16) +
+    " SALARY"
+  return [header, "-".repeat(header.length), ...rows].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  try {
+    let cards = await searchPage(opts.query, opts.location, opts.page)
+    if (opts.limit !== undefined && opts.limit >= 0) {
+      cards = cards.slice(0, opts.limit)
+    }
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(cards) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        cards
+          .map(
+            (c) =>
+              `${c.title}\n  ${c.company || "—"} · ${c.location || "—"} · ${c.salary || "—"}\n  id: ${c.id}\n  ${c.url}`,
+          )
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify(
+          { meta: { count: cards.length, page: opts.page }, results: cards },
+          null,
+          2,
+        ) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/zhipin-search/cli/src/helpers.ts
+++ b/.agents/skills/zhipin-search/cli/src/helpers.ts
@@ -1,0 +1,262 @@
+// Data source: the user's logged-in BOSS直聘 session via Chrome CDP.
+// Search reads the rendered job cards; detail reads the rendered description.
+// Read-only. The DOM selectors below are the current BOSS直聘 markup; if they
+// change, update them here and in url-reference.md.
+
+import { CDPSession, getPageTab, sleep } from "./cdp.js"
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+export interface JobCard {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  salary: string | null
+  date: string | null
+  url: string
+}
+
+export interface JobDetail extends JobCard {
+  description: string | null
+  applyUrl: string | null
+}
+
+// BOSS直聘 city codes. 上海 is verified; the rest are best-effort — confirm by
+// checking the `city=` param in the browser URL before relying on them.
+export const CITY_CODES: Record<string, string> = {
+  上海: "101020100",
+  北京: "101010100",
+  杭州: "101210100",
+  深圳: "101280600",
+  广州: "101280100",
+  南京: "101190100",
+  苏州: "101190400",
+  成都: "101270100",
+  武汉: "101200100",
+  西安: "101110100",
+}
+
+export function cityCode(location: string | undefined): string {
+  if (!location) return ""
+  if (CITY_CODES[location]) return CITY_CODES[location]
+  if (/^\d{9}$/.test(location)) return location // raw code passthrough
+  return location // unmapped name — pass through and let the site resolve it
+}
+
+export function buildSearchUrl(opts: {
+  query?: string
+  location?: string
+  page: number
+}): string {
+  const params = new URLSearchParams()
+  if (opts.query) params.set("query", opts.query)
+  const code = cityCode(opts.location)
+  if (code) params.set("city", code)
+  params.set("page", String(Math.max(1, opts.page)))
+  return `https://www.zhipin.com/web/geek/job?${params.toString()}`
+}
+
+/** Reuse one page tab across operations. Leave it open — rapid open/close
+ *  trips BOSS直聘's risk control and returns empty results. */
+async function withPage<T>(driver: (session: CDPSession) => Promise<T>): Promise<T> {
+  await sleep(800) // pace consecutive operations so they don't look like a bot
+  const target = await getPageTab()
+  const session = await CDPSession.connect(target.webSocketDebuggerUrl)
+  try {
+    await session.send("Page.enable")
+    await session.send("Runtime.enable")
+    return await driver(session)
+  } finally {
+    session.close() // keep the tab open for reuse
+  }
+}
+
+/** Poll until `expression` evaluates truthy, or time out. */
+async function waitFor(
+  session: CDPSession,
+  expression: string,
+  timeoutMs = 15000,
+  pollMs = 500,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await session.evaluate(`Boolean(${expression})`)) return true
+    await sleep(pollMs)
+  }
+  return false
+}
+
+/**
+ * Navigate and wait until the page actually loads the new URL. A bare
+ * `Page.navigate` returns before the navigation begins, and BOSS直聘's SPA can
+ * restore a stale render from the browser's back/forward cache — so we bounce
+ * through `about:blank` first to force a clean load, then wait for the site.
+ */
+async function navigateAndWait(session: CDPSession, url: string): Promise<void> {
+  await session.navigate("about:blank")
+  await sleep(300)
+  await session.navigate(url)
+  const deadline = Date.now() + 12000
+  while (Date.now() < deadline) {
+    const here = (await session.evaluate("location.href")) as string
+    if (here.includes("zhipin.com")) return
+    await sleep(300)
+  }
+}
+
+const SEARCH_EXTRACT = `(() => {
+  const text = (root, sel) => {
+    const el = root.querySelector(sel);
+    return el ? el.textContent.replace(/\\s+/g, ' ').trim() : '';
+  };
+  const out = [];
+  for (const card of document.querySelectorAll('li.job-card-box')) {
+    const link = card.querySelector('a[href*="/job_detail/"]');
+    const href = link ? (link.getAttribute('href') || '') : '';
+    out.push({
+      href,
+      title: text(card, '.job-name'),
+      salary: text(card, '.job-salary'),
+      company: text(card, '.boss-name'),
+      area: text(card, '.company-location')
+    });
+  }
+  return out;
+})()`
+
+export function parseJobId(href: string): string | null {
+  const m = href.match(/\/job_detail\/([^/?#]+)/)
+  if (!m) return null
+  return m[1].replace(/\.html$/, "")
+}
+
+export async function searchPage(
+  query: string | undefined,
+  location: string | undefined,
+  page: number,
+): Promise<JobCard[]> {
+  const url = buildSearchUrl({ query, location, page })
+  return withPage(async (session) => {
+    await navigateAndWait(session, url)
+    const ready = await waitFor(
+      session,
+      `document.querySelectorAll('li.job-card-box').length > 0`,
+    )
+    if (!ready) await sleep(1500)
+
+    const raw = (await session.evaluate(SEARCH_EXTRACT)) as Array<{
+      href: string
+      title: string
+      salary: string
+      company: string
+      area: string
+    }> | null
+
+    if (!Array.isArray(raw) || raw.length === 0) {
+      const here = (await session.evaluate("location.href")) as string
+      if (here.includes("passport") || here.includes("security")) {
+        throw new Error(
+          "BOSS直聘 redirected to a login/security page — log into BOSS直聘 in the Chrome window first.",
+        )
+      }
+      return []
+    }
+
+    const cards: JobCard[] = []
+    for (const r of raw) {
+      const id = parseJobId(r.href || "")
+      if (!r.title || !id) continue
+      cards.push({
+        id,
+        title: r.title,
+        company: r.company || null,
+        location: r.area || null,
+        salary: r.salary || null,
+        date: null,
+        url: r.href.startsWith("http")
+          ? r.href
+          : `https://www.zhipin.com${r.href}`,
+      })
+    }
+    return cards
+  })
+}
+
+const DETAIL_EXTRACT = `(() => {
+  const text = (sel) => {
+    const el = document.querySelector(sel);
+    return el ? el.textContent.replace(/\\s+/g, ' ').trim() : '';
+  };
+  const inner = (sel) => {
+    const el = document.querySelector(sel);
+    return el ? el.innerText.replace(/\\s+/g, ' ').trim() : '';
+  };
+  const company = (() => {
+    const a = document.querySelector('.company-info a[href*="/gongsi/"]');
+    return a ? (a.getAttribute('title') || a.textContent.replace(/\\s+/g, ' ').trim()) : '';
+  })();
+  const desc = Array.from(document.querySelectorAll('.job-sec-text'))
+    .map((s) => s.innerText.replace(/\\s+/g, ' ').trim())
+    .filter(Boolean)
+    .join('\\n\\n');
+  return {
+    title: text('h1'),
+    salary: text('.salary'),
+    company,
+    location: text('.location-address') || text('.job-location'),
+    description: desc || inner('.job-detail')
+  };
+})()`
+
+export async function detailPage(id: string): Promise<JobDetail | null> {
+  const url = `https://www.zhipin.com/job_detail/${id}.html`
+  return withPage(async (session) => {
+    await navigateAndWait(session, url)
+    // The description loads via XHR with variable timing; poll the extract
+    // directly until it returns usable content (up to ~20s).
+    let raw: {
+      title: string
+      salary: string
+      company: string
+      location: string
+      description: string
+    } | null = null
+    const deadline = Date.now() + 20000
+    while (Date.now() < deadline) {
+      raw = (await session.evaluate(DETAIL_EXTRACT)) as {
+        title: string
+        salary: string
+        company: string
+        location: string
+        description: string
+      } | null
+      if (raw && (raw.title || raw.description)) break
+      await sleep(1000)
+    }
+
+    if (!raw || (!raw.title && !raw.description)) {
+      const here = (await session.evaluate("location.href")) as string
+      if (here.includes("passport") || here.includes("security")) {
+        throw new Error(
+          "BOSS直聘 redirected to a login/security page — log into BOSS直聘 in the Chrome window first.",
+        )
+      }
+      return null
+    }
+
+    return {
+      id,
+      title: raw.title || "(untitled)",
+      company: raw.company || null,
+      location: raw.location || null,
+      salary: raw.salary || null,
+      date: null,
+      url,
+      description: raw.description || null,
+      applyUrl: null,
+    }
+  })
+}

--- a/.agents/skills/zhipin-search/cli/tests/cli-contract.test.ts
+++ b/.agents/skills/zhipin-search/cli/tests/cli-contract.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "bun:test";
+import { runCLI, parseJSON } from "./helpers.js";
+
+async function chromeUp(): Promise<boolean> {
+  try {
+    const res = await fetch("http://127.0.0.1:9222/json/version", {
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+const HAS_CHROME = await chromeUp();
+
+test("help prints usage and exits 0", async () => {
+  const r = await runCLI(["--help"]);
+  expect(r.exitCode).toBe(0);
+  expect(r.stdout).toContain("USAGE");
+});
+
+test("no command exits 1", async () => {
+  const r = await runCLI([]);
+  expect(r.exitCode).toBe(1);
+});
+
+test("unknown command exits 1 with JSON error on stderr", async () => {
+  const r = await runCLI(["bogus"]);
+  expect(r.exitCode).toBe(1);
+  const e = JSON.parse(r.stderr);
+  expect(e.code).toBe("BAD_CMD");
+});
+
+test("search with non-numeric --page exits 1", async () => {
+  const r = await runCLI(["search", "-q", "x", "--page", "abc"]);
+  expect(r.exitCode).toBe(1);
+  const e = JSON.parse(r.stderr);
+  expect(e.code).toBe("BAD_ARG");
+});
+
+test("detail without id exits 1", async () => {
+  const r = await runCLI(["detail"]);
+  expect(r.exitCode).toBe(1);
+  const e = JSON.parse(r.stderr);
+  expect(e.code).toBe("NO_ID");
+});
+
+// Live test: runs only when Chrome CDP is reachable, so CI stays green.
+test("live search returns results via Chrome CDP", async () => {
+  if (!HAS_CHROME) {
+    console.log("skip: Chrome CDP (127.0.0.1:9222) not running");
+    return;
+  }
+  const r = await runCLI([
+    "search",
+    "-q",
+    "算法工程师",
+    "-l",
+    "上海",
+    "--limit",
+    "3",
+  ]);
+  expect(r.exitCode).toBe(0);
+  const parsed = parseJSON<{
+    results: Array<{ id: string; title: string; url: string }>;
+  }>(r);
+  expect(parsed.results.length).toBeGreaterThan(0);
+  expect(parsed.results[0].id).toBeTruthy();
+  expect(parsed.results[0].title).toBeTruthy();
+  expect(parsed.results[0].url).toContain("zhipin.com");
+});

--- a/.agents/skills/zhipin-search/cli/tests/helpers.ts
+++ b/.agents/skills/zhipin-search/cli/tests/helpers.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/zhipin-search/cli/tsconfig.json
+++ b/.agents/skills/zhipin-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/zhipin-search/url-reference.md
+++ b/.agents/skills/zhipin-search/url-reference.md
@@ -1,0 +1,87 @@
+# url-reference.md — zhipin-search (BOSS直聘)
+
+Data source: the user's logged-in BOSS直聘 session via Chrome CDP. Read-only.
+
+## Access
+
+- CDP HTTP endpoint: `http://127.0.0.1:9222` (override with `ZHIPIN_CDP_URL`)
+- Requires Chrome launched with `--remote-debugging-port=9222 --remote-allow-origins=*`
+  and logged into BOSS直聘.
+- Flow: `PUT /json/new` to open a tab → WebSocket to `webSocketDebuggerUrl` →
+  `Page.navigate` → poll `Runtime.evaluate` until content renders → extract →
+  `GET /json/close/<id>`.
+
+## Search page
+
+- URL: `https://www.zhipin.com/web/geek/job?query=<q>&city=<code>&page=<n>`
+  (redirects to `/web/geek/jobs` — same params).
+- Params:
+
+| param | meaning |
+|-------|---------|
+| query | keyword search |
+| city  | city code (see table below) |
+| page  | 1-indexed page |
+
+- Rendering: Vue SPA; job cards render asynchronously. Poll for
+  `li.job-card-box` before extracting.
+- robots.txt disallows `/*?query=*` and `/job_detail/*` for crawlers — this skill
+  does not crawl anonymously; it reads the user's own logged-in session.
+
+## Job card selectors (verified against live DOM, 2026-08)
+
+| field   | selector                      |
+|---------|-------------------------------|
+| card    | `li.job-card-box`             |
+| link    | `a[href*="/job_detail/"]`     |
+| title   | `.job-name`                   |
+| salary  | `.job-salary`                 |
+| company | `.boss-name`                  |
+| area    | `.company-location`           |
+
+## Salary obfuscation (search list only)
+
+The search-list salary is rendered via a **custom obfuscating font**
+(`kanzhun-mix` / `kanzhun-Regular`): the digit glyphs are mapped to Private-Use-Area
+codepoints, so `textContent` returns garbled glyphs (e.g. `30-50K·15薪` shows as
+`-K·薪`), and the same digit maps to multiple codepoints (defeats a fixed
+lookup table). Decoding requires parsing the font's cmap + glyph names — not yet
+implemented.
+
+**The detail page does NOT obfuscate salary** — `.salary` there returns clean text
+(e.g. `30-60K·15薪`). Fetch `detail <id>` for the real salary.
+
+## Detail page
+
+- URL: `https://www.zhipin.com/job_detail/<id>.html`
+- Selectors (verified):
+
+| field       | selector                                            |
+|-------------|-----------------------------------------------------|
+| title       | `h1`                                                |
+| salary      | `.salary` (clean text)                              |
+| company     | `.company-info a[href*="/gongsi/"]` → `title` attr  |
+| location    | `.location-address`                                 |
+| description | `.job-sec-text` (`.innerText`, excludes hidden junk)|
+
+- The detail page top header shows an anonymized company name (`某500强上市公司`);
+  the real name lives in the `公司基本信息` section, reachable via the
+  `.company-info a[href*="/gongsi/"]` `title` attribute.
+- The description text contains anti-scrape `<span>`s (hidden junk like `直聘`,
+  `boss`, plus visible spans wrapping single characters). `.innerText` correctly
+  excludes the hidden (`display:none`) junk.
+
+## City codes (上海 verified; others best-effort — confirm via the `city=` param)
+
+| city | code      |
+|------|-----------|
+| 上海 | 101020100 |
+| 北京 | 101010100 |
+| 杭州 | 101210100 |
+| 深圳 | 101280600 |
+| 广州 | 101280100 |
+| 南京 | 101190100 |
+| 苏州 | 101190400 |
+| 成都 | 101270100 |
+| 武汉 | 101200100 |
+| 西安 | 101110100 |

--- a/README.md
+++ b/README.md
@@ -304,6 +304,34 @@ For **country-agnostic** starting points outside Denmark, the repo ships two por
 - **`linkedin-search`** — built on LinkedIn's public, unauthenticated `jobs-guest` endpoints. Field-agnostic, **zero runtime dependencies** (runs with just `bun`), and takes the search location as an explicit flag, so it works for any market out of the box (`-l "Berlin, Germany"`, `-l "Mumbai, Maharashtra, India"`, `-l "Remote"`, …). Intended for **personal use only** — automated access is against LinkedIn's Terms of Service, so keep volume low. See `.agents/skills/linkedin-search/SKILL.md`.
 - **`freehire-search`** — queries the [freehire.me](https://freehire.me) aggregator's public REST API (JSON, no API key). Tech-focused (software, data, engineering, DevOps, remote), multi-market via facet flags (`--region`, `--country`, `--remote`), and **zero runtime dependencies**. Unlike the HTML-scraping Danish portals, results come back structured (skills, seniority, category). The backend is MIT-licensed and [self-hostable](https://github.com/strelov1/freehire) — point `FREEHIRE_API_URL` at your own instance if you prefer. See `.agents/skills/freehire-search/SKILL.md`.
 
+### BOSS直聘 (zhipin.com) — this fork
+
+This fork ships an additional **`zhipin-search`** portal skill for **BOSS直聘** (zhipin.com),
+China's largest direct-chat recruiting platform. Unlike the country-agnostic portals above, there
+is no anonymous endpoint to query — BOSS直聘 is login-walled and anti-bot protected — so the skill
+drives your own logged-in Chrome session over the Chrome DevTools Protocol (CDP), read-only.
+
+Prerequisite (run once, then reuse the same profile dir to stay logged in):
+
+```bash
+open -a "Google Chrome" --args --remote-debugging-port=9222 \
+    --remote-allow-origins=* --user-data-dir="$HOME/zhipin-chrome-profile"
+```
+
+Usage:
+
+```bash
+# search by keyword, optionally scoped to a city (--format json|table|plain)
+bun run .agents/skills/zhipin-search/cli/src/cli.ts search -q "算法工程师" -l 上海 --format table
+
+# read a listing's full description — salary is clean here, the search list obfuscates it
+bun run .agents/skills/zhipin-search/cli/src/cli.ts detail <job-id> --format plain
+```
+
+**Personal use only** — this drives your own BOSS直聘 account; keep volume low and apply manually.
+Full command reference in `.agents/skills/zhipin-search/SKILL.md`; verified DOM selectors and city
+codes in `.agents/skills/zhipin-search/url-reference.md`.
+
 ### Extending the framework: portals, templates, criteria - and borrowing from other forks
 
 Everything above adds up to an extension model, so here it is stated plainly. The framework has three extension points, and none of them require touching upstream:


### PR DESCRIPTION
## China fork — BOSS直聘 (zhipin.com) portal skill

  Fork: https://github.com/hacktmz/ai-job-search

  Adds a **`zhipin-search`** portal skill for **BOSS直聘**, China's largest
  direct-chat recruiting platform. BOSS直聘 is login-walled and anti-bot
  protected, so the skill drives your own logged-in Chrome session over the
  Chrome DevTools Protocol (CDP), read-only — no anonymous endpoint.

  - `search` / `detail` commands, `--format json|table|plain`, stderr JSON errors
  - zero runtime dependencies (bun only)
  - salary is obfuscated on the search list but clean on the detail page
    (documented in `url-reference.md`, with verified selectors + city codes)

  Usage (after launching Chrome with `--remote-debugging-port=9222`):

      bun run .agents/skills/zhipin-search/cli/src/cli.ts search -q "算法工程师" -l 上海

  See `.agents/skills/zhipin-search/SKILL.md` for the full reference.

  ---