### PR TITLE
fix(security): move the interview protection note to the rule that provides it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,14 @@ documents/cv/**
 documents/linkedin/**
 documents/diplomas/**
 documents/references/**
+# Also where /interview saves its prep packs (interview_prep_<stage>.md): these
+# name the employers applied to, quote what was submitted, and set out the
+# candidate's weak points.
 documents/applications/**
 documents/postings/**
-# Interview prep and experience records: these name the employers applied to,
-# quote what was submitted, and set out the candidate's weak points.
+# Belt-and-braces, not the primary guard: nothing writes here. Prep packs land
+# in documents/applications/<company>_<role>/, covered above. Kept because
+# tools/security_guards.py pins it in REQUIRED_IGNORE_RULES.
 documents/interview/**
 !documents/**/.gitkeep
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ per-file diff commands.
 
 ### Fixed
 
+- **The `documents/interview/**` ignore rule no longer claims interview prep is written there**
+  (#336). `/interview` saves its pack to
+  `documents/applications/<company>_<role>/interview_prep_<stage>.md`, already ignored by
+  `documents/applications/**`; nothing has ever written to `documents/interview/`. Nothing leaked -
+  but it was the personal-data block's one dedicated line about interview material, so an auditor
+  checking the framework's most sensitive artifact had every reason to read it and stop, at the
+  only path in the block with no writer. The protection rationale now sits above
+  `documents/applications/**`, the rule that actually provides it, so the next reader finds it
+  where it lives; `documents/interview/**` stays, relabelled belt-and-braces rather than primary
+  guard (`REQUIRED_IGNORE_RULES` pins it, so removing it from `.gitignore` alone fails the guard).
+  Pinned by `tests/test_security_guards.py`, which derives the prep-pack path from
+  `/interview`'s own spec instead of hardcoding it - so moving that path fails CI rather than
+  quietly re-staling the comment.
+
 - **`/scrape` now persists each posting's publication date** (#390) - Step 2's contract guarantees a
   `date` on every portal CLI's search output (CI enforces it in `test_scrape_contract.py`) and
   Step 1b uses that date to scope a run to the last 14 days, but Step 4's `seen_jobs.json` schema

--- a/tests/test_security_guards.py
+++ b/tests/test_security_guards.py
@@ -261,24 +261,28 @@ class GitignoreGuardTests(GuardRepoFixture):
 
 
 class GitignorePatternBehaviorTests(unittest.TestCase):
-    """Pin the match semantics of the shipped .gitignore for upskill reports.
+    """Pin the match semantics of the shipped .gitignore, not just rule presence.
 
-    The upskill skill resolves `upskill/` relative to its own directory (the
-    same observed behavior the **/job_scraper rules exist for), so a report
-    must be ignored at that depth too. The skill's own SKILL.md lives in a
-    directory that shares the `upskill` name, so a broad `**/upskill/*.md`
-    would ignore the template's own skill file - this pins that it stays
-    tracked. Guard presence checks cannot see either property; only real
-    check-ignore semantics can.
+    The guard checks that a rule exists; it never checks what the rule matches.
+    These cases run real `git check-ignore` over the shipped file, for paths the
+    framework actually writes.
     """
 
-    def test_upskill_reports_ignored_at_depth_but_skill_md_stays_tracked(self):
-        root = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
         subprocess.run(
-            ["git", "init", "-q", str(root)], check=True, capture_output=True
+            ["git", "init", "-q", str(self.root)], check=True, capture_output=True
         )
-        shutil.copy(REPO_ROOT / ".gitignore", root / ".gitignore")
+        shutil.copy(REPO_ROOT / ".gitignore", self.root / ".gitignore")
+
+    def test_upskill_reports_ignored_at_depth_but_skill_md_stays_tracked(self):
+        # The upskill skill resolves `upskill/` relative to its own directory
+        # (the same observed behavior the **/job_scraper rules exist for), so a
+        # report must be ignored at that depth too. The skill's own SKILL.md
+        # lives in a directory that shares the `upskill` name, so a broad
+        # `**/upskill/*.md` would ignore the template's own skill file - this
+        # pins that it stays tracked.
         cases = {
             "upskill/report-2026-08-11.md": True,
             ".claude/skills/upskill/upskill/report-2026-08-11.md": True,
@@ -288,7 +292,7 @@ class GitignorePatternBehaviorTests(unittest.TestCase):
         for path, expect_ignored in cases.items():
             with self.subTest(path=path):
                 result = subprocess.run(
-                    ["git", "-C", str(root), "check-ignore", "-q", path],
+                    ["git", "-C", str(self.root), "check-ignore", "-q", path],
                     capture_output=True,
                 )
                 self.assertEqual(
@@ -296,6 +300,38 @@ class GitignorePatternBehaviorTests(unittest.TestCase):
                     expect_ignored,
                     f"{path}: expected ignored={expect_ignored}",
                 )
+
+    def test_interview_prep_pack_is_ignored_at_the_path_the_command_writes(self):
+        # Derived, never copied: a hardcoded prep-pack path pins only that
+        # documents/applications/** still matches that shape - which the
+        # presence guard already catches - and stays green if /interview moves
+        # its output, leaving .gitignore's comment stale exactly the way #336
+        # found it. Reading the path back from the command spec is what makes
+        # the move fail here instead.
+        # Two fragments, not one literal: #329 split the path across Step 1
+        # (which derives the archive folder) and Step 3 (which names the file),
+        # so either half can move independently and each must be pinned.
+        folder = "documents/applications/<company>_<role>/"
+        filename = "interview_prep_<stage>.md"
+        spec = (REPO_ROOT / ".claude" / "commands" / "interview.md").read_text(encoding="utf-8")
+        for fragment in (folder, filename):
+            # assertTrue, not assertIn: the haystack is the whole command spec,
+            # and dumping it buries the one sentence explaining the failure.
+            self.assertTrue(
+                fragment in spec,
+                f"/interview no longer writes {fragment}; .gitignore's comment is now stale",
+            )
+
+        path = folder.replace("<company>_<role>", "acme_data_scientist") + filename.replace(
+            "<stage>", "technical"
+        )
+        result = subprocess.run(
+            ["git", "-C", str(self.root), "check-ignore", "-v", path],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, f"{path}: not ignored by the shipped .gitignore")
+        self.assertIn("documents/applications/**", result.stdout)
 
 
 class GitignoreNegationTests(GuardRepoFixture):

--- a/tools/security_guards.py
+++ b/tools/security_guards.py
@@ -80,6 +80,8 @@ REQUIRED_IGNORE_RULES = [
     "documents/references/**",
     "documents/applications/**",
     "documents/postings/**",
+    # Belt-and-braces, not the primary guard: nothing writes here.
+    # /interview's prep packs land under documents/applications/**, above.
     "documents/interview/**",
     "job_search_tracker.csv",
     "gmail_sync/",


### PR DESCRIPTION
Closes #336.

`.gitignore`'s comment above `documents/interview/**` claims interview prep and experience records
are written there. Nothing has ever written to that directory. `/interview` saves its pack to
`documents/applications/<company>_<role>/interview_prep_<stage>.md`
(`.claude/commands/interview.md:79`), which `documents/applications/**` already ignores.

Nothing leaks either way. The comment is the defect, and it is the misleading kind: it is the
personal-data block's one dedicated, well-argued line about interview material, so an auditor
checking that the framework's most sensitive artifact is covered reads it and stops, at the only
path in the block with no writer.

## Evidence

```console
$ git grep -n "documents/interview"
.gitignore:81:documents/interview/**
tools/security_guards.py:74:    "documents/interview/**",

$ git log --all -- 'documents/interview*'      # empty: the directory has never existed

$ git check-ignore -v documents/applications/acme_data_scientist/interview_prep_technical.md
.gitignore:76:documents/applications/**	documents/applications/acme_data_scientist/interview_prep_technical.md
```

Both `git grep` hits are declarations of the rule itself. `documents/README.md:160` documents the
applications path outright, and the directory is absent from the folder-structure diagram at
`documents/README.md:9-24`.

## What changed

The comment's description of *what* needs protecting was always right; only its location was
wrong. Per your ask, it now sits above `documents/applications/**` - the rule that actually
provides that protection - rather than being corrected in place:

```diff
 documents/references/**
+# Also where /interview saves its prep packs (interview_prep_<stage>.md): these
+# name the employers applied to, quote what was submitted, and set out the
+# candidate's weak points.
 documents/applications/**
 documents/postings/**
-# Interview prep and experience records: these name the employers applied to,
-# quote what was submitted, and set out the candidate's weak points.
+# Belt-and-braces, not the primary guard: nothing writes here. Prep packs land
+# in documents/applications/<company>_<role>/, covered above. Kept because
+# tools/security_guards.py pins it in REQUIRED_IGNORE_RULES.
 documents/interview/**
```

I kept `documents/interview/**` rather than dropping it: `REQUIRED_IGNORE_RULES` pins it, so
removing it from `.gitignore` alone turns CI red, and keeping it is the smaller diff for something
harmless. It is now labelled belt-and-braces in both files, so it cannot read as the primary guard
again.

- `.gitignore` - rationale relocated above `documents/applications/**`; `documents/interview/**`
  relabelled belt-and-braces with the binding reason it stays.
- `tools/security_guards.py` - the twin declaration was bare among annotated neighbours; it now
  carries the same belt-and-braces note.
- `tests/test_security_guards.py` - a `check-ignore` case in `GitignorePatternBehaviorTests`.
- `CHANGELOG.md` - Unreleased/Fixed entry.

## On the test, since "claims get verified" is the house bar

The obvious version of this test hardcodes a prep-pack path and asserts it resolves to
`documents/applications/**`. That version is worth nothing, and I want to be explicit that it was
written, rejected, and replaced rather than shipped:

- Its only failing mode is `documents/applications/**` going missing, which
  `python3 tools/security_guards.py` already fails on first, with
  `required personal-data rule missing`.
- It stays green if `/interview` moves its output, which is the exact rot mode this issue is about.
- It is the hand-built input CONTRIBUTING warns against.

So the shipped version derives the path from `/interview`'s own spec instead, following the
`Derived, never copied` pattern already established at `tests/test_html_report_command.py:53-63`.
Verified by mutation - repointing `interview.md:79` at `documents/prep_packs/<company>_<role>/`:

```console
$ python3 -m unittest tests.test_security_guards
AssertionError: False is not true : /interview no longer writes to
documents/applications/<company>_<role>/interview_prep_<stage>.md; .gitignore's comment is now stale

$ python3 tools/security_guards.py
security_guards: OK (permissions allowlist, hooks allowlist, gitignore rules, package manifests)
```

The guard cannot see the move; the test can. That gap is the test's entire justification.

## Acceptance criteria

- [x] The comment above `documents/interview/**` no longer claims interview prep is written there
- [x] `documents/interview/**` still present in `.gitignore` and still listed in
      `REQUIRED_IGNORE_RULES`
- [x] `python3 tools/security_guards.py` prints `security_guards: OK`
- [x] `git check-ignore -v` on a real prep-pack path still resolves to `documents/applications/**`,
      pinned in `GitignorePatternBehaviorTests`
- [x] No tracked file changes status on a clean checkout

## Verification

```
lint_skills: OK (9 skills, 12 commands, settings.json)
Framework Version Check: OK
security_guards: OK (permissions allowlist, hooks allowlist, gitignore rules, package manifests)
Ran 247 tests in 3.619s -- OK (skipped=6)
```

Single commit, clean descendant of `master` @ `5c423b4`. No rebase needed.

Does not overlap #317 (merged as `cfd9a9f`), which added `**/upskill/report-*.md` and left this
rule and its comment untouched. The skill-relative resolution trap that issue is about cannot reach
this path: `git grep -n "documents/applications" .claude/skills/` returns nothing, so no skill
resolves that directory against its own location. Every writer of the prep pack is a
repo-root-relative command.
