### PR TITLE
feat(computrabajo-search): add Computrabajo Colombia portal CLI

### DIFF
--- a/.agents/skills/computrabajo-search/SKILL.md
+++ b/.agents/skills/computrabajo-search/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: computrabajo-search
+version: 1.0.0
+description: >
+  Use this skill whenever the user wants to search job listings on Computrabajo
+  Colombia (computrabajo.com.co — canonical host co.computrabajo.com), the
+  largest job board in Latin America, or look up a specific Computrabajo
+  posting. Invoke for vacancies, open positions, and hiring in Colombia: Bogotá,
+  Medellín, Cali, Barranquilla, remote, and any city or sector (software,
+  engineering, finance, healthcare, operations). Trigger phrases: computrabajo,
+  trabajo en colombia, empleos colombia, ofertas de trabajo colombia, buscar
+  trabajo, vacantes colombia, find a job in colombia, "are there any X jobs in
+  colombia", look up this computrabajo posting.
+context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
+allowed-tools: Bash(bun run .agents/skills/computrabajo-search/cli/src/cli.ts *)
+---
+
+# Computrabajo Search Skill
+
+Search live job listings from **Computrabajo Colombia** (`co.computrabajo.com`, the
+canonical host — `www.computrabajo.com.co` 301-redirects there). No authentication,
+no API key, and **zero runtime dependencies** — it runs with just `bun`.
+
+> Colombia-market example of the repo's job-portal-skill pattern. Computrabajo runs
+> in many countries (co., com.mx, com.ar, ...) under the same markup; this skill is
+> pinned to the Colombian deployment the fork targets.
+
+## ⚠️ Personal use only
+
+This uses Computrabajo's public pages; automated access is against the portal's terms,
+so **keep volume low and don't use it commercially or for bulk data collection.** Run it
+on your own responsibility. The CLI stays inside `robots.txt`: it fetches only the
+page-1 document (search and detail); `/Ajax/*` — the portal's real paginator — is
+disallowed, so there is no pagination beyond page 1.
+
+## When to use this skill
+
+- Search for job openings in Colombia (any city, remote, any sector)
+- Get the full description, requirements, salary tag, and apply link of a specific offer
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run .agents/skills/computrabajo-search/cli/src/cli.ts search --query "<text>" [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q <text>` — **required.** Keywords, e.g. `"desarrollador backend"`, `"analista de datos"`, `"frontend react"`.
+- `--page <n>` — page number. **Only `1` is supported**; `2+` exits with `UNSUPPORTED_PAGINATION` (Computrabajo's real paginator is Ajax-based and disallowed by its robots.txt).
+- `--limit <n>` / `-n <n>` — cap total results emitted (client-side).
+- `--format json|table|plain` — default `json`.
+
+There is **no recency filter flag** — Computrabajo cards carry relative dates ("Hace 12
+horas", "Ayer", "Hoy") that the CLI converts to `YYYY-MM-DD` in the `date` field; filter
+client-side on `date` when a window is needed.
+
+### Fetch full offer detail
+
+```bash
+bun run .agents/skills/computrabajo-search/cli/src/cli.ts detail <url> [--format json|plain]
+```
+
+`<url>` is the posting URL from `search` results (its address includes the job slug, so a
+bare id cannot address the page). Returns the full description, requirements list, salary
+tag, relative date, and the apply (match) link. Computrabajo publishes **no application
+deadlines** — `deadline` is always `null`.
+
+## Usage examples
+
+```bash
+# Backend roles anywhere in Colombia
+bun run .agents/skills/computrabajo-search/cli/src/cli.ts search -q "desarrollador backend" --format table
+
+# Data analyst roles, capped
+bun run .agents/skills/computrabajo-search/cli/src/cli.ts search -q "analista de datos" -n 5
+
+# Full details for a specific offer
+bun run .agents/skills/computrabajo-search/cli/src/cli.ts detail "https://co.computrabajo.com/ofertas-de-trabajo/oferta-de-trabajo-de-desarrollador-backend-E92595FF9C5126D461373E686DCF3405" --format plain
+```
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing URLs to `detail` |
+| `table` | Quick human-readable scanning |
+| `plain` | Reading a single offer's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the process exits with code `1`.
+
+## Notes
+
+- Data comes from Computrabajo's public HTML pages — no credentials required.
+- Job ids are 32-hex strings (e.g. `E92595FF9C5126D461373E686DCF3405`) used in the posting URL.
+- Search returns offers on page 1 only (see the robots note above); `meta.count` reflects that page.
+- Computrabajo may rate-limit; the CLI retries 429/5xx with exponential backoff. Keep volume low (see ToS note above).

--- a/.agents/skills/computrabajo-search/cli/README.md
+++ b/.agents/skills/computrabajo-search/cli/README.md
@@ -1,0 +1,63 @@
+# computrabajo-cli
+
+CLI for searching jobs on **Computrabajo Colombia** (`co.computrabajo.com`, the canonical
+host; `www.computrabajo.com.co` 301-redirects there).
+
+**Data source**: Computrabajo's public HTML search (`/trabajo-de-<query>`) and offer detail pages.
+**Authentication**: None required.
+**Dependencies**: None (plain `bun` + `fetch`). `bun install` is optional and only pulls dev type defs.
+
+> **Personal use only.** This reads Computrabajo's public pages; automated access is against
+> the portal's terms. Keep volume low and run it on your own responsibility. The CLI stays
+> within the portal's `robots.txt`: only the page-1 document fetch is used — `/Ajax/*` (its
+> real paginator) is disallowed, so `--page 2+` is rejected.
+
+## Installation
+
+```bash
+cd .agents/skills/computrabajo-search/cli
+bun install   # optional — only installs TypeScript dev types
+```
+
+The CLI runs without any install because it has zero runtime dependencies.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `search` | Search for job listings (`--query` required) |
+| `detail` | Fetch full detail for a single offer (pass the full URL from search results) |
+
+`search` accepts `--format json|table|plain` (default `json`); `detail` accepts `--format json|plain`.
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` with exit code `1`.
+
+## Quick examples
+
+```bash
+# Backend roles anywhere in Colombia
+bun run src/cli.ts search -q "desarrollador backend" --format table
+
+# Data analyst roles, cap results
+bun run src/cli.ts search -q "analista de datos" -n 5
+
+# Full detail for one offer (URL from the search output)
+bun run src/cli.ts detail "https://co.computrabajo.com/ofertas-de-trabajo/oferta-de-trabajo-de-desarrollador-backend-E92595FF9C5126D461373E686DCF3405" --format plain
+```
+
+See `../SKILL.md` for the full flag reference and portal notes.
+
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--query` | `-q` | **Required.** Keywords (title / skill / role), e.g. `"desarrollador backend"`, `"analista de datos"`, `"frontend react"`. |
+| `--page` | | Page number. **Only `1` is supported** — exits with `UNSUPPORTED_PAGINATION` otherwise (Ajax paginator is robots-disallowed). |
+| `--limit` | `-n` | Cap results emitted. |
+| `--format` | | `json` \| `table` \| `plain`. |
+
+## Notes
+
+- Computrabajo publishes dates as relative text ("Hace 12 horas", "Ayer", "Hoy"); the CLI
+  converts them to `YYYY-MM-DD` at search time. Sub-day units resolve to the current day.
+- The portal publishes no application deadlines on offer pages — `deadline` is always `null`.
+- There is no recency filter flag: filter client-side on the `date` field if needed.

--- a/.agents/skills/computrabajo-search/cli/package.json
+++ b/.agents/skills/computrabajo-search/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "computrabajo-cli",
+  "version": "1.0.0",
+  "description": "CLI for searching jobs on Computrabajo Colombia (co.computrabajo.com) — no authentication, zero runtime dependencies. Personal use only (Computrabajo terms).",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "computrabajo-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "1.3.14"
+  }
+}

--- a/.agents/skills/computrabajo-search/cli/src/cli.ts
+++ b/.agents/skills/computrabajo-search/cli/src/cli.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+// Self-contained CLI for searching jobs on Computrabajo Colombia
+// (co.computrabajo.com). No external CLI framework, so it runs anywhere `bun`
+// is available with zero install beyond the repo clone.
+//
+// Respects the portal's robots.txt: only the document fetch of page 1 of a
+// keyword search is used; the Ajax-based paginator (/Ajax/*) is disallowed,
+// so --page 2+ is rejected. Keep volume low.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", n: "limit" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `computrabajo-cli — search jobs on Computrabajo Colombia (co.computrabajo.com)
+
+USAGE
+  bun run src/cli.ts search --query "<text>" [flags]
+  bun run src/cli.ts detail <url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>     Keywords (job title or skill). REQUIRED, e.g. "desarrollador
+                         backend", "analista de datos", "frontend react".
+  --page <n>             1-indexed page. Only 1 is supported: Computrabajo's real
+                         paginator is Ajax-based (/Ajax/* is disallowed by its
+                         robots.txt), so --page 2+ exits with UNSUPPORTED_PAGINATION.
+  --limit, -n <n>        Cap results emitted (client-side).
+  --format <fmt>         json (default) | table | plain.
+
+EXAMPLES
+  bun run src/cli.ts search -q "desarrollador backend" --format table
+  bun run src/cli.ts search -q "analista de datos" -n 5
+  bun run src/cli.ts detail "https://co.computrabajo.com/ofertas-de-trabajo/oferta-de-trabajo-de-desarrollador-backend-E92595FF9C5126D461373E686DCF3405" --format plain
+
+The detail <url> must be the full posting URL from search results: Computrabajo's
+address includes the job slug, so a bare id cannot address the page.
+`
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  if (cmd === "search") {
+    const query = typeof flags.query === "string" ? flags.query : undefined
+    if (!query) {
+      process.stderr.write(
+        JSON.stringify({
+          error: "the --query/-q flag is required (e.g. -q \"desarrollador backend\")",
+          code: "NO_QUERY",
+        }) + "\n",
+      )
+      return 1
+    }
+
+    const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
+      const val = parseInt(raw as string, 10)
+      if (isNaN(val)) {
+        process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+        return null
+      }
+      return val
+    }
+
+    if (flags.page !== undefined) {
+      const v = parseIntFlag("page", flags.page)
+      if (v === null) return 1
+      if (v > 1) {
+        process.stderr.write(
+          JSON.stringify({
+            error: `--page ${v} is unsupported: Computrabajo's paginator is Ajax-based (/Ajax/* is disallowed by its robots.txt), so this CLI fetches page 1 only`,
+            code: "UNSUPPORTED_PAGINATION",
+          }) + "\n",
+        )
+        return 1
+      }
+      flags.page = String(v)
+    }
+    if (flags.limit !== undefined) {
+      const v = parseIntFlag("limit", flags.limit)
+      if (v === null) return 1
+      flags.limit = String(v)
+    }
+
+    const fmt = (flags.format as string) || "json"
+    const opts: SearchOpts = {
+      query,
+      page: 1,
+      limit: flags.limit ? parseInt(flags.limit as string, 10) : undefined,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const input = (flags._ as string[])[1]
+    if (!input) {
+      process.stderr.write(JSON.stringify({ error: "detail requires a <url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      input,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write(
+      JSON.stringify({
+        error: e instanceof Error ? e.message : String(e),
+        code: "INTERNAL_ERROR",
+      }) + "\n",
+    )
+    process.exit(1)
+  })

--- a/.agents/skills/computrabajo-search/cli/src/commands/detail.ts
+++ b/.agents/skills/computrabajo-search/cli/src/commands/detail.ts
@@ -1,0 +1,74 @@
+import { htmlFetch, parseJobDetail, writeError } from "../helpers.js"
+
+export interface DetailOpts {
+  input: string
+  format: "json" | "plain"
+}
+
+const HEX_ID = /([0-9a-f]{32})/i
+
+/**
+ * Computrabajo's posting address includes the job slug, so a bare id cannot
+ * address the page: accept the full URL (as emitted by search results) or the
+ * relative path, stripping the #lc= fragment and query string.
+ */
+export function normalizeDetailUrl(input: string): string | null {
+  const t = input.trim()
+  if (/^https?:\/\//i.test(t)) {
+    return t.split("#")[0].split("?")[0]
+  }
+  if (t.startsWith("/")) {
+    return t.split("#")[0].split("?")[0]
+  }
+  return null
+}
+
+export function idFromUrl(url: string): string | null {
+  const m = url.match(HEX_ID)
+  return m ? m[1].toLowerCase() : null
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const url = normalizeDetailUrl(opts.input)
+  const id = url ? idFromUrl(url) : null
+  if (!url || !id || !/ofertas-de-trabajo/.test(url)) {
+    writeError(
+      `Could not parse a Computrabajo posting URL from "${opts.input}" (pass the full URL from search results — the address includes the job slug)`,
+      "BAD_ID",
+    )
+    return 1
+  }
+  try {
+    const html = await htmlFetch(url)
+    if (!html) {
+      writeError("Job not found", "NOT_FOUND")
+      return 1
+    }
+    const job = parseJobDetail(html, url, id)
+
+    if (opts.format === "plain") {
+      const lines = [
+        job.title,
+        `${job.company || "—"} · ${job.location || "—"}`,
+        job.salary ? `Salary: ${job.salary}` : "",
+        job.date ? `Posted: ${job.date}` : "",
+        "",
+        job.description || "(no description)",
+        "",
+        ...(job.requirements.length > 0
+          ? ["Requirements:", ...job.requirements.map((r) => `  • ${r}`)]
+          : []),
+        "",
+        `URL: ${job.url}`,
+        job.applyUrl ? `Apply: ${job.applyUrl}` : "",
+      ].filter((l) => l !== "")
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(job, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/computrabajo-search/cli/src/commands/search.ts
+++ b/.agents/skills/computrabajo-search/cli/src/commands/search.ts
@@ -1,0 +1,72 @@
+import {
+  SEARCH_URL,
+  htmlFetch,
+  parseJobCards,
+  writeError,
+  type JobCard,
+} from "../helpers.js"
+
+export interface SearchOpts {
+  query: string
+  page: number // always 1 — Computrabajo's real paginator is Ajax-based and robots-disallowed
+  limit?: number
+  format: "json" | "table" | "plain"
+}
+
+export function buildSearchUrl(query: string): string {
+  return `${SEARCH_URL}/trabajo-de-${encodeURIComponent(query)}`
+}
+
+function renderTable(cards: JobCard[]): string {
+  if (cards.length === 0) return "No results."
+  const rows = cards.map((c) => {
+    const title = (c.title || "").slice(0, 42).padEnd(42)
+    const company = (c.company || "—").slice(0, 26).padEnd(26)
+    const loc = (c.location || "—").slice(0, 24).padEnd(24)
+    const date = c.date || "—"
+    return `${c.id.slice(0, 11).padEnd(11)} ${title} ${company} ${loc} ${date}`
+  })
+  const header =
+    "ID".padEnd(11) +
+    " " +
+    "TITLE".padEnd(42) +
+    " " +
+    "COMPANY".padEnd(26) +
+    " " +
+    "LOCATION".padEnd(24) +
+    " DATE"
+  return [header, "-".repeat(header.length), ...rows].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  try {
+    const html = await htmlFetch(buildSearchUrl(opts.query))
+    let cards = parseJobCards(html)
+    if (opts.limit !== undefined && opts.limit >= 0) cards = cards.slice(0, opts.limit)
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(cards) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        cards
+          .map(
+            (c) =>
+              `${c.title}\n  ${c.company || "—"} · ${c.location || "—"} · ${c.date || "—"}\n  id: ${c.id}\n  ${c.url}`,
+          )
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify(
+          { meta: { count: cards.length, page: opts.page }, results: cards },
+          null,
+          2,
+        ) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/computrabajo-search/cli/src/helpers.ts
+++ b/.agents/skills/computrabajo-search/cli/src/helpers.ts
@@ -1,0 +1,317 @@
+// Data source: Computrabajo Colombia public pages (co.computrabajo.com).
+// Search returns an HTML list of offer cards (`article.box_offer`); detail
+// returns a single offer's HTML. We parse both with regex — the markup is
+// shallow and stable, and a full DOM parser is unnecessary.
+
+export const SEARCH_URL = "https://co.computrabajo.com"
+// canonical host: www.computrabajo.com.co 301-redirects here
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+const UA = "Mozilla/5.0 (compatible; computrabajo-search-cli/1.0)"
+
+/** Fetch HTML with exponential backoff on 429/5xx. Returns "" on a 404. */
+export async function htmlFetch(url: string): Promise<string> {
+  const maxRetries = 6
+  let delay = 500
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": UA,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "es-CO,es;q=0.9,en;q=0.8",
+      },
+      redirect: "follow",
+      signal: AbortSignal.timeout(15000),
+    })
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+      }
+      const jitter = Math.floor(Math.random() * 500)
+      await new Promise((r) => setTimeout(r, delay + jitter))
+      delay = Math.min(delay * 2, 8000)
+      continue
+    }
+    if (response.status === 404) return ""
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+    }
+    return response.text()
+  }
+  throw new Error("Request failed after max retries")
+}
+
+export interface JobCard {
+  id: string
+  title: string
+  company: string | null
+  companyUrl: string | null
+  location: string | null
+  date: string | null
+  url: string
+}
+
+export interface JobDetail extends JobCard {
+  description: string | null
+  requirements: string[]
+  salary: string | null
+  applyUrl: string | null
+  deadline: string | null // Computrabajo publishes no closing dates -> always null
+}
+
+/**
+ * Extract the inner HTML of a <div> identified by a non-class attribute
+ * (e.g. <div ... div-link="oferta">), correctly handling nested <div>
+ * elements by tracking tag depth.
+ */
+export function extractDivByAttr(html: string, attr: string, value: string): string | null {
+  const openRe = new RegExp(`<div[^>]*${attr}="${value}"[^>]*>`, "i")
+  const open = openRe.exec(html)
+  if (!open) return null
+
+  let i = open.index + open[0].length
+  let depth = 1
+
+  while (depth > 0 && i < html.length) {
+    const nextOpen = html.indexOf("<div", i)
+    const nextClose = html.indexOf("</div>", i)
+
+    if (nextClose === -1) return null
+
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth++
+      i = nextOpen + 4
+    } else {
+      depth--
+      i = nextClose + 6
+    }
+  }
+
+  return html.slice(open.index + open[0].length, i - 6)
+}
+
+/**
+ * Convert a Unicode code point to a string. Uses `fromCodePoint` (not
+ * `fromCharCode`) so supplementary-plane code points (e.g. emoji, U+1F600)
+ * decode correctly, and drops out-of-range values instead of throwing.
+ */
+function numericEntity(cp: number): string {
+  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    // Numeric character references: decimal (&#233;) and hexadecimal (&#xE9;).
+    .replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
+    .replace(/&nbsp;/g, " ")
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim()
+}
+
+function clean(html: string): string {
+  return decodeHtmlEntities(stripTags(html))
+}
+
+const MONTH_DAYS = 30
+const YEAR_DAYS = 365
+
+/**
+ * Parse Computrabajo's relative dates ("Hoy", "Ayer", "Hace 12 horas",
+ * "Hace 2 días", "Hace 1 semana", "Hace 3 meses", optionally followed by
+ * notes like "(actualizada)") into a local YYYY-MM-DD string. Sub-day units
+ * (minutes/hours) resolve to the current day. Returns null when the text is
+ * not a relative date (e.g. "Palabras clave: ...").
+ */
+export function relativeDateToISO(
+  text: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!text) return null
+  // Real pages hide accents inside the date text ("Hace 2 d&#xED;as") — decode first.
+  const t = decodeHtmlEntities(text).replace(/\s+/g, " ").trim().toLowerCase()
+  const m = t.match(
+    /^(hoy|ayer|hace\s+(\d+)\s+(minuto|minutos|hora|horas|dia|dias|día|días|semana|semanas|mes|meses|año|años|ano|anos))/,
+  )
+  if (!m) return null
+  const unit = (m[3] ?? "").toLowerCase()
+  if (m[1] === "ayer") {
+    return isoDaysAgo(now, 1)
+  }
+  if (m[1] === "hoy") {
+    return isoDaysAgo(now, 0)
+  }
+  const n = parseInt(m[2], 10)
+  if (unit.startsWith("minuto") || unit.startsWith("hora")) {
+    return isoDaysAgo(now, 0)
+  }
+  if (unit.startsWith("dia") || unit.startsWith("día")) {
+    return isoDaysAgo(now, n)
+  }
+  if (unit.startsWith("semana")) {
+    return isoDaysAgo(now, n * 7)
+  }
+  if (unit.startsWith("mes")) {
+    return isoDaysAgo(now, n * MONTH_DAYS)
+  }
+  return isoDaysAgo(now, n * YEAR_DAYS)
+}
+
+function isoDaysAgo(now: Date, days: number): string {
+  const d = new Date(now.getTime() - days * 86400000)
+  const mo = String(d.getMonth() + 1).padStart(2, "0")
+  const da = String(d.getDate()).padStart(2, "0")
+  return `${d.getFullYear()}-${mo}-${da}`
+}
+
+/**
+ * Parse the search response: a flat list of <article class="box_offer"
+ * data-id='<32-hex>'> cards. We split on the card id attribute and parse each
+ * chunk independently so one malformed card cannot break the rest.
+ */
+export function parseJobCards(html: string, now: Date = new Date()): JobCard[] {
+  const results: JobCard[] = []
+  const chunks = html.split(/data-id='/i).slice(1)
+
+  for (const chunk of chunks) {
+    const idMatch = chunk.match(/^([0-9a-f]{32})/i)
+    if (!idMatch) continue
+    const id = idMatch[1]
+
+    // Title link: <a class="js-o-link fc_base" href="/ofertas-de-trabajo/...">Title</a>
+    const link = chunk.match(/class="js-o-link fc_base"[^>]*href="([^"]+)"/i)
+    if (!link) continue
+    const path = decodeHtmlEntities(link[1]).split("#")[0]
+    if (!path.startsWith("/ofertas-de-trabajo/")) continue
+    const titleMatch = chunk.match(
+      /class="js-o-link fc_base"[^>]*href="[^"]+"[^>]*>\s*([\s\S]*?)\s*<\/a>/i,
+    )
+    if (!titleMatch) continue
+    const title = clean(titleMatch[1])
+    if (!title) continue
+    const url = `${SEARCH_URL}${path}`
+
+    // Company: <a ... href="https://co.computrabajo.com/<company-slug>"
+    //   target='_blank' offer-grid-article-company-url>Name</a>
+    let company: string | null = null
+    let companyUrl: string | null = null
+    const compLink = chunk.match(/href="(https?:\/\/[^"]+)"[^>]*offer-grid-article-company-url/i)
+    if (compLink) {
+      companyUrl = decodeHtmlEntities(compLink[1]).split("?")[0]
+      const compText = chunk.match(/offer-grid-article-company-url[^>]*>\s*([\s\S]*?)\s*<\/a>/i)
+      if (compText) company = clean(compText[1]) || null
+    }
+
+    // Location: <p class="fs16 fc_base mt5"><span class="mr10">City, Dept.</span></p>
+    // (the rating row above it is <p class="dFlex vm_fx fs16 fc_base mt5">, which
+    // this exact-class regex deliberately does not match)
+    const loc = chunk.match(/<p class="fs16 fc_base mt5">\s*<span class="mr10">\s*([\s\S]*?)\s*<\/span>/i)
+    const location = loc ? clean(loc[1]) || null : null
+
+    // Relative date: <p class="fs13 fc_aux mt15">Hace 12 horas</p>
+    const dt = chunk.match(/<p class="fs13 fc_aux mt15">\s*([\s\S]*?)\s*<\/p>/i)
+    const date = dt ? relativeDateToISO(dt[1], now) : null
+
+    results.push({
+      id,
+      title,
+      company,
+      companyUrl,
+      location,
+      date,
+      url,
+    })
+  }
+
+  return results
+}
+
+/** Parse a single offer's detail page. */
+export function parseJobDetail(
+  html: string,
+  url: string,
+  id: string,
+  now: Date = new Date(),
+): JobDetail {
+  const title = html.match(/<h1[^>]*class="[^"]*fwB[^"]*fs24[^"]*"[^>]*>\s*([\s\S]*?)\s*<\/h1>/i)
+
+  // Company + location share one line right under the h1:
+  // <p class="fs16">AGAVAL - Medellín, Antioquia</p>  (the marketing row above
+  // the h1 carries the extra fc_aux class, so exact-class matching is safe)
+  let company: string | null = null
+  let location: string | null = null
+  const orgLoc = html.match(/<p class="fs16">\s*([\s\S]*?)\s*<\/p>/i)
+  if (orgLoc) {
+    const parts = clean(orgLoc[1]).split(" - ")
+    company = parts[0] || null
+    location = parts.slice(1).join(" - ") || null
+  }
+
+  let description: string | null = null
+  let requirements: string[] = []
+  let salary: string | null = null
+  let date: string | null = null
+
+  const block = extractDivByAttr(html, "div-link", "oferta")
+  if (block) {
+    // First tag span is the salary ("A convenir" when unpublished).
+    const tags = [...block.matchAll(/<span class="tag base mb10"[^>]*>\s*([\s\S]*?)\s*<\/span>/gi)]
+    if (tags.length > 0) salary = clean(tags[0][1]) || null
+
+    // Requirements: <p ... >Requerimientos</p><ul class="disc mbB"><li ...>
+    const reqUl = block.match(/<ul class="disc mbB">([\s\S]*?)<\/ul>/i)
+    if (reqUl) {
+      requirements = [...reqUl[1].matchAll(/<li[^>]*>\s*([\s\S]*?)\s*<\/li>/gi)]
+        .map((m) => clean(m[1]))
+        .filter((t) => t.length > 0)
+    }
+
+    // Description: the <p class="mbB"> paragraph(s) below the tag row, up to
+    // the Requerimientos heading.
+    const descStart = block.indexOf('<p class="mbB">')
+    const reqIdx = block.search(/Requerimientos/i)
+    if (descStart !== -1 && (reqIdx === -1 || descStart < reqIdx)) {
+      const endIdx = reqIdx === -1 ? block.length : reqIdx
+      const raw = block.slice(descStart, endIdx)
+      const withBreaks = raw.replace(/<\s*br\s*\/?>/gi, "\n").replace(/<\/p>/gi, "\n")
+      description =
+        decodeHtmlEntities(stripTags(withBreaks)).replace(/\n{3,}/g, "\n\n").trim() || null
+    }
+
+    // Relative date lives in the last <p class="fc_aux fs13"> that parses
+    // ("Ayer (actualizada)"); the "Palabras clave" line does not parse.
+    const auxDates = [...block.matchAll(/<p class="fc_aux fs13"[^>]*>\s*([\s\S]*?)\s*<\/p>/gi)]
+      .map((m) => relativeDateToISO(m[1], now))
+      .filter((d): d is string => d !== null)
+    if (auxDates.length > 0) date = auxDates[auxDates.length - 1]
+  }
+
+  const applyMatch = html.match(/data-href-offer-apply="([^"]+)"/i)
+  const applyUrl = applyMatch ? decodeHtmlEntities(applyMatch[1]) : null
+
+  return {
+    id,
+    title: title ? clean(title[1]) : "(untitled)",
+    company,
+    companyUrl: null,
+    location,
+    date,
+    url,
+    description,
+    requirements,
+    salary,
+    applyUrl,
+    deadline: null,
+  }
+}

--- a/.agents/skills/computrabajo-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/computrabajo-search/cli/tests/cli-flag-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test";
+import { runCLI } from "./helpers";
+
+function parsedStderr(stderr: string): { error?: string; code?: string } {
+  try {
+    return JSON.parse(stderr);
+  } catch {
+    return {};
+  }
+}
+
+describe("Computrabajo CLI flag validation (all failures short-circuit before any fetch)", () => {
+  test("missing --query exits 1 with NO_QUERY", async () => {
+    const result = await runCLI(["search"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(parsedStderr(result.stderr).code).toBe("NO_QUERY");
+  });
+
+  test("--page 2 exits 1 with UNSUPPORTED_PAGINATION", async () => {
+    const result = await runCLI(["search", "-q", "backend", "--page", "2"]);
+    expect(result.exitCode).not.toBe(0);
+    const err = parsedStderr(result.stderr);
+    expect(err.code).toBe("UNSUPPORTED_PAGINATION");
+    expect(err.error).toMatch(/robots/);
+  });
+
+  test("non-numeric --page exits 1 with BAD_ARG", async () => {
+    const result = await runCLI(["search", "-q", "backend", "--page", "abc"]);
+    expect(result.exitCode).not.toBe(0);
+    const err = parsedStderr(result.stderr);
+    expect(err.code).toBe("BAD_ARG");
+    expect(err.error).toMatch(/page/);
+  });
+
+  test("non-numeric --limit exits 1 with BAD_ARG", async () => {
+    const result = await runCLI(["search", "-q", "backend", "--limit", "xyz"]);
+    expect(result.exitCode).not.toBe(0);
+    const err = parsedStderr(result.stderr);
+    expect(err.code).toBe("BAD_ARG");
+    expect(err.error).toMatch(/limit/);
+  });
+
+  test("detail without a url exits 1 with NO_ID", async () => {
+    const result = await runCLI(["detail"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(parsedStderr(result.stderr).code).toBe("NO_ID");
+  });
+
+  test("detail with a bare id exits 1 with BAD_ID (slug required)", async () => {
+    const result = await runCLI(["detail", "E92595FF9C5126D461373E686DCF3405"]);
+    expect(result.exitCode).not.toBe(0);
+    const err = parsedStderr(result.stderr);
+    expect(err.code).toBe("BAD_ID");
+    expect(err.error).toMatch(/slug/);
+  });
+
+  test("unknown command exits 1 with BAD_CMD", async () => {
+    const result = await runCLI(["frobnicate"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(parsedStderr(result.stderr).code).toBe("BAD_CMD");
+  });
+});

--- a/.agents/skills/computrabajo-search/cli/tests/helpers.ts
+++ b/.agents/skills/computrabajo-search/cli/tests/helpers.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/computrabajo-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/computrabajo-search/cli/tests/parsing.test.ts
@@ -1,0 +1,255 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parseJobCards,
+  parseJobDetail,
+  extractDivByAttr,
+  relativeDateToISO,
+} from "../src/helpers";
+import { idFromUrl, normalizeDetailUrl } from "../src/commands/detail";
+
+// Real markup as fetched from co.computrabajo.com (2026-08): the rating row's
+// class list ("dFlex vm_fx fs16 fc_base mt5") is deliberately NOT matched by
+// the location regex (exact class "fs16 fc_base mt5").
+function cardMarkup(opts: {
+  id?: string;
+  title?: string;
+  company?: string;
+  location?: string;
+  date?: string;
+  includeCompanyLink?: boolean;
+}): string {
+  const id = opts.id ?? "E92595FF9C5126D461373E686DCF3405";
+  const company = opts.includeCompanyLink === false
+    ? ""
+    : `<a class="fc_base t_ellipsis" href="https://co.computrabajo.com/adecco-colombia-sa" target='_blank' offer-grid-article-company-url> ${opts.company ?? "Adecco Colombia S.A."} </a>`;
+  return `<article class="box_offer sel " data-id='${id}' data-blind="false" id="${id}" data-lc="ListOffers-Score4-0" data-offers-grid-offer-item-container>
+    <h2 class="fs18 fwB prB">
+      <a class="js-o-link fc_base" href="/ofertas-de-trabajo/oferta-de-trabajo-de-${opts.title?.toLowerCase().replace(/\s+/g, "-") ?? "desarrollador-backend"}-${id}#lc=ListOffers-Score4-0"> ${opts.title ?? "Desarrollador Backend ASO/APX &#x2013; Senior"} </a>
+      <div class="tags"><span class="tag postulated hide" applied-offer-tag><span class="icon i_check_circle_full mr5"></span> Postulado </span></div>
+    </h2>
+    <p class="dFlex vm_fx fs16 fc_base mt5">
+      <span class="fx_none mr10"><span class="fwB">4,6</span> <span class="star"></span></span>
+      <span class="icon i_verificada mr5"></span>
+      ${company}
+    </p>
+    <p class="fs16 fc_base mt5"><span class="mr10"> ${opts.location ?? "Bogot&#xE1;, D.C., Bogot&#xE1;, D.C."} </span></p>
+    <p class="fs13 fc_aux mt15"> ${opts.date ?? "Hace 12 horas"} </p>
+  </article>`;
+}
+
+function searchPage(...cards: string[]): string {
+  return `<!DOCTYPE html><html><body>${cards.join("\n")}</body></html>`;
+}
+
+const NOW = new Date("2026-08-17T10:00:00");
+
+describe("parseJobCards", () => {
+  test("parses a full card: id, title, url, company, location, date", () => {
+    const [card] = parseJobCards(searchPage(cardMarkup({})), NOW);
+    expect(card.id).toBe("E92595FF9C5126D461373E686DCF3405");
+    expect(card.title).toBe("Desarrollador Backend ASO/APX – Senior");
+    expect(card.url).toBe(
+      "https://co.computrabajo.com/ofertas-de-trabajo/oferta-de-trabajo-de-desarrollador-backend-E92595FF9C5126D461373E686DCF3405",
+    );
+    expect(card.company).toBe("Adecco Colombia S.A.");
+    expect(card.companyUrl).toBe("https://co.computrabajo.com/adecco-colombia-sa");
+    expect(card.location).toBe("Bogotá, D.C., Bogotá, D.C.");
+    expect(card.date).toBe("2026-08-17"); // "Hace 12 horas" -> same day
+  });
+
+  test("location regex does not grab the rating row (dFlex)", () => {
+    const [card] = parseJobCards(searchPage(cardMarkup({ location: "Medell&#xED;n, Antioquia" })), NOW);
+    expect(card.location).toBe("Medellín, Antioquia");
+  });
+
+  test("decodes the en-dash entity in the title", () => {
+    const [card] = parseJobCards(searchPage(cardMarkup({ title: "Frontend &#x2013; Junior" })), NOW);
+    expect(card.title).toBe("Frontend – Junior");
+  });
+
+  test("date null when the card has no date line", () => {
+    const [card] = parseJobCards(searchPage(cardMarkup({ date: "" })), NOW);
+    expect(card.date).toBeNull();
+  });
+
+  test("date null when the date text is not a relative date", () => {
+    const [card] = parseJobCards(searchPage(cardMarkup({ date: "Oferta destacada" })), NOW);
+    expect(card.date).toBeNull();
+  });
+
+  test("a card without a title link is skipped, the rest survive", () => {
+    const broken = `<article class="box_offer sel " data-id='AAAA0000BBBBCCCCDDDDEEEEFFFF1111'><p>no link</p></article>`;
+    const ok = cardMarkup({ id: "E92595FF9C5126D461373E686DCF3405" });
+    const cards = parseJobCards(searchPage(broken, ok), NOW);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].id).toBe("E92595FF9C5126D461373E686DCF3405");
+  });
+
+  test("company null when the card has no company link", () => {
+    const [card] = parseJobCards(
+      searchPage(cardMarkup({ includeCompanyLink: false })),
+      NOW,
+    );
+    expect(card.company).toBeNull();
+    expect(card.companyUrl).toBeNull();
+  });
+});
+
+describe("relativeDateToISO", () => {
+  test("Hoy -> today", () => {
+    expect(relativeDateToISO("Hoy", NOW)).toBe("2026-08-17");
+  });
+  test("Ayer -> yesterday", () => {
+    expect(relativeDateToISO("Ayer", NOW)).toBe("2026-08-16");
+  });
+  test("Ayer with a parenthetical note (detail pages)", () => {
+    expect(relativeDateToISO("Ayer (actualizada)", NOW)).toBe("2026-08-16");
+  });
+  test("Hace N días", () => {
+    expect(relativeDateToISO("Hace 2 días", NOW)).toBe("2026-08-15");
+  });
+  test("decodes hex entities inside the date text (live markup: `d&#xED;as`)", () => {
+    expect(relativeDateToISO("Hace 2 d&#xED;as", NOW)).toBe("2026-08-15");
+  });
+  test("Hace 1 semana", () => {
+    expect(relativeDateToISO("Hace 1 semana", NOW)).toBe("2026-08-10");
+  });
+  test("Hace 3 meses (month = 30 days)", () => {
+    expect(relativeDateToISO("Hace 3 meses", NOW)).toBe("2026-05-19");
+  });
+  test("Hace 1 año (year = 365 days)", () => {
+    expect(relativeDateToISO("Hace 1 año", NOW)).toBe("2025-08-17");
+  });
+  test("sub-day units resolve to today", () => {
+    expect(relativeDateToISO("Hace 30 minutos", NOW)).toBe("2026-08-17");
+    expect(relativeDateToISO("Hace 12 horas", NOW)).toBe("2026-08-17");
+  });
+  test("collapses irregular whitespace", () => {
+    expect(relativeDateToISO("  Hace   12  horas  ", NOW)).toBe("2026-08-17");
+  });
+  test("non-date text returns null", () => {
+    expect(relativeDateToISO("Palabras clave: analyst", NOW)).toBeNull();
+    expect(relativeDateToISO("Oferta oculta", NOW)).toBeNull();
+  });
+  test("null/empty input returns null", () => {
+    expect(relativeDateToISO(null, NOW)).toBeNull();
+    expect(relativeDateToISO("", NOW)).toBeNull();
+  });
+});
+
+function detailMarkup(opts: { withOfertaBlock?: boolean } = {}): string {
+  const oferta = opts.withOfertaBlock === false ? "" : `
+  <div class="mb40 pb40 bb1" div-link="oferta">
+    <h3 class="fwB fs18 mb20">Descripci&#xF3;n de la oferta</h3>
+    <div class="mbB">
+      <span class="tag base mb10">A convenir</span>
+      <span class="tag base mb10">Contrato a t&#xE9;rmino indefinido</span>
+      <span class="tag base mb10">Tiempo Completo</span>
+      <span class="tag base mb10">Presencial y remoto</span>
+    </div>
+    <p class="mbB">Empresa del sector Retail, solicita Analista de Desarrollador, para Crear y desarrollar nuevos programas o sistemas.</p>
+    <p class="mbB">Con experiencia de 2 a&#xF1;os como analista desarrollador.</p>
+    <p class="fwB fs18 mtB mb10">Requerimientos</p>
+    <ul class="disc mbB">
+      <li class='mb10'>Educaci&#xF3;n m&#xED;nima: Universidad / Carrera tecnol&#xF3;gica</li><li class='mb10'>2 a&#xF1;os de experiencia</li>
+    </ul>
+    <p class="fc_aux fs13 mbB mtB">Palabras clave: analyst</p>
+    <p class="fc_aux fs13">Ayer (actualizada)</p>
+    <div class="posSticky_m bottom0 bg_white pAllB_m mtB">
+      <div class="w40 dFlex tc_fx mAuto w100_m">
+        <a data-href-access="https://candidato.co.computrabajo.com/match/?oi=914951A43A87C52A61373E686DCF3405&amp;p=57&amp;idb=1" data-href-offer-apply="https://candidato.co.computrabajo.com/match/?oi=914951A43A87C52A61373E686DCF3405&amp;p=57&amp;idb=1" class="b_primary big w100 t_no_wrap" data-js-t-d> Aplicar </a>
+      </div>
+    </div>
+  </div>`;
+  return `<!DOCTYPE html><html><head>
+    <title>Empleo de Analista de Desarrollo Tecnol&#xF3;gico en AGAVAL - Medell&#xED;n</title>
+  </head><body>
+    <p class="fs16 fc_aux">Las mejores empresas para trabajar en Colombia</p>
+    <h1 class="fwB fs24 mb5 box_detail w100_m">Analista de Desarrollo Tecnol&#xF3;gico</h1>
+    <p class="fs16">AGAVAL - Medell&#xED;n, Antioquia</p>
+    ${oferta}
+  </body></html>`;
+}
+
+const DETAIL_URL =
+  "https://co.computrabajo.com/ofertas-de-trabajo/oferta-de-trabajo-de-analista-de-desarrollo-tecnologico-914951A43A87C52A61373E686DCF3405";
+
+describe("parseJobDetail", () => {
+  test("parses title, company/location split, description, requirements, dates", () => {
+    const job = parseJobDetail(detailMarkup(), DETAIL_URL, "914951a43a87c52a61373e686dcf3405", NOW);
+    expect(job.id).toBe("914951a43a87c52a61373e686dcf3405");
+    expect(job.title).toBe("Analista de Desarrollo Tecnológico");
+    expect(job.company).toBe("AGAVAL");
+    expect(job.location).toBe("Medellín, Antioquia");
+    expect(job.salary).toBe("A convenir");
+    expect(job.description).toContain("Empresa del sector Retail");
+    expect(job.description).toContain("2 años como analista desarrollador");
+    expect(job.description).not.toContain("Requerimientos");
+    expect(job.requirements).toEqual([
+      "Educación mínima: Universidad / Carrera tecnológica",
+      "2 años de experiencia",
+    ]);
+    expect(job.date).toBe("2026-08-16"); // "Ayer (actualizada)" relative to the injected NOW
+    expect(job.applyUrl).toBe(
+      "https://candidato.co.computrabajo.com/match/?oi=914951A43A87C52A61373E686DCF3405&p=57&idb=1",
+    );
+    expect(job.deadline).toBeNull();
+    expect(job.url).toBe(DETAIL_URL);
+  });
+
+  test("does not grab the fc_aux marketing row as company", () => {
+    const job = parseJobDetail(detailMarkup(), DETAIL_URL, "x", NOW);
+    expect(job.company).toBe("AGAVAL");
+    expect(job.location).toBe("Medellín, Antioquia");
+  });
+
+  test("no oferta block -> null description, empty requirements, null date", () => {
+    const job = parseJobDetail(detailMarkup({ withOfertaBlock: false }), DETAIL_URL, "x", NOW);
+    expect(job.description).toBeNull();
+    expect(job.requirements).toEqual([]);
+    expect(job.salary).toBeNull();
+    expect(job.date).toBeNull();
+    expect(job.applyUrl).toBeNull();
+  });
+});
+
+describe("extractDivByAttr", () => {
+  test("extracts content from a simple div", () => {
+    const html = '<div class="mb40" div-link="oferta">Simple text</div>';
+    expect(extractDivByAttr(html, "div-link", "oferta")).toBe("Simple text");
+  });
+
+  test("handles nested divs by tracking depth", () => {
+    const html = `<div div-link="oferta">
+      <div>Requerimientos block</div>
+      <ul><li>Skill A</li></ul>
+    </div>`;
+    expect(extractDivByAttr(html, "div-link", "oferta")).toBe(
+      '\n      <div>Requerimientos block</div>\n      <ul><li>Skill A</li></ul>\n    ',
+    );
+  });
+
+  test("returns null when attribute not found", () => {
+    expect(extractDivByAttr("<div>no attr</div>", "div-link", "oferta")).toBeNull();
+  });
+});
+
+describe("detail URL handling", () => {
+  test("normalizeDetailUrl accepts a full URL and strips #lc + query", () => {
+    expect(normalizeDetailUrl(`${DETAIL_URL}#lc=Detail&oi=1`)).toBe(DETAIL_URL);
+  });
+  test("normalizeDetailUrl accepts a relative path", () => {
+    expect(normalizeDetailUrl("/ofertas-de-trabajo/oferta-de-trabajo-de-x-E92595FF9C5126D461373E686DCF3405")).toBe(
+      "/ofertas-de-trabajo/oferta-de-trabajo-de-x-E92595FF9C5126D461373E686DCF3405",
+    );
+  });
+  test("normalizeDetailUrl rejects a bare id", () => {
+    expect(normalizeDetailUrl("E92595FF9C5126D461373E686DCF3405")).toBeNull();
+  });
+  test("idFromUrl extracts the 32-hex id (lowercased)", () => {
+    expect(idFromUrl(DETAIL_URL)).toBe("914951a43a87c52a61373e686dcf3405");
+  });
+  test("idFromUrl returns null without a 32-hex id", () => {
+    expect(idFromUrl("https://co.computrabajo.com/ofertas-de-trabajo/x")).toBeNull();
+  });
+});

--- a/.agents/skills/computrabajo-search/cli/tests/search.test.ts
+++ b/.agents/skills/computrabajo-search/cli/tests/search.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { runSearch, buildSearchUrl } from "../src/commands/search";
+
+const originalFetch = globalThis.fetch;
+const originalStdoutWrite = process.stdout.write;
+
+const CARD = `<article class="box_offer sel " data-id='E92595FF9C5126D461373E686DCF3405'>
+  <h2 class="fs18 fwB prB"><a class="js-o-link fc_base" href="/ofertas-de-trabajo/oferta-de-trabajo-de-desarrollador-backend-E92595FF9C5126D461373E686DCF3405#lc=ListOffers-Score4-0"> Desarrollador Backend </a></h2>
+  <p class="fs16 fc_base mt5"><span class="mr10"> Bogot&#xE1; </span></p>
+  <p class="fs13 fc_aux mt15"> Hace 8 horas </p>
+</article>`;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+});
+
+describe("buildSearchUrl", () => {
+  test("encodes the query into the /trabajo-de- path", () => {
+    expect(buildSearchUrl("desarrollador backend")).toBe(
+      "https://co.computrabajo.com/trabajo-de-desarrollador%20backend",
+    );
+  });
+});
+
+describe("runSearch", () => {
+  test("--limit 0 emits zero results", async () => {
+    globalThis.fetch = (async () => new Response(CARD)) as typeof fetch;
+
+    let stdout = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runSearch({ query: "desarrollador backend", page: 1, limit: 0, format: "json" });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).results).toHaveLength(0);
+  });
+
+  test("emits parsed cards and a page-1 meta", async () => {
+    globalThis.fetch = (async () => new Response(`<body>${CARD}</body>`)) as typeof fetch;
+
+    let stdout = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+
+    const code = await runSearch({ query: "desarrollador backend", page: 1, format: "json" });
+    expect(code).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.meta).toEqual({ count: 1, page: 1 });
+    expect(out.results[0].title).toBe("Desarrollador Backend");
+  });
+});

--- a/.agents/skills/computrabajo-search/cli/tsconfig.json
+++ b/.agents/skills/computrabajo-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/computrabajo-search/url-reference.md
+++ b/.agents/skills/computrabajo-search/url-reference.md
@@ -1,0 +1,60 @@
+# Computrabajo Colombia URL Reference
+
+Public, unauthenticated pages used by this skill. Colombia deployment:
+`www.computrabajo.com.co` 301-redirects to the canonical host `co.computrabajo.com`.
+
+> Personal use only — automated access is against the portal's terms; keep volume low.
+
+## Search
+
+```
+GET https://co.computrabajo.com/trabajo-de-<query>
+```
+
+`query` is the URL-encoded keyword (no other params needed). Returns HTML with one
+`<article class="box_offer ...">` per offer. Parsing anchors (verified against live
+pages, 2026-08):
+
+| Field | Anchor |
+|-------|--------|
+| id | `article data-id='<32-hex>'` (single-quoted attribute) |
+| title | `a.js-o-link.fc_base` inside `h2.fs18.fwB.prB` |
+| url | that anchor's `href` (`/ofertas-de-trabajo/...`) minus the `#lc=` fragment, prefixed with the base host |
+| company | `a[offer-grid-article-company-url]` (text + same-anchor `href`) |
+| location | `<p class="fs16 fc_base mt5"><span class="mr10">City, Dept.</span></p>` — exact class; the rating row above is `dFlex vm_fx fs16 fc_base mt5` and must NOT match |
+| date | `<p class="fs13 fc_aux mt15">Hace N horas|Ayer|Hoy</p>` — relative |
+
+## Detail
+
+```
+GET https://co.computrabajo.com/ofertas-de-trabajo/oferta-de-trabajo-de-<slug>-<32-hex-id>
+```
+
+Returns a single offer's HTML. Parsing anchors:
+
+| Field | Anchor |
+|-------|--------|
+| title | `<h1 class="fwB fs24 ...">` |
+| company + location | `<p class="fs16">AGAVAL - Medellín, Antioquia</p>` right under the h1 (split on `" - "`); the marketing row above the h1 carries `fc_aux` |
+| oferta block | `<div class="mb40 pb40 bb1" div-link="oferta">` (depth-walked) |
+| salary | first `<span class="tag base mb10">` in the block (`"A convenir"` when unpublished) |
+| description | `<p class="mbB">` paragraph(s) until the `Requerimientos` heading |
+| requirements | `<ul class="disc mbB"><li>` items |
+| date | the `<p class="fc_aux fs13">` inside the block whose text parses as relative (e.g. `"Ayer (actualizada)"`; the `Palabras clave:` line does not parse) |
+| applyUrl | `a[data-href-offer-apply]` (`candidato.co.computrabajo.com/match/?oi=...`) |
+
+No application deadline is published on offer pages — the CLI always emits `deadline: null`.
+
+## Robots.txt compliance (why page 1 only)
+
+`robots.txt` allows `/trabajo-de-*` and `/ofertas-de-trabajo/*` but disallows
+`/Ajax/*`, `/_services/*`, the filter params (`*dis=*`, `*cont=*`, `*sal=*`, ...),
+and CV/account routes. Computrabajo's real paginator is Ajax-based, so the CLI
+rejects `--page 2+` with `UNSUPPORTED_PAGINATION` instead of fake-paginating
+(`?page=2` is ignored server-side; the `-p-2` URL variant returns non-standard cards).
+
+## Notes
+
+- Entities are emitted as hex numeric refs (`&#xE9;`, `&#xED;`, `&#x2013;`) — the CLI decodes them.
+- Dates are relative text; the CLI converts to local `YYYY-MM-DD` at parse time (sub-day units → same day; `1 mes` → 30 days, `1 año` → 365 days).
+- Query pages without results return HTTP 200 with zero cards — the CLI emits an empty `results` array.


### PR DESCRIPTION
Fork-only portal skill (co.computrabajo.com, canonical host of computrabajo.com.co) mirroring the linkedin-search zero-deps pattern: search page-1 via /trabajo-de-<query>, detail via the full posting URL (slug lives in the address, so bare ids are rejected with BAD_ID). Relative dates (Hoy/Ayer/Hace N ...) normalize to YYYY-MM-DD, hex entities decode everywhere (incl. inside date text), pagination beyond page 1 exits UNSUPPORTED_PAGINATION (Ajax paginator is robots-disallowed). 40 bun tests + typecheck green; live-verified search + detail.

<!-- Heads-up before you publish: if you built this in a personalized fork
     (your profile data, your market's job portals, another AI runtime),
     note that GitHub points new PRs at the UPSTREAM repo by default.
     Those adaptations live in forks - see CONTRIBUTING.md - and get
     discovered via the pinned "Community forks & adaptations" discussion (#78).
     Check the "base repository" dropdown above before you continue. -->

## What changed and why

## Failing case / reproduction (for fixes)

## Verification
<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
     python3 tools/check_framework_version.py, bun test / bun run typecheck
     in touched CLIs, python3 -m unittest discover -s tests -->
