### PR TITLE
ci(latex-smoke): add a debian:bookworm leg compiling on apt-packaged TeX Live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,38 @@ jobs:
           fail-on-severity: high
 
   latex-smoke:
-    name: Compile example CV and cover letter
+    # Two legs. texlive/texlive:latest tracks current TeX Live (moderncv 2.5+);
+    # debian:bookworm compiles on apt-packaged TeX Live 2022 with moderncv
+    # 2.3.1 - the environment #242 hit and the one texlive:latest can never
+    # catch a regression in, because it never shipped the old class. The
+    # README's Linux setup path is apt, so both ends of the moderncv range
+    # users actually have stay compiled.
+    name: Compile example CV and cover letter (${{ matrix.leg.name }})
     runs-on: ubuntu-latest
-    container: texlive/texlive:latest
+    container: ${{ matrix.leg.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        leg:
+          - name: texlive-latest
+            container: texlive/texlive:latest
+          - name: debian-bookworm
+            container: debian:bookworm
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install apt-packaged TeX Live (bookworm leg)
+        if: matrix.leg.name == 'debian-bookworm'
+        # --no-install-recommends keeps the leg lean, so the two font packages
+        # must then be named explicitly: moderncv loads fontawesome5, which apt
+        # ships in texlive-fonts-extra (lualatex dies fatally without it), and
+        # hyperref's xetex driver probes the pzdr metrics from
+        # texlive-fonts-recommended (the cover letter fails without it).
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            texlive-luatex texlive-latex-extra texlive-xetex \
+            texlive-fonts-extra texlive-fonts-recommended \
+            poppler-utils python3
       - name: Install PDF inspection tools
         run: |
           if ! command -v pdfinfo >/dev/null || ! command -v pdftotext >/dev/null; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ per-file diff commands.
   `apply.md` Step 0 states for the posting itself, since cache notes are written from
   the same fetched web content. The verification-still-applies restatement in both
   `apply.md` and `interview.md`'s cache-check paragraphs is now pinned too.
+- **CI now compiles the LaTeX examples on Debian bookworm's apt-packaged TeX Live** (the
+  separate-PR follow-up invited in #323's review). The `latex-smoke` job ran only
+  `texlive/texlive:latest` - the environment that never had the #242 bug, so the moderncv-2.3.1
+  compile fix shipped guarded by nothing: the next edit to `cv/main_example.tex` could
+  reintroduce a `\firstnamestyle` override or a top-level `\usepackage{hyperref}` and CI would
+  stay green. The job is now a two-leg matrix, `texlive-latest` unchanged and `debian-bookworm`
+  installing TeX Live 2022 from apt (moderncv 2.3.1, verified in a real bookworm container:
+  both documents compile clean and the strict stock assertions - 2-page CV, 1-page cover
+  letter, extractable text - pass on both legs unchanged). `--no-install-recommends` keeps the
+  leg lean, which makes two font packages explicit requirements: `texlive-fonts-extra`
+  (moderncv loads fontawesome5) and `texlive-fonts-recommended` (hyperref's xetex driver
+  probes the `pzdr` metrics). **Note for repo admins:** the matrix renames the check from
+  "Compile example CV and cover letter" to two leg-suffixed names, so a branch-protection
+  rule requiring the old name needs updating once.
 
 ## [1.6.0] - 2026-08-19
 


### PR DESCRIPTION
The separate-PR follow-up invited in #323's review ("a `debian:bookworm` leg is separate-PR scope if anyone wants it").

`latex-smoke` ran only `texlive/texlive:latest` — the environment that never had the #242 bug. Apt-packaged TeX Live 2022 ships moderncv 2.3.1, whose missing name-style macros and hyperref option clash the #323 fix works around; with no CI on that end, the next edit to `cv/main_example.tex` could reintroduce either failure and stay green. This PR turns the job into a `fail-fast: false` matrix: `texlive-latest` unchanged, `debian-bookworm` installing TeX Live from apt in one leg-gated step. Every subsequent step runs unchanged on both legs — including the upstream-only strict stock assertions, which pass on 2.3.1 output too (verified below), so the old-moderncv leg gets the full check, not a weakened one.

Package set established empirically in a real bookworm container (moderncv `2022-02-21 v2.3.1`), not guessed: `--no-install-recommends` keeps the leg lean, which makes two font packages explicit requirements — `texlive-fonts-extra` (moderncv loads fontawesome5; lualatex dies fatally without it) and `texlive-fonts-recommended` (hyperref's xetex driver probes the `pzdr` metrics; the cover letter's xelatex compile fails without it). Full verification run: both documents compile clean, text layer extracts, 2-page CV / 1-page cover letter with expected content, and no `/FullScreen` page mode in the catalog (the #323 blocker stays fixed on 2.3.1, where hyperref simply omits `/PageMode` for the default).

**One admin note:** the matrix renames the check from "Compile example CV and cover letter" to two leg-suffixed names ("… (texlive-latest)" / "… (debian-bookworm)"), so a branch-protection rule requiring the old name needs a one-time update.