### PR TITLE
fix(jobbank-search): emit date key derived from posted in search output

### DIFF
--- a/.agents/skills/jobbank-search/cli/README.md
+++ b/.agents/skills/jobbank-search/cli/README.md
@@ -247,6 +247,7 @@ bun run src/cli.ts search --education 24 --suitable-for 2 --since 2026-03-01
       "description": "Fuldtidsjob hos Novo Nordisk, Bagsværd (Ansøgningsfrist: 12.04.2026)",
       "url": "https://jobbank.dk/job/1234567/novo-nordisk/senior-data-scientist",
       "posted": "2026-03-02T00:00:00+01:00",
+      "date": "2026-03-02",
       "deadline": "2026-04-12"
     }
   ]
@@ -265,6 +266,7 @@ bun run src/cli.ts search --education 24 --suitable-for 2 --since 2026-03-01
 | `description` | string | Raw RSS description field (single-line summary) |
 | `url` | string | Full URL to job posting |
 | `posted` | string | Publication date in ISO 8601 |
+| `date` | string \| null | Publication date as `YYYY-MM-DD` (derived from `posted`), or `null` if absent |
 | `deadline` | string \| null | Application deadline as `DD.MM.YYYY` string, or `null` if "løbende" / not present |
 
 > `meta.total` is fetched from the HTML page `<title>` in a secondary request (pattern: `"{N} relevante job og karriereopslag"`). If the secondary request fails, `meta.total` is `null`.

--- a/.agents/skills/jobbank-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/search.ts
@@ -147,6 +147,7 @@ export const search = defineCommand({
           description: item.description,
           url: item.link,
           posted,
+          date: posted ? posted.slice(0, 10) : null,
           deadline: parsed.deadline,
         }
       })

--- a/.agents/skills/jobbank-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/search.ts
@@ -1,6 +1,24 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { rssFetch, fetchWithUA, writeError, parseRssDescription, extractJobIdFromUrl, BASE_URL } from "../helpers.js"
+import { rssFetch, fetchWithUA, writeError, parseRssDescription, extractJobIdFromUrl, BASE_URL, type RssItem } from "../helpers.js"
+
+export function normalizeSearchItem(item: RssItem): Record<string, unknown> {
+  const parsed = parseRssDescription(item.description)
+  const id = extractJobIdFromUrl(item.link)
+  const posted = item.pubDate ? new Date(item.pubDate).toISOString() : ""
+  return {
+    id,
+    title: item.title,
+    company: parsed.company,
+    location: parsed.location,
+    jobType: parsed.jobType,
+    description: item.description,
+    url: item.link,
+    posted,
+    date: posted ? posted.slice(0, 10) : null,
+    deadline: parsed.deadline,
+  }
+}
 
 export const search = defineCommand({
   name: "search",
@@ -134,23 +152,7 @@ export const search = defineCommand({
       }
 
       // Normalize items
-      let results = items.map((item) => {
-        const parsed = parseRssDescription(item.description)
-        const id = extractJobIdFromUrl(item.link)
-        const posted = item.pubDate ? new Date(item.pubDate).toISOString() : ""
-        return {
-          id,
-          title: item.title,
-          company: parsed.company,
-          location: parsed.location,
-          jobType: parsed.jobType,
-          description: item.description,
-          url: item.link,
-          posted,
-          date: posted ? posted.slice(0, 10) : null,
-          deadline: parsed.deadline,
-        }
-      })
+      let results = items.map(normalizeSearchItem)
 
       // Apply limit
       if (flags.limit !== undefined) {

--- a/.agents/skills/jobbank-search/cli/tests/search-normalization.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/search-normalization.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeSearchItem } from "../src/commands/search";
+import type { RssItem } from "../src/helpers";
+
+function rssItem(): RssItem {
+  return {
+    title: "Data Scientist",
+    description: "Fuldtidsjob hos Acme A/S, København (Ansøgningsfrist: 31.07.2026)",
+    link: "https://jobbank.dk/job/12345/acme/data-scientist",
+    pubDate: "Fri, 14 Aug 2026 09:30:00 +0200",
+  };
+}
+
+describe("Jobbank search normalization", () => {
+  test("derives the /scrape contract date from posted as YYYY-MM-DD", () => {
+    const result = normalizeSearchItem(rssItem());
+
+    expect(result.posted).toBe("2026-08-14T07:30:00.000Z");
+    expect(result.date).toBe((result.posted as string).slice(0, 10));
+    expect(result.date).toBe("2026-08-14");
+  });
+
+  test("emits a null date when pubDate is absent (posted is empty)", () => {
+    const result = normalizeSearchItem({ ...rssItem(), pubDate: "" });
+
+    expect(result.posted).toBe("");
+    expect(result.date).toBeNull();
+  });
+
+  test("keeps the native fields alongside the contract date (additive)", () => {
+    const result = normalizeSearchItem(rssItem());
+
+    expect(result.company).toBe("Acme A/S");
+    expect(result.location).toBe("København");
+    expect(result.url).toBe("https://jobbank.dk/job/12345/acme/data-scientist");
+    expect(result.deadline).toBe("31.07.2026");
+  });
+});


### PR DESCRIPTION
## Summary

`jobbank-search` search output was the only portal CLI not emitting the shared search contract fields that `/scrape` (`.claude/skills/job-scraper/SKILL.md`, Step 2) requires: `title`, `company`, `location`, `date`, `url`. It emitted `posted` (ISO 8601) but no `date`.

This PR adds an additive `date` field to every search result, derived from `posted` as `YYYY-MM-DD` (same convention as the detail command's `datePosted`). `posted` is kept unchanged for backwards compatibility. `deadline` is left untouched (not part of the step-2 field list). The inline normalization is extracted into an exported `normalizeSearchItem` (no behavior change) so the mapping is testable directly, following the #339/#340 pattern.

## Evidence

- **Failing test against pre-fix source**: on master, `search.ts` emits `posted` (always a `toISOString()` result or `""`) and no `date` key; the new normalization tests import `normalizeSearchItem`, which master does not export — they fail on master and pass with the fix.
- **New normalization tests** (`tests/search-normalization.test.ts`): a fixture asserting `date === posted.slice(0, 10)` (concretely `2026-08-14`) and the null path (`pubDate` absent → `posted: ""`, `date: null`); deleting the `date` line fails them.
- **Live verification blocked**: `jobbank-search search` returns `{"error": "Jobbank is blocking automated requests with Cloudflare bot protection...", "code": "API_ERROR"}` (documented in the CLI README), so no live JSON is obtainable — the evidence is source-level, same as the other portal fixes.
- **Tests**: 25 pass / 0 fail in `cli/` (`bun test`), `bun run typecheck` clean.
- README response shape and field table updated.

## Checklist

- [x] One change per PR: only the jobbank search `date` field (+ testable extraction + README)
- [x] No personal fork configuration touched