### PR TITLE
fix(jobnet-search): emit the /scrape contract fields in search output

### DIFF
--- a/.agents/skills/jobnet-search/SKILL.md
+++ b/.agents/skills/jobnet-search/SKILL.md
@@ -202,5 +202,5 @@ All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and 
 - Pagination is 1-indexed (`--page 1` is the first page).
 - `search` results omit the HTML job description — use `detail` to get it.
 - `detail --format plain` strips HTML tags for readable text output.
-- Job ad detail pages on jobnet.dk: `https://jobnet.dk/job/{jobAdId}`
+- Job ad detail pages on jobnet.dk: `https://jobnet.dk/find-job/{jobAdId}`
 - `suggestions` is tuned for Danish job titles — English terms may return empty results.

--- a/.agents/skills/jobnet-search/cli/README.md
+++ b/.agents/skills/jobnet-search/cli/README.md
@@ -152,7 +152,7 @@ bun run src/cli.ts search \
       "location": "Viborg",
       "date": "2026-03-13",
       "deadline": "2026-04-05",
-      "url": "https://jobnet.dk/job/9ef43bce-d82b-4ea1-a098-7ff6520f99be"
+      "url": "https://jobnet.dk/find-job/9ef43bce-d82b-4ea1-a098-7ff6520f99be"
     }
   ]
 }
@@ -357,8 +357,13 @@ All errors are written to **stderr** in JSON format and exit with code `1`:
 Job ad detail pages on jobnet.dk:
 
 ```
-https://jobnet.dk/job/{jobAdId}
+https://jobnet.dk/find-job/{jobAdId}
 ```
+
+The legacy `https://jobnet.dk/job/{jobAdId}` route redirects anonymous visitors into the
+MitID login flow, so it is never emitted. External ads (`isExternal: true`, jobAdIds with an
+`E` prefix) 404 on `/find-job/` and hit the login wall on `/job/` - neither route serves them
+anonymously; `/find-job/` is still strictly better and external ads are left as-is.
 
 Company logo images (prefix relative logoUrl from API):
 

--- a/.agents/skills/jobnet-search/cli/README.md
+++ b/.agents/skills/jobnet-search/cli/README.md
@@ -147,13 +147,20 @@ bun run src/cli.ts search \
       "workPlaceAddress": "",
       "conceptUriDa": "http://data.star.dk/esco/occupation/426e017f-ebe5-4bea-b1eb-7d2d5ab3c6db",
       "isSeen": false,
-      "isFavorite": false
+      "isFavorite": false,
+      "company": "Region Midtjylland",
+      "location": "Viborg",
+      "date": "2026-03-13",
+      "deadline": "2026-04-05",
+      "url": "https://jobnet.dk/job/9ef43bce-d82b-4ea1-a098-7ff6520f99be"
     }
   ]
 }
 ```
 
 > **Note**: The `description` field (raw HTML) is intentionally omitted from `search` results for brevity. Use `detail` to retrieve the full job description.
+
+> **Note**: Every result also carries the cross-portal contract fields `company`, `location`, `date`, `deadline` and `url` — derived respectively from `hiringOrgName`, `postalDistrictName`/`municipality`, and the jobnet detail page URL. `/scrape` Step 2 expects search output to include title, company, location, date, and URL, and dates follow the `YYYY-MM-DD` convention of the other portal CLIs. The API's `1900-01-01` deadline sentinel (deadline not disclosed) maps to `null`. The native fields above are preserved unchanged.
 
 > **Note**: `resultsPerPage` and `pageNumber` must always be provided — omitting them while also providing `searchString` causes the API to return error 1014 ("Fejl i formatering af inputs").
 

--- a/.agents/skills/jobnet-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/search.ts
@@ -106,7 +106,7 @@ export function createSearchOutput(data: SearchApiResponse, flags: SearchFlags) 
     deadline: job.applicationDeadline && !job.applicationDeadline.startsWith("1900-01-01")
       ? job.applicationDeadline.slice(0, 10)
       : null,
-    url: `https://jobnet.dk/job/${job.jobAdId}`,
+    url: `https://jobnet.dk/find-job/${job.jobAdId}`,
   }))
 
   if (flags.limit !== undefined) {

--- a/.agents/skills/jobnet-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/search.ts
@@ -100,6 +100,13 @@ export function createSearchOutput(data: SearchApiResponse, flags: SearchFlags) 
     workPlaceAddress: job.workPlaceAddress ?? "",
     isSeen: job.isSeen,
     isFavorite: job.isFavorite,
+    company: job.hiringOrgName,
+    location: job.postalDistrictName ?? job.municipality ?? null,
+    date: job.publicationDate.slice(0, 10),
+    deadline: job.applicationDeadline && !job.applicationDeadline.startsWith("1900-01-01")
+      ? job.applicationDeadline.slice(0, 10)
+      : null,
+    url: `https://jobnet.dk/job/${job.jobAdId}`,
   }))
 
   if (flags.limit !== undefined) {

--- a/.agents/skills/jobnet-search/cli/tests/search-normalization.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/search-normalization.test.ts
@@ -127,4 +127,37 @@ describe("Jobnet search normalization", () => {
     });
     expect("description" in output.results[0]).toBe(false);
   });
+
+  test("additively emits the /scrape contract fields (company, location, date, deadline, url)", () => {
+    const output = createSearchOutput(apiResponse(), { ...flags, limit: undefined });
+
+    expect(output.results).toHaveLength(2);
+    expect(output.results[0]).toMatchObject({
+      company: "Acme",
+      location: null,
+      date: "2026-07-01",
+      deadline: null,
+      url: "https://jobnet.dk/job/job-1",
+    });
+    expect(output.results[1]).toMatchObject({
+      company: "Example Co",
+      location: "København Ø",
+      date: "2026-07-02",
+      deadline: "2026-08-01",
+      url: "https://jobnet.dk/job/job-2",
+    });
+    expect(output.results[0].hiringOrgName).toBe("Acme");
+    expect(output.results[1].applicationDeadline).toBe("2026-08-01T23:59:00+02:00");
+  });
+
+  test("maps Jobnet's undisclosed-deadline sentinel (1900-01-01) to null", () => {
+    const response = apiResponse();
+    response.jobAds[0].applicationDeadline = "1900-01-01T00:00:00+01:00";
+    response.jobAds[0].applicationDeadlineStatus = "NotDisclosed";
+
+    const output = createSearchOutput(response, { ...flags, limit: undefined });
+
+    expect(output.results[0].deadline).toBeNull();
+    expect(output.results[1].deadline).toBe("2026-08-01");
+  });
 });

--- a/.agents/skills/jobnet-search/cli/tests/search-normalization.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/search-normalization.test.ts
@@ -137,14 +137,14 @@ describe("Jobnet search normalization", () => {
       location: null,
       date: "2026-07-01",
       deadline: null,
-      url: "https://jobnet.dk/job/job-1",
+      url: "https://jobnet.dk/find-job/job-1",
     });
     expect(output.results[1]).toMatchObject({
       company: "Example Co",
       location: "København Ø",
       date: "2026-07-02",
       deadline: "2026-08-01",
-      url: "https://jobnet.dk/job/job-2",
+      url: "https://jobnet.dk/find-job/job-2",
     });
     expect(output.results[0].hiringOrgName).toBe("Acme");
     expect(output.results[1].applicationDeadline).toBe("2026-08-01T23:59:00+02:00");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ per-file diff commands.
 
 ### Fixed
 
+- **`jobnet-search` search output now carries the `/scrape` contract fields** - the CLI emitted
+  the raw Jobnet API schema (`jobAdId`, `hiringOrgName`, `publicationDate`, …) with no
+  `company`, `location`, `date` or `url`, so every `/scrape` run flagged jobnet as degraded
+  forever (CI stayed green), the `seen_jobs.json` dedupe fell back to company+title, and `/rank`
+  lost the posting link. Search results now additively emit `company`, `location`, `date`,
+  `deadline` and `url` (`https://jobnet.dk/find-job/{jobAdId}` - the `/job/` route is
+  login-walled); the API's `1900-01-01` "deadline not disclosed" sentinel maps to `null`.
+
 - **The `/html-report` dashboard now reads and renders the tracker's `deadline`** (follow-up to
   #319). The tracker gained a fourteenth `deadline` column and every other consumer (`/outcome`,
   `/upskill`, `/notion-sync`) was updated to know it, but the dashboard's Step 1 field


### PR DESCRIPTION
## Problem

The `jobnet-search` CLI's `search` output exposes the raw Jobnet API schema (`jobAdId`, `hiringOrgName`, `publicationDate`, `postalDistrictName`, …) and **no `url`**, while `/scrape` promises a cross-portal contract:

- `.claude/skills/job-scraper/SKILL.md` Step 2: *"Search output already includes title, company, location, date, and URL."*
- Step 4.75 degraded scan flags *"`company` null or empty on every result"* as a half-working parser that makes `/scrape` collect junk.

A real run against the portal (one of today's documented queries):

```bash
bun run .agents/skills/jobnet-search/cli/src/cli.ts search \
  --search-string "softwareudvikler" --region HovedstadenOgBornholm \
  --per-page 20 --format json
```

returns **20/20 results with no `company`, `location`, `date` or `url` keys**. Consequences in the real `/scrape` flow: every run flags jobnet as *degraded* forever (while CI stays green), the dedupe (`url_or_company_title_key` in `seen_jobs.json`) falls back to company+title with no URL, and `/rank` loses the posting link entirely — jobnet detail pages are `https://jobnet.dk/job/{jobAdId}` (documented in the skill and CLI README).

The three other unblocked portals (jobindex, jobindex, linkedin, freehire) all emit the same key names (`id, title, company, companyUrl, location, date, url`); jobnet is the only one without even `url`.

## Fix

Additive normalization in `createSearchOutput` (`cli/src/commands/search.ts`):

| contract field | derived from |
|---|---|
| `company` | `hiringOrgName` |
| `location` | `postalDistrictName ?? municipality` |
| `date` | `publicationDate` → `YYYY-MM-DD` (convention of the other portal CLIs) |
| `deadline` | `applicationDeadline` → `YYYY-MM-DD`; the API's `1900-01-01` "deadline not disclosed" sentinel (observed live with `applicationDeadlineStatus: NotDisclosed`) maps to `null` |
| `url` | `https://jobnet.dk/job/{jobAdId}` |

All native fields stay untouched, so existing consumers pinned with `toMatchObject` are unaffected. The CLI README's documented response shape was updated.

## Evidence

- **Failing test against the pre-fix file**: `test("additively emits the /scrape contract fields …")` fails on master's `search.ts` (`expect(results[0]).toMatchObject({ company: "Acme", url: … })` → received object has none of them) and passes with the fix.
- **Live run with the fix** (`--per-page 3 --limit 3`):

  ```
  PAIBLOCK A/S | Søborg | 2026-08-17 | 2026-10-12 | https://jobnet.dk/job/67aa1c7a-…
  SAXO BANK A/S | Hellerup | 2026-08-16 | null (sentinel) | https://jobnet.dk/job/E11159529
  ```
- Suite: **25 pass, 0 fail**, `bun run typecheck` clean.