### PR TITLE
test(scraper): pin the /scrape Step 2 search-output contract across portal CLIs

### DIFF
--- a/tests/test_scrape_contract.py
+++ b/tests/test_scrape_contract.py
@@ -1,0 +1,78 @@
+"""Tests for the /scrape Step 2 search-output contract across portal CLIs.
+
+Mirrors the pattern of test_html_report_command.py: derive the contract from
+the spec itself and compare it against the real portal CLIs, so a drift on
+either side fails with a clean diff.
+
+Why this test exists: .claude/skills/job-scraper/SKILL.md Step 2 promises
+"Search output already includes title, company, location, date, and URL" for
+every portal CLI, and Step 4.75's degraded scan flags "company null or empty
+on every result" as a half-working parser. A CLI that quietly stops emitting
+those fields flags the portal as degraded on every /scrape run while CI stays
+green, breaks the seen_jobs.json dedupe (url_or_company_title_key), and leaves
+/rank without a posting URL. That failure class landed for real: jobnet-search
+emitted only the raw API schema and jobdanmark-search emitted companyName with
+no company/location/date keys until both were normalized.
+
+{helpers.ts, commands/search.ts} are the two files where every registered
+CLI's search output currently lives (HTML-parsing portals normalize in
+helpers.ts, API portals in commands/search.ts). detail.ts is deliberately
+excluded: the contract is about the search output /scrape consumes.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRAPER_SKILL = REPO_ROOT / ".claude" / "skills" / "job-scraper" / "SKILL.md"
+PORTAL_CLIS = sorted((REPO_ROOT / ".agents" / "skills").glob("*-search"))
+
+# Derived, never copied: a hardcoded field list drifts in lockstep with
+# nothing - if Step 2's prose drops or adds a field, the known-good portals
+# and this pin would keep agreeing forever while the contract changed.
+_CONTRACT_SENTENCE = re.compile(r"Search output already includes ([a-zA-Z0-9\s,]+)\.", re.MULTILINE)
+
+
+def derive_contract_fields() -> frozenset[str]:
+    text = SCRAPER_SKILL.read_text(encoding="utf-8")
+    match = _CONTRACT_SENTENCE.search(text)
+    if match is None:
+        raise AssertionError("Step 2 contract sentence not found in job-scraper/SKILL.md")
+    fields_text = re.sub(r"\s+and\s+", ",", match.group(1))
+    fields = {f.strip().lower() for f in fields_text.split(",") if f.strip()}
+    return frozenset(fields)
+
+
+def search_output_source(search_ts: Path) -> str:
+    helpers_ts = search_ts.parent.parent / "helpers.ts"
+    files = [search_ts, helpers_ts] if helpers_ts.exists() else [search_ts]
+    return "\n".join(f.read_text(encoding="utf-8") for f in files)
+
+
+class ScrapeSearchOutputContractTests(unittest.TestCase):
+    """Every portal CLI's search output must carry the Step 2 contract fields."""
+
+    def test_step2_contract_sentence_is_found_in_the_scraper_skill(self):
+        """Guards the anchor the field list is derived from."""
+        fields = derive_contract_fields()
+        self.assertGreaterEqual(fields, {"title", "company", "location", "date", "url"})
+
+    def test_every_portal_cli_emits_the_step2_contract_fields(self):
+        contract = derive_contract_fields()
+        failures: list[str] = []
+        for portal in PORTAL_CLIS:
+            search_ts = portal / "cli" / "src" / "commands" / "search.ts"
+            if not search_ts.exists():
+                failures.append(f"{portal.name}: no cli/src/commands/search.ts")
+                continue
+            source = search_output_source(search_ts)
+            emitted = set(re.findall(r"^\s*([a-zA-Z_][a-zA-Z0-9_]*):", source, re.MULTILINE))
+            missing = sorted(contract - emitted)
+            if missing:
+                failures.append(f"{portal.name}: missing {missing} in search output")
+        self.assertEqual([], failures, "; ".join(failures) or "no portal CLIs checked")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed and why

Invited in the #342 review ("if you have a cross-portal contract-pin test ready, I'd genuinely like to see it as its own PR - it's the piece that would stop this class of drift recurring"): a cross-portal regression net for the `/scrape` Step 2 search-output contract.

The failure class this kills: a portal CLI that quietly drops a contract field flags the portal as *degraded* on every `/scrape` run (Step 4.75's scan, "`company` null or empty on every result") while CI stays green, breaks the `seen_jobs.json` dedupe (`url_or_company_title_key`), and leaves `/rank` without a posting URL. It landed for real on three portals at once - jobnet/jobdanmark/jobbank emitted no or partial contract fields until #339/#340/#342.

## How the pin works

- **Derived, never copied**: the field list is parsed from the Step 2 sentence in `.claude/skills/job-scraper/SKILL.md` ("Search output already includes title, company, location, date, and URL") - a hardcoded list would drift in lockstep with the known-good portals and keep agreeing forever while the contract changed. Same pattern as `tests/test_html_report_command.py`.
- **Every registered portal CLI** under `.agents/skills/*-search` is checked: `{cli/src/commands/search.ts, cli/src/helpers.ts}` are the two files where search output lives (HTML-parsing portals normalize in `helpers.ts`, API portals in `commands/search.ts`); `detail.ts` is deliberately excluded - the contract is about the search output `/scrape` consumes.
- A portal with no `search.ts` at all is a failure (it cannot possibly satisfy the contract).

## Evidence

- **Fails on master** with exactly the three portals the fixes cover:

  ```
  jobbank-search: missing ['date'] in search output
  jobdanmark-search: missing ['company', 'date', 'location'] in search output
  jobnet-search: missing ['company', 'date', 'location', 'url'] in search output
  ```

- **Passes with #339/#340/#342 applied**: running the test's own derivation against the three fixed `search.ts` files (from those branches) reports no missing fields in any portal.
- **CI note, deliberate**: the `python-tests` job (`python -m unittest discover -s tests`) will stay red on this PR until #339/#340/#342 merge. That red is the point - the pin fails against the pre-fix files and only unlocks when the contract is actually restored everywhere.

## Verification

- `python tools/lint_skills.py` - OK (9 skills, 12 commands, settings.json)
- `python tools/security_guards.py` - OK
- `python tools/check_framework_version.py` - OK
- `python -m unittest discover -s tests -t .` - fails on the three portals above on master, passes with the three fixes applied
- `git diff --check` - clean

Single commit, clean descendant of `master` @ `f136b53`. No overlap with #338 (merged) or any open PR.