### PR TITLE
feat(job-scraper): add a live, filterable local dashboard for job status

### DIFF
--- a/.claude/commands/dashboard.md
+++ b/.claude/commands/dashboard.md
@@ -1,0 +1,63 @@
+# /dashboard - Start (or Reuse) the Live Job Dashboard
+
+You are getting the local job-search dashboard up and visible in the user's browser. This command wraps `job_scraper/serve_dashboard.js` - see that file and `job_scraper/dashboard_lib.js` for what the dashboard actually does (filterable/sortable table, an Apply button, status updates that write straight to `job_search_tracker.csv`). This command's only job is: make sure the server is running, then open it - it does not touch any data itself.
+
+`$ARGUMENTS` may contain a port number (e.g. `/dashboard 5000`) to use instead of the default `4321`. Otherwise proceed with `4321`.
+
+---
+
+## Step 1: Check Whether It's Already Running
+
+Never start a second server on a port that's already serving the dashboard - it fails with an address-in-use error, and if the user already has a tab open, restarting for no reason is unnecessary churn. Check first:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<port>/api/data --max-time 2
+```
+
+- **`200`** → already running. Skip Step 2, go straight to Step 3.
+- **Anything else** (connection refused, timeout, non-200) → not running. Continue to Step 2.
+
+---
+
+## Step 2: Start the Server
+
+This is a long-lived process that never exits on its own - **always start it in the background**, never in the foreground, or the command will hang for the rest of the session.
+
+```bash
+bun run job_scraper/serve_dashboard.js
+```
+
+(Prefix with `PORT=<port>` if a non-default port was requested in `$ARGUMENTS`, e.g. `PORT=5000 bun run job_scraper/serve_dashboard.js`.)
+
+**If this fails with exit code 127 ("command not found"):** `bun` is likely installed but not on this shell's `PATH`. Retry with the full path instead: `"$HOME/.bun/bin/bun" run job_scraper/serve_dashboard.js` (or the platform-appropriate install location) rather than retrying the bare `bun run ...` command a second time.
+
+Check the background output for the line `Job Search Dashboard running at http://127.0.0.1:<port>/` before proceeding, to confirm it actually started. If it failed instead (port already in use by something unrelated, a syntax error in the server code, etc.), report the real error to the user rather than silently opening a browser tab to a dead server.
+
+---
+
+## Step 3: Open the Browser
+
+```bash
+powershell -Command "Start-Process 'http://127.0.0.1:<port>/'"
+```
+
+This repo's dev environment is Windows, so `Start-Process` via PowerShell is the default opener. If run on macOS or Linux instead, use `open http://127.0.0.1:<port>/` or `xdg-open http://127.0.0.1:<port>/` respectively.
+
+**This always opens a new tab - it cannot refresh or focus an already-open one.** There is no reliable way to target a specific existing browser tab from a shell command. If Step 1 found the server already running, tell the user it's likely already open in a tab somewhere and they may prefer to switch to it and press F5 rather than opening a duplicate - but still open it if they ask, since you can't know for certain a tab is still open.
+
+---
+
+## Step 4: Confirm
+
+Tell the user:
+- Whether the server was already running or just started
+- The URL (`http://127.0.0.1:<port>/`) - worth bookmarking if they haven't
+- That it stays live only as long as this background process keeps running for the session; closing the terminal / ending the session stops it, and the next `/dashboard` call will restart it
+
+---
+
+## Important Rules
+
+1. **Never run the server in the foreground.** It has no natural exit point.
+2. **Never start a duplicate on an already-occupied port** - always check first (Step 1).
+3. **This command never modifies data.** It only starts a process and opens a URL; all reads/writes happen inside the server itself (`dashboard_lib.js`).

--- a/.claude/commands/rank.md
+++ b/.claude/commands/rank.md
@@ -92,6 +92,8 @@ Store both arrays **verbatim** as the agent returned them (1-3 bullets each) - n
 
 Do not modify `job_search_tracker.csv` - that file records applications, and `/rank` never applies. Re-running `/rank` never re-scores an already-`ranked` job unless `--all` says so, so scoring is idempotent. **Rule 6's sweep is the deliberate exception and still runs**: it re-reads stored deadlines for exactly those skipped entries and may retire one to `expired`. That is not a re-score and costs no fetch, and skipping it because the entry was "already ranked" is what would leave a closed posting on the shortlist indefinitely.
 
+A live, filterable, write-back-capable dashboard is also available - see `job_scraper/serve_dashboard.js` (`bun run job_scraper/serve_dashboard.js`, then bookmark the URL it prints, or use `/dashboard`); it reads `seen_jobs.json` fresh on every page load, so nothing needs to be run here to keep it in sync.
+
 ---
 
 ## Step 5: Present the Shortlist

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -157,6 +157,8 @@ The `source` field records which mechanism produced the entry: `cli` for Step 1b
 
 2. Only present jobs NOT already in the seen list or tracker.
 
+3. No separate export step is needed. A live, filterable, write-back-capable dashboard is also available - see `job_scraper/serve_dashboard.js` (`bun run job_scraper/serve_dashboard.js`, then bookmark the URL it prints, or use `/dashboard`); it reads `seen_jobs.json` and `job_search_tracker.csv` fresh on every page load, so nothing here needs to stay in sync with a separate file.
+
 ### Step 4.5: Generate Referral Contact Links (High & Medium Fit Only)
 
 For every job from this run with `fit` of **high** or **medium** (skip low-fit jobs),

--- a/job_scraper/dashboard_lib.js
+++ b/job_scraper/dashboard_lib.js
@@ -1,0 +1,1025 @@
+// Shared data-building, HTML shell, and tracker-write logic for the live job dashboard
+// served by serve_dashboard.js. There is no static-export mode: a bookmarked page can't
+// write to job_search_tracker.csv without a server behind it (that's the whole point of
+// the Apply / status-update buttons), so once the server exists there is no reason to
+// also maintain a stale, read-only snapshot file alongside it. GET / serves the shell
+// below unchanged; the client fetches /api/data itself, so nothing here needs to embed
+// a data snapshot into the HTML.
+
+const JSON_PATH = new URL("./seen_jobs.json", import.meta.url)
+const TRACKER_PATH = new URL("../job_search_tracker.csv", import.meta.url)
+
+export const VALID_STATUSES = [
+  "applied",
+  "interview",
+  "offer",
+  "hired",
+  "rejected",
+  "no response",
+  "offer declined",
+  "withdrawn",
+  "drafted",
+  "skipped",
+]
+
+const TRACKER_HEADER = [
+  "date",
+  "company",
+  "sector",
+  "role",
+  "role_type",
+  "channel",
+  "status",
+  "contact_person",
+  "fit_rating",
+  "notes",
+  "cv_file",
+  "cover_letter_file",
+  "source",
+]
+
+/**
+ * Minimal RFC4180-ish CSV line parser/writer — only what's needed to read and write
+ * back the tracker's own quoting (quotes doubled, fields with commas/newlines wrapped).
+ * No external dependency, matching this repo's zero-dependency tooling convention.
+ */
+function parseCsvLine(line) {
+  const fields = []
+  let cur = ""
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]
+    if (inQuotes) {
+      if (c === '"' && line[i + 1] === '"') {
+        cur += '"'
+        i++
+      } else if (c === '"') {
+        inQuotes = false
+      } else {
+        cur += c
+      }
+    } else if (c === '"') {
+      inQuotes = true
+    } else if (c === ",") {
+      fields.push(cur)
+      cur = ""
+    } else {
+      cur += c
+    }
+  }
+  fields.push(cur)
+  return fields
+}
+
+function csvEscape(value) {
+  const s = value === null || value === undefined ? "" : String(value)
+  if (/[",\n]/.test(s)) return '"' + s.replace(/"/g, '""') + '"'
+  return s
+}
+
+/**
+ * German-market postings routinely carry a gender-marker suffix - (m/w/d), (m/f/d),
+ * (w/m/d), (f/m/d), and their asterisk/slash variants - that the scraped title keeps
+ * but a tracker row written by hand or trimmed during /apply may drop (or vice versa).
+ * Stripping it before matching avoids false "Not applied" negatives on an otherwise
+ * identical role/company pair.
+ */
+function normalizeRole(role) {
+  return role
+    .replace(/[\s([]*[mwfd]\s*[/*]\s*[mwfd]\s*(?:[/*]\s*[mwfd]\s*)?\)?\s*$/i, "")
+    .trim()
+}
+
+function trackerKey(company, role) {
+  return `${(company ?? "").trim().toLowerCase()}|${normalizeRole((role ?? "").trim().toLowerCase())}`
+}
+
+/**
+ * Derives a short market label from the scraper's free-text location string, so the
+ * dashboard can group/filter by market without a hardcoded country list - whatever
+ * markets a fork's own `/scrape` queries actually cover show up on their own. Takes
+ * the last comma-separated segment ("Berlin, Germany" -> "Germany"), which is where
+ * every portal in this repo's search-queries.md convention puts the country.
+ */
+function inferMarket(locationText) {
+  if (!locationText) return null
+  const parts = locationText.split(",").map((s) => s.trim()).filter(Boolean)
+  return parts.length ? parts[parts.length - 1] : null
+}
+
+/**
+ * The dashboard's detail panel wants the full tracker row - date, fit_rating, notes,
+ * cv_file, cover_letter_file, channel, contact_person - so this returns parsed rows
+ * keyed by normalized company|role, last-match-wins (a re-application overwrites the
+ * earlier row, which is the more current state to show).
+ */
+async function readTrackerRows(trackerPath) {
+  const byKey = new Map()
+  let text
+  try {
+    text = await Bun.file(trackerPath).text()
+  } catch {
+    return byKey
+  }
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0)
+  if (lines.length < 2) return byKey
+  const header = parseCsvLine(lines[0]).map((h) => h.trim().toLowerCase())
+  const idx = Object.fromEntries(header.map((h, i) => [h, i]))
+  if (idx.company === undefined || idx.role === undefined) return byKey
+  for (const line of lines.slice(1)) {
+    const f = parseCsvLine(line)
+    const company = (f[idx.company] ?? "").trim()
+    const role = (f[idx.role] ?? "").trim()
+    if (!company || !role) continue
+    byKey.set(trackerKey(company, role), {
+      date: f[idx.date] ?? "",
+      sector: f[idx.sector] ?? "",
+      role_type: f[idx.role_type] ?? "",
+      channel: f[idx.channel] ?? "",
+      status: (f[idx.status] ?? "").trim(),
+      contact_person: f[idx.contact_person] ?? "",
+      fit_rating: f[idx.fit_rating] ?? "",
+      notes: f[idx.notes] ?? "",
+      cv_file: f[idx.cv_file] ?? "",
+      cover_letter_file: f[idx.cover_letter_file] ?? "",
+      source: f[idx.source] ?? "",
+      // Optional column some forks add via a dashboard write-back convention of their
+      // own; read it if present, but never require it - absent means simply blank here.
+      applied_at: f[idx.applied_at] ?? "",
+    })
+  }
+  return byKey
+}
+
+function findTrackerRow(entry, trackerByKey) {
+  return trackerByKey.get(trackerKey(entry.company, entry.title)) ?? null
+}
+
+/** Relative-to-site-root link for a tracker file path like "cv/main_x.tex", preferring the compiled PDF sibling since that's what a human actually wants to open. serve_dashboard.js serves GET /cv/* and /cover_letters/* directly from the project root, so "../cv/x.pdf" normalizes to "/cv/x.pdf" against the server's root - see that file's isSafeStaticPath. */
+function toDashboardLink(path) {
+  if (!path) return null
+  const pdf = path.replace(/\.tex$/i, ".pdf")
+  return `../${pdf}`
+}
+
+/**
+ * Deterministic 5-character base36 ID derived from the entry's own seen_jobs.json
+ * key (URL, or company+title composite for portals without a clean URL - see the
+ * schema note on that key format). Requires no stored state and no migration of
+ * existing entries: the same key always hashes to the same ID, so it's stable
+ * across re-scrapes and safe to use as a short human-referenceable handle in
+ * conversation ("job A3F9K") instead of quoting a full URL.
+ */
+function shortId(key) {
+  let hash = 5381
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0
+  }
+  return (hash >>> 0).toString(36).slice(0, 5).toUpperCase()
+}
+
+function buildJobs(seen, trackerByKey) {
+  return Object.entries(seen).map(([key, entry]) => {
+    const tracker = findTrackerRow(entry, trackerByKey)
+    const market = inferMarket(entry.location_text)
+    return {
+      key,
+      id: shortId(key),
+      title: entry.title ?? null,
+      company: entry.company ?? null,
+      url: entry.url ?? null,
+      first_seen: entry.first_seen ?? null,
+      status: entry.status ?? null,
+      portal: entry.portal ?? null,
+      location_text: entry.location_text ?? null,
+      market,
+      rank_score: typeof entry.rank_score === "number" ? entry.rank_score : null,
+      rank_verdict: entry.rank_verdict ?? null,
+      rank_date: entry.rank_date ?? null,
+      // Some forks' /rank writes a location_verdict field instead of the plain
+      // location key (avoids colliding with the scraper's own place field of the
+      // same name); support both so this reads correctly either way.
+      location_gate: entry.location_verdict ?? entry.location ?? null,
+      language_gate: entry.language_gate ?? null,
+      language_note: entry.language_note ?? null,
+      strengths: Array.isArray(entry.strengths) ? entry.strengths : [],
+      gaps: Array.isArray(entry.gaps) ? entry.gaps : [],
+      application: tracker
+        ? {
+            status: tracker.status || null,
+            date: tracker.date || null,
+            applied_at: tracker.applied_at || null,
+            fit_rating: tracker.fit_rating || null,
+            notes: tracker.notes || null,
+            channel: tracker.channel || null,
+            contact_person: tracker.contact_person || null,
+            cv_link: toDashboardLink(tracker.cv_file),
+            cover_letter_link: toDashboardLink(tracker.cover_letter_file),
+          }
+        : null,
+    }
+  })
+}
+
+function computeStats(jobs) {
+  const isVetoed = (j) => j.location_gate === "FAIL" || j.language_gate === "FAIL"
+  const isDuplicate = (j) => j.status === "duplicate"
+  const isShortlisted = (j) =>
+    j.rank_verdict && ["Strong Fit", "Good Fit"].includes(j.rank_verdict) && !isVetoed(j) && j.status !== "expired" && !isDuplicate(j)
+  const appStatus = (j) => (j.application?.status ?? "").toLowerCase()
+  const stageCount = (pred) => jobs.filter(pred).length
+  // Stage counts (drafted/applied/interview/offer/rejected) reflect real-world application
+  // state, which lives once per role even when the same posting was scraped under multiple
+  // URLs (a LinkedIn repost of a company's own ATS listing, for instance). Both duplicate
+  // entries join to the same tracker row via company+role matching and would otherwise both
+  // count - excluding status:"duplicate" here is what keeps "Applied" etc. from double-counting
+  // a single real submission.
+  const appStageCount = (pred) => jobs.filter((j) => pred(j) && !isDuplicate(j)).length
+
+  return {
+    total: jobs.length,
+    ranked: stageCount((j) => !!j.rank_verdict),
+    shortlisted: stageCount(isShortlisted),
+    excluded: stageCount(isVetoed),
+    duplicates: stageCount(isDuplicate),
+    drafted: appStageCount((j) => appStatus(j) === "drafted"),
+    applied: appStageCount((j) => appStatus(j) === "applied"),
+    interview: appStageCount((j) => appStatus(j).includes("interview")),
+    offer: appStageCount((j) => appStatus(j).includes("offer") || appStatus(j) === "hired"),
+    rejected: appStageCount((j) => appStatus(j).includes("reject")),
+  }
+}
+
+/** Full data payload, read fresh from disk on every call - this is what GET /api/data returns, so every page load and every post-update refresh reflects current file state with no caching or regeneration step anywhere. */
+export async function buildDashboardData() {
+  const data = JSON.parse(await Bun.file(JSON_PATH).text())
+  const trackerByKey = await readTrackerRows(TRACKER_PATH)
+  const jobs = buildJobs(data.seen ?? {}, trackerByKey)
+  const stats = computeStats(jobs)
+  const generatedAt = new Date().toISOString().replace("T", " ").slice(0, 16) + " UTC"
+  return { jobs, stats, generatedAt }
+}
+
+/**
+ * Writes an application-status update straight to job_search_tracker.csv, mirroring
+ * /outcome's Step 4 rules exactly: update status, overwrite `date` with today only when
+ * leaving "drafted" (the tracker's date column means "applied on", not "drafted on"),
+ * append a dated note rather than overwrite notes, and never restructure the CSV or
+ * touch other rows. If no row matches (a job applied to outside the /apply workflow),
+ * appends a new minimal row instead of failing - mirroring /outcome Step 1.2's "None ->
+ * add a tracker row" behavior, just without the extra clarifying questions that command
+ * asks conversationally.
+ *
+ * `trackerPath` defaults to the real tracker so callers don't need to pass it, but stays
+ * overridable so tests can point at a scratch copy instead of mutating live data.
+ */
+export async function updateTrackerStatus({ company, role, status, note, source, fit_rating }, trackerPath = TRACKER_PATH) {
+  if (!company || !role) return { ok: false, error: "company and role are required" }
+  if (!VALID_STATUSES.includes(status)) {
+    return { ok: false, error: `Unknown status "${status}". Valid: ${VALID_STATUSES.join(", ")}` }
+  }
+
+  let text = ""
+  try {
+    text = await Bun.file(trackerPath).text()
+  } catch {
+    text = TRACKER_HEADER.join(",") + "\n"
+  }
+  // Preserve whatever line ending the file already uses rather than forcing one -
+  // this tracker is normally hand-edited via the Edit tool (plain \n). Hardcoding
+  // \r\n here would silently rewrite every line's bytes (not just the changed row)
+  // on the very first write, which is surprising for a file the user may also be
+  // versioning or diffing elsewhere.
+  const eol = text.includes("\r\n") ? "\r\n" : "\n"
+  let lines = text.split(/\r?\n/).filter((l) => l.length > 0)
+  if (lines.length === 0) lines = [TRACKER_HEADER.join(",")]
+
+  const header = parseCsvLine(lines[0]).map((h) => h.trim().toLowerCase())
+  const idx = Object.fromEntries(header.map((h, i) => [h, i]))
+  if (["date", "company", "role", "status", "notes"].some((c) => idx[c] === undefined)) {
+    return { ok: false, error: "job_search_tracker.csv is missing one of the required columns (date/company/role/status/notes)" }
+  }
+
+  const targetKey = trackerKey(company, role)
+  const today = new Date().toISOString().slice(0, 10)
+  const dated = note ? `${note} (${today})` : `status -> ${status} (${today})`
+
+  let matchIndex = -1
+  for (let i = 1; i < lines.length; i++) {
+    const f = parseCsvLine(lines[i])
+    if (trackerKey(f[idx.company], f[idx.role]) === targetKey) {
+      matchIndex = i
+      break
+    }
+  }
+
+  if (matchIndex === -1) {
+    const row = header.map((col) => {
+      if (col === "date") return today
+      if (col === "company") return company
+      if (col === "role") return role
+      if (col === "status") return status
+      if (col === "channel") return "portal"
+      if (col === "notes") return dated
+      if (col === "source") return source ?? ""
+      if (col === "fit_rating") return fit_rating ?? ""
+      if (col === "applied_at") return status === "applied" ? new Date().toISOString() : ""
+      return ""
+    })
+    lines.push(row.map(csvEscape).join(","))
+    await Bun.write(trackerPath, lines.join(eol) + eol)
+    return { ok: true, created: true, message: `Added a new tracker row for ${company} and set status to "${status}".` }
+  }
+
+  const f = parseCsvLine(lines[matchIndex])
+  while (f.length < header.length) f.push("")
+  const oldStatus = (f[idx.status] ?? "").trim().toLowerCase()
+  if (oldStatus === "drafted" && status !== "drafted") f[idx.date] = today
+  // Stamp applied_at the moment status first becomes "applied" - never overwritten on
+  // subsequent status changes (interview, offer, etc.), so it always answers "when did
+  // I actually submit this?" for follow-up timing, distinct from `date` which tracks
+  // whatever the most recent status-relevant date is. Only applies when the tracker
+  // already has this optional column.
+  if (status === "applied" && oldStatus !== "applied" && idx.applied_at !== undefined && !f[idx.applied_at]) {
+    f[idx.applied_at] = new Date().toISOString()
+  }
+  f[idx.status] = status
+  const existingNotes = f[idx.notes] ?? ""
+  f[idx.notes] = existingNotes ? `${existingNotes}; ${dated}` : dated
+  lines[matchIndex] = f.map(csvEscape).join(",")
+  await Bun.write(trackerPath, lines.join(eol) + eol)
+  return { ok: true, created: false, message: `Updated ${company} to "${status}".` }
+}
+
+/** Static page shell - no data embedded, nothing varies per request. The client fetches /api/data itself on load and after every write, so this same constant is returned by GET / every time. */
+export const SHELL_HTML = String.raw`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Job Search Dashboard</title>
+<style>
+:root {
+  --bg: #f6f7fb; --panel: #ffffff; --text: #1a1f2b; --muted: #667085; --border: #e3e6ee;
+  --accent: #2f5fe0; --green: #12805c; --green-bg: #e3f7ee; --blue: #2f5fe0; --blue-bg: #e8edfc;
+  --amber: #92620a; --amber-bg: #fdf1d8; --red: #b3261e; --red-bg: #fbe7e6; --gray: #667085; --gray-bg: #eef0f4;
+  --purple: #6b3fd4; --purple-bg: #efe8fc; --teal: #0f7a72; --teal-bg: #e2f5f3;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #12141c; --panel: #1a1d29; --text: #e7e9f0; --muted: #9aa1b5; --border: #2a2e3d;
+    --accent: #7c9bff; --green: #4fd8a3; --green-bg: #113228; --blue: #7c9bff; --blue-bg: #1c2542;
+    --amber: #f0b94d; --amber-bg: #3a2c0f; --red: #ff8a80; --red-bg: #3a1a18; --gray: #9aa1b5; --gray-bg: #23273a;
+    --purple: #b79aff; --purple-bg: #2a2049; --teal: #6fe0d3; --teal-bg: #10312e;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg); color: var(--text); line-height: 1.4;
+}
+header { padding: 20px 24px 8px; }
+header h1 { margin: 0 0 4px; font-size: 22px; }
+header .meta { color: var(--green); font-size: 13px; }
+header .meta.error { color: var(--red); }
+main { padding: 0 24px 40px; max-width: 1400px; margin: 0 auto; }
+
+.stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; margin: 16px 0 20px; }
+.stat-card {
+  background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px;
+  cursor: pointer; transition: border-color .15s;
+}
+.stat-card:hover { border-color: var(--accent); }
+.stat-card.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.stat-card .num { font-size: 24px; font-weight: 700; }
+.stat-card .label { font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+.controls {
+  display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 14px;
+  background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px;
+}
+.controls input[type="search"] {
+  background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 7px;
+  padding: 7px 10px; font-size: 13px;
+}
+.controls input[type="search"] { flex: 1 1 220px; min-width: 160px; }
+.controls button {
+  background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 7px;
+  padding: 7px 12px; font-size: 13px; cursor: pointer;
+}
+.controls button:hover { border-color: var(--accent); }
+.result-count { font-size: 12px; color: var(--muted); margin-left: auto; white-space: nowrap; }
+
+.multiselect { position: relative; flex: 0 0 auto; }
+.ms-toggle {
+  background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 7px;
+  padding: 7px 10px; font-size: 13px; cursor: pointer; white-space: nowrap;
+}
+.ms-toggle:hover { border-color: var(--accent); }
+.multiselect.open .ms-toggle { border-color: var(--accent); }
+.ms-panel {
+  display: none; position: absolute; top: 100%; left: 0; margin-top: 4px; background: var(--panel);
+  border: 1px solid var(--border); border-radius: 7px; padding: 6px; min-width: 200px; max-height: 260px;
+  overflow-y: auto; z-index: 20; box-shadow: 0 4px 14px rgba(0,0,0,.25);
+}
+.multiselect.open .ms-panel { display: block; }
+.ms-option { display: flex; align-items: center; gap: 6px; padding: 5px 6px; border-radius: 5px; font-size: 13px; cursor: pointer; }
+.ms-option:hover { background: var(--bg); }
+.ms-option input { margin: 0; }
+.ms-clear { display: block; width: 100%; text-align: left; background: none; border: none; color: var(--accent); font-size: 12px; padding: 5px 6px 8px; cursor: pointer; }
+.ms-clear:hover { text-decoration: underline; }
+
+table { width: 100%; border-collapse: collapse; background: var(--panel); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+thead th {
+  text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: .03em; color: var(--muted);
+  padding: 10px 12px; border-bottom: 1px solid var(--border); cursor: pointer; user-select: none; white-space: nowrap;
+  position: sticky; top: 0; background: var(--panel);
+}
+thead th:hover { color: var(--text); }
+thead th .arrow { opacity: .5; margin-left: 3px; }
+tbody td { padding: 10px 12px; border-bottom: 1px solid var(--border); font-size: 13px; vertical-align: top; }
+tbody tr.job-row { cursor: pointer; }
+tbody tr.job-row:hover { background: var(--bg); }
+tbody tr.detail-row td { background: var(--bg); }
+.company { font-weight: 600; }
+.role { color: var(--muted); font-size: 12px; margin-top: 1px; }
+
+.badge {
+  display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; white-space: nowrap;
+}
+.badge-green { background: var(--green-bg); color: var(--green); }
+.badge-blue { background: var(--blue-bg); color: var(--blue); }
+.badge-amber { background: var(--amber-bg); color: var(--amber); }
+.badge-red { background: var(--red-bg); color: var(--red); }
+.badge-gray { background: var(--gray-bg); color: var(--gray); }
+.badge-purple { background: var(--purple-bg); color: var(--purple); }
+.badge-teal { background: var(--teal-bg); color: var(--teal); }
+
+.score { font-variant-numeric: tabular-nums; font-weight: 600; }
+.link-icon { color: var(--accent); text-decoration: none; font-size: 14px; }
+.link-icon:hover { text-decoration: underline; }
+.apply-btn {
+  background: var(--accent); color: #fff; border: none; border-radius: 6px; padding: 4px 10px;
+  font-size: 12px; font-weight: 600; cursor: pointer;
+}
+.apply-btn:hover { opacity: .88; }
+.apply-btn:disabled { opacity: .5; cursor: default; }
+
+.detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 6px 4px 14px; }
+.detail-grid h4 { margin: 0 0 6px; font-size: 12px; text-transform: uppercase; color: var(--muted); letter-spacing: .03em; }
+.detail-grid ul { margin: 0; padding-left: 18px; font-size: 13px; }
+.detail-grid ul li { margin-bottom: 3px; }
+.detail-grid .empty { color: var(--muted); font-size: 13px; font-style: italic; }
+.detail-field { font-size: 13px; margin-bottom: 4px; }
+.detail-field b { color: var(--muted); font-weight: 600; }
+.detail-grid a { color: var(--accent); }
+
+.status-form { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-top: 8px; }
+.status-form select, .status-form input[type="text"] {
+  background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: 6px;
+  padding: 5px 8px; font-size: 12px;
+}
+.status-form input[type="text"] { flex: 1 1 160px; min-width: 120px; }
+.status-form button {
+  background: var(--accent); color: #fff; border: none; border-radius: 6px; padding: 5px 10px;
+  font-size: 12px; font-weight: 600; cursor: pointer;
+}
+
+.id-code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color: var(--muted); letter-spacing: .02em; }
+
+.empty-state { text-align: center; padding: 40px; color: var(--muted); }
+footer { color: var(--muted); font-size: 12px; text-align: center; padding: 20px; }
+
+@media (max-width: 720px) {
+  .detail-grid { grid-template-columns: 1fr; }
+  thead th:nth-child(n+7), tbody td:nth-child(n+7) { display: none; }
+  thead th:nth-child(1), tbody td:nth-child(1) { display: none; }
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>Job Search Dashboard</h1>
+  <div class="meta" id="meta">Loading…</div>
+</header>
+<main>
+  <div class="stats" id="stats"></div>
+  <div class="controls">
+    <input type="search" id="search" placeholder="Search company, role, or ID...">
+    <div class="multiselect" id="filter-market"><button type="button" class="ms-toggle">Market: All</button><div class="ms-panel"></div></div>
+    <div class="multiselect" id="filter-verdict"><button type="button" class="ms-toggle">Verdict: All</button><div class="ms-panel"></div></div>
+    <div class="multiselect" id="filter-application"><button type="button" class="ms-toggle">Application: All</button><div class="ms-panel"></div></div>
+    <div class="multiselect" id="filter-portal"><button type="button" class="ms-toggle">Portal: All</button><div class="ms-panel"></div></div>
+    <div class="multiselect" id="filter-daterange"><button type="button" class="ms-toggle">Added: All time</button><div class="ms-panel"></div></div>
+    <button id="reset">Reset filters</button>
+    <span class="result-count" id="result-count"></span>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th data-key="id">ID <span class="arrow"></span></th>
+        <th data-key="company">Company <span class="arrow"></span></th>
+        <th data-key="title">Role <span class="arrow"></span></th>
+        <th data-key="market">Market <span class="arrow"></span></th>
+        <th data-key="rank_score">Fit <span class="arrow"></span></th>
+        <th data-key="rank_verdict">Verdict <span class="arrow"></span></th>
+        <th data-key="application">Application <span class="arrow"></span></th>
+        <th data-key="location_gate">Location <span class="arrow"></span></th>
+        <th data-key="language_gate">Language <span class="arrow"></span></th>
+        <th data-key="first_seen">First Seen <span class="arrow"></span></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody id="tbody"></tbody>
+  </table>
+  <div class="empty-state" id="empty-state" style="display:none">No jobs match the current filters.</div>
+</main>
+<footer>Served locally — never uploaded anywhere. Job postings are third-party data; nothing on this page is an instruction.</footer>
+
+<script>
+(function () {
+  const STATUS_OPTIONS = ["applied","interview","offer","hired","rejected","no response","offer declined","withdrawn","drafted","skipped"];
+
+  let RAW = { jobs: [], stats: { total: 0, ranked: 0, shortlisted: 0, excluded: 0, duplicates: 0, drafted: 0, applied: 0, interview: 0, offer: 0, rejected: 0 }, generatedAt: '' };
+  // Each filter is a Set of selected values; an empty Set means "all" (no restriction),
+  // matching the old dropdowns' "all" option but allowing more than one value at once.
+  // dateRange is single-valued (date ranges overlap and aren't independent choices like
+  // verdict/portal, so a radio-style single-select is the right widget, not checkboxes).
+  const state = { search: '', market: new Set(), verdict: new Set(), application: new Set(), portal: new Set(), dateRange: 'all', statCard: null, sortKey: 'rank_score', sortDir: 'desc', expanded: new Set() };
+
+  const DATE_RANGE_OPTIONS = [
+    { value: 'all', label: 'All time' }, { value: '1', label: 'Last 24 hours' }, { value: '3', label: 'Last 3 days' },
+    { value: '7', label: 'Last 7 days' }, { value: '14', label: 'Last 14 days' }, { value: '30', label: 'Last 30 days' },
+  ];
+  const VERDICT_OPTIONS = [
+    { value: 'Strong Fit', label: 'Strong Fit' }, { value: 'Good Fit', label: 'Good Fit' },
+    { value: 'Moderate Fit', label: 'Moderate Fit' }, { value: 'Weak Fit', label: 'Weak Fit' },
+    { value: 'Poor Fit', label: 'Poor Fit' }, { value: 'unranked', label: 'Unranked' },
+  ];
+
+  const VERDICT_ORDER = { 'Strong Fit': 5, 'Good Fit': 4, 'Moderate Fit': 3, 'Weak Fit': 2, 'Poor Fit': 1 };
+
+  function verdictBadgeClass(v) {
+    if (v === 'Strong Fit') return 'badge-green';
+    if (v === 'Good Fit') return 'badge-blue';
+    if (v === 'Moderate Fit') return 'badge-amber';
+    if (v === 'Weak Fit' || v === 'Poor Fit') return 'badge-red';
+    return 'badge-gray';
+  }
+  function gateBadgeClass(g) {
+    if (g === 'PASS') return 'badge-green';
+    if (g === 'FLAG') return 'badge-amber';
+    if (g === 'FAIL') return 'badge-red';
+    return 'badge-gray';
+  }
+  function appBadgeClass(status, isDup) {
+    if (isDup) return 'badge-gray';
+    const s = (status || '').toLowerCase();
+    if (!s) return 'badge-gray';
+    if (s.includes('reject')) return 'badge-red';
+    if (s.includes('offer') || s === 'hired') return 'badge-green';
+    if (s.includes('interview')) return 'badge-teal';
+    if (s === 'applied') return 'badge-purple';
+    if (s === 'drafted') return 'badge-blue';
+    return 'badge-gray';
+  }
+  // Duplicate listings (the same real-world application, scraped under a second URL - a
+  // LinkedIn repost of a company's own ATS listing, for instance) still join to the one real
+  // tracker row via company+role matching, so job.application would otherwise show the same
+  // "Applied"/"Drafted" badge on both rows. Labeling the job's own status:"duplicate" here
+  // keeps the table honest about which row is the one real application.
+  function appLabel(job) {
+    if (job.status === 'duplicate') {
+      const real = job.application && job.application.status;
+      return real ? 'Duplicate (' + real.charAt(0).toUpperCase() + real.slice(1) + ')' : 'Duplicate';
+    }
+    if (!job.application || !job.application.status) return 'Not applied';
+    const s = job.application.status;
+    return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  function el(tag, opts) {
+    const node = document.createElement(tag);
+    if (opts) {
+      if (opts.class) node.className = opts.class;
+      if (opts.text !== undefined) node.textContent = opts.text;
+      if (opts.html !== undefined) node.innerHTML = opts.html;
+      if (opts.attrs) for (const k in opts.attrs) node.setAttribute(k, opts.attrs[k]);
+    }
+    return node;
+  }
+
+  function badge(text, cls) { return '<span class="badge ' + cls + '">' + text + '</span>'; }
+
+  async function refreshData() {
+    const res = await fetch('/api/data');
+    RAW = await res.json();
+  }
+
+  async function postStatus(job, status, note) {
+    try {
+      const res = await fetch('/api/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ company: job.company, role: job.title, status, note, url: job.url, rank_score: job.rank_score }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.ok) { alert('Update failed: ' + (body.error || res.statusText)); return false; }
+      await refreshData();
+      render();
+      return true;
+    } catch (err) {
+      alert('Update failed: ' + err.message);
+      return false;
+    }
+  }
+
+  function portalOptions() {
+    return Array.from(new Set(RAW.jobs.map(j => j.portal).filter(Boolean))).sort().map(p => ({ value: p, label: p }));
+  }
+
+  // Markets aren't a fixed enum - they're whatever country names show up in the scraped
+  // location text, so this list grows/shrinks on its own as search coverage changes.
+  function marketOptions() {
+    return Array.from(new Set(RAW.jobs.map(j => j.market).filter(Boolean))).sort().map(m => ({ value: m, label: m }));
+  }
+
+  // "Not applied" is always offered even with zero matches (it's the default state for
+  // most rows); every other status is only added once it actually appears in the tracker,
+  // so the list grows on its own as the pipeline progresses (applied, interview, offer...)
+  function applicationOptions() {
+    const statuses = Array.from(new Set(RAW.jobs.map(j => j.application && j.application.status ? j.application.status.toLowerCase() : null).filter(Boolean))).sort();
+    const opts = [{ value: 'not_applied', label: 'Not applied' }, ...statuses.map(s => ({ value: s, label: s.charAt(0).toUpperCase() + s.slice(1) }))];
+    if (RAW.jobs.some(j => j.status === 'duplicate')) opts.push({ value: 'duplicate', label: 'Duplicate' });
+    return opts;
+  }
+
+  function multiSelectLabel(prefix, selected, options) {
+    if (selected.size === 0) return prefix + ': All';
+    if (selected.size === 1) {
+      const only = options.find(o => o.value === [...selected][0]);
+      return prefix + ': ' + (only ? only.label : [...selected][0]);
+    }
+    return prefix + ': ' + selected.size + ' selected';
+  }
+
+  function renderSingleSelect(containerId, prefix, options, currentValue, onSelect) {
+    const container = document.getElementById(containerId);
+    const toggle = container.querySelector('.ms-toggle');
+    const panel = container.querySelector('.ms-panel');
+    const current = options.find(o => o.value === currentValue);
+    toggle.textContent = prefix + ': ' + (current ? current.label : 'All time');
+    panel.innerHTML = '';
+    for (const opt of options) {
+      const label = el('label', { class: 'ms-option' });
+      const radio = el('input', { attrs: { type: 'radio', name: containerId + '-radio' } });
+      radio.checked = currentValue === opt.value;
+      radio.addEventListener('change', () => {
+        onSelect(opt.value);
+        container.classList.remove('open');
+        render();
+      });
+      label.appendChild(radio);
+      label.appendChild(document.createTextNode(opt.label));
+      panel.appendChild(label);
+    }
+  }
+
+  function renderMultiSelect(containerId, prefix, options, selected) {
+    const container = document.getElementById(containerId);
+    const toggle = container.querySelector('.ms-toggle');
+    const panel = container.querySelector('.ms-panel');
+    toggle.textContent = multiSelectLabel(prefix, selected, options);
+    panel.innerHTML = '';
+    const clearBtn = el('button', { class: 'ms-clear', text: 'Clear', attrs: { type: 'button' } });
+    clearBtn.addEventListener('click', (e) => { e.stopPropagation(); selected.clear(); render(); });
+    panel.appendChild(clearBtn);
+    for (const opt of options) {
+      const label = el('label', { class: 'ms-option' });
+      const cb = el('input', { attrs: { type: 'checkbox' } });
+      cb.checked = selected.has(opt.value);
+      cb.addEventListener('change', () => {
+        if (cb.checked) selected.add(opt.value); else selected.delete(opt.value);
+        render();
+      });
+      label.appendChild(cb);
+      label.appendChild(document.createTextNode(opt.label));
+      panel.appendChild(label);
+    }
+  }
+
+  function applicationFilterValue(job) {
+    if (job.status === 'duplicate') return 'duplicate';
+    return job.application && job.application.status ? job.application.status.toLowerCase() : 'not_applied';
+  }
+  function isVetoed(j) { return j.location_gate === 'FAIL' || j.language_gate === 'FAIL'; }
+  function isShortlisted(j) { return j.rank_verdict && (j.rank_verdict === 'Strong Fit' || j.rank_verdict === 'Good Fit') && !isVetoed(j) && j.status !== 'expired' && j.status !== 'duplicate'; }
+
+  function matchesFilters(job) {
+    if (state.search) {
+      const hay = ((job.company || '') + ' ' + (job.title || '') + ' ' + (job.id || '')).toLowerCase();
+      if (!hay.includes(state.search.toLowerCase())) return false;
+    }
+    if (state.market.size && !state.market.has(job.market)) return false;
+    // Expired/duplicate postings never match a verdict filter - a "Good Fit"/"Strong Fit"
+    // selection means "roles worth pursuing", and a dead listing or a duplicate of another
+    // row isn't one, regardless of what score it carries. Use the "Excluded"/"Duplicates"
+    // stat cards to see those specifically.
+    if (state.verdict.size && (!state.verdict.has(job.rank_verdict || 'unranked') || job.status === 'expired' || job.status === 'duplicate')) return false;
+    if (state.application.size && !state.application.has(applicationFilterValue(job))) return false;
+    if (state.portal.size && !state.portal.has(job.portal)) return false;
+    if (state.dateRange !== 'all') {
+      if (!job.first_seen) return false;
+      const days = Number(state.dateRange);
+      const cutoff = new Date();
+      cutoff.setHours(0, 0, 0, 0);
+      cutoff.setDate(cutoff.getDate() - days);
+      if (new Date(job.first_seen + 'T00:00:00') < cutoff) return false;
+    }
+    if (state.statCard === 'shortlisted' && !isShortlisted(job)) return false;
+    if (state.statCard === 'excluded' && !isVetoed(job)) return false;
+    if (state.statCard && ['drafted', 'applied'].includes(state.statCard) && applicationFilterValue(job) !== state.statCard) return false;
+    if (state.statCard === 'interview' && !applicationFilterValue(job).includes('interview')) return false;
+    if (state.statCard === 'offer' && !(applicationFilterValue(job).includes('offer') || applicationFilterValue(job) === 'hired')) return false;
+    if (state.statCard === 'ranked' && !job.rank_verdict) return false;
+    if (state.statCard === 'duplicate' && job.status !== 'duplicate') return false;
+    return true;
+  }
+
+  function sortValue(job, key) {
+    if (key === 'id') return job.id || '';
+    if (key === 'rank_score') return job.rank_score === null ? -1 : job.rank_score;
+    if (key === 'rank_verdict') return VERDICT_ORDER[job.rank_verdict] || 0;
+    if (key === 'company') return (job.company || '').toLowerCase();
+    if (key === 'title') return (job.title || '').toLowerCase();
+    if (key === 'market') return job.market || '';
+    if (key === 'application') return applicationFilterValue(job);
+    if (key === 'location_gate') return job.location_gate || '';
+    if (key === 'language_gate') return job.language_gate || '';
+    if (key === 'first_seen') return job.first_seen || '';
+    return '';
+  }
+
+  function sortJobs(list) {
+    const dir = state.sortDir === 'asc' ? 1 : -1;
+    return list.slice().sort((a, b) => {
+      const av = sortValue(a, state.sortKey), bv = sortValue(b, state.sortKey);
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return 0;
+    });
+  }
+
+  function renderStats() {
+    const s = RAW.stats;
+    const cards = [
+      { key: null, label: 'Total Jobs', num: s.total },
+      { key: 'ranked', label: 'Ranked', num: s.ranked },
+      { key: 'shortlisted', label: 'Shortlisted', num: s.shortlisted },
+      { key: 'drafted', label: 'Drafted', num: s.drafted },
+      { key: 'applied', label: 'Applied', num: s.applied },
+      { key: 'interview', label: 'Interview', num: s.interview },
+      { key: 'offer', label: 'Offer', num: s.offer },
+      { key: 'excluded', label: 'Excluded', num: s.excluded },
+      { key: 'duplicate', label: 'Duplicates', num: s.duplicates },
+    ];
+    const container = document.getElementById('stats');
+    container.innerHTML = '';
+    for (const c of cards) {
+      const card = el('div', { class: 'stat-card' + (state.statCard === c.key && c.key ? ' active' : '') });
+      card.appendChild(el('div', { class: 'num', text: String(c.num) }));
+      card.appendChild(el('div', { class: 'label', text: c.label }));
+      card.addEventListener('click', () => {
+        state.statCard = state.statCard === c.key ? null : c.key;
+        render();
+      });
+      container.appendChild(card);
+    }
+  }
+
+  function statusForm(job) {
+    const wrap = el('div', { class: 'status-form' });
+    const select = el('select');
+    for (const opt of STATUS_OPTIONS) {
+      const o = el('option', { text: opt.charAt(0).toUpperCase() + opt.slice(1), attrs: { value: opt } });
+      if (job.application && job.application.status && job.application.status.toLowerCase() === opt) o.selected = true;
+      select.appendChild(o);
+    }
+    const note = el('input', { attrs: { type: 'text', placeholder: 'Add a note (optional)' } });
+    const btn = el('button', { text: job.application ? 'Update status' : 'Mark applied / set status' });
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      await postStatus(job, select.value, note.value.trim() || null);
+      btn.disabled = false;
+    });
+    wrap.appendChild(select);
+    wrap.appendChild(note);
+    wrap.appendChild(btn);
+    return wrap;
+  }
+
+  function detailRow(job) {
+    const tr = el('tr', { class: 'detail-row' });
+    const td = el('td', { attrs: { colspan: '10' } });
+    const grid = el('div', { class: 'detail-grid' });
+
+    const left = el('div');
+    left.appendChild(el('h4', { text: 'Strengths' }));
+    if (job.strengths.length) {
+      const ul = el('ul');
+      job.strengths.forEach(s => ul.appendChild(el('li', { text: s })));
+      left.appendChild(ul);
+    } else left.appendChild(el('div', { class: 'empty', text: 'None recorded' }));
+    left.appendChild(el('h4', { text: 'Gaps' }));
+    if (job.gaps.length) {
+      const ul = el('ul');
+      job.gaps.forEach(s => ul.appendChild(el('li', { text: s })));
+      left.appendChild(ul);
+    } else left.appendChild(el('div', { class: 'empty', text: 'None recorded' }));
+    if (job.language_note) {
+      left.appendChild(el('h4', { text: 'Language note' }));
+      left.appendChild(el('div', { class: 'detail-field', text: job.language_note }));
+    }
+
+    const right = el('div');
+    right.appendChild(el('h4', { text: 'Details' }));
+    const fields = [
+      ['Location', job.location_text],
+      ['Portal', job.portal],
+      ['Rank date', job.rank_date],
+      ['Source', null],
+    ];
+    for (const [label, val] of fields) {
+      if (label === 'Source') {
+        if (job.url) {
+          const f = el('div', { class: 'detail-field' });
+          f.appendChild(el('b', { text: label + ': ' }));
+          const a = el('a', { text: 'Open posting', attrs: { href: job.url, target: '_blank', rel: 'noopener' } });
+          f.appendChild(a);
+          right.appendChild(f);
+        }
+        continue;
+      }
+      if (!val) continue;
+      const f = el('div', { class: 'detail-field' });
+      f.appendChild(el('b', { text: label + ': ' }));
+      f.appendChild(document.createTextNode(val));
+      right.appendChild(f);
+    }
+    right.appendChild(el('h4', { text: 'Application' }));
+    if (job.application) {
+      const a = job.application;
+      const appliedAtLabel = a.applied_at ? new Date(a.applied_at).toLocaleString() : null;
+      const appFields = [['Applied/drafted', a.date], ['Applied at', appliedAtLabel], ['Channel', a.channel], ['Contact', a.contact_person], ['Notes', a.notes]];
+      for (const [label, val] of appFields) {
+        if (!val) continue;
+        const f = el('div', { class: 'detail-field' });
+        f.appendChild(el('b', { text: label + ': ' }));
+        f.appendChild(document.createTextNode(val));
+        right.appendChild(f);
+      }
+      if (a.cv_link) {
+        const f = el('div', { class: 'detail-field' });
+        f.appendChild(el('b', { text: 'CV: ' }));
+        f.appendChild(el('a', { text: 'Open CV PDF', attrs: { href: a.cv_link, target: '_blank' } }));
+        right.appendChild(f);
+      }
+      if (a.cover_letter_link) {
+        const f = el('div', { class: 'detail-field' });
+        f.appendChild(el('b', { text: 'Cover letter: ' }));
+        f.appendChild(el('a', { text: 'Open cover letter PDF', attrs: { href: a.cover_letter_link, target: '_blank' } }));
+        right.appendChild(f);
+      }
+    } else {
+      right.appendChild(el('div', { class: 'empty', text: 'Not applied yet' }));
+    }
+    right.appendChild(statusForm(job));
+
+    grid.appendChild(left);
+    grid.appendChild(right);
+    td.appendChild(grid);
+    tr.appendChild(td);
+    return tr;
+  }
+
+  function renderTable(list) {
+    const tbody = document.getElementById('tbody');
+    tbody.innerHTML = '';
+    document.getElementById('empty-state').style.display = list.length ? 'none' : 'block';
+
+    for (const job of list) {
+      const tr = el('tr', { class: 'job-row' });
+
+      tr.appendChild(el('td', { class: 'id-code', text: job.id || '—' }));
+
+      const tdCompany = el('td');
+      tdCompany.appendChild(el('div', { class: 'company', text: job.company || '—' }));
+      tr.appendChild(tdCompany);
+
+      tr.appendChild(el('td', { text: job.title || '—' }));
+      tr.appendChild(el('td', { html: job.market ? badge(job.market, 'badge-gray') : '—' }));
+      tr.appendChild(el('td', { class: 'score', text: job.rank_score !== null ? job.rank_score.toFixed(1) : '—' }));
+      tr.appendChild(el('td', { html: job.rank_verdict ? badge(job.rank_verdict, verdictBadgeClass(job.rank_verdict)) : badge('Unranked', 'badge-gray') }));
+      tr.appendChild(el('td', { html: badge(appLabel(job), appBadgeClass(job.application ? job.application.status : null, job.status === 'duplicate')) }));
+      tr.appendChild(el('td', { html: job.location_gate ? badge(job.location_gate, gateBadgeClass(job.location_gate)) : '—' }));
+      tr.appendChild(el('td', { html: job.language_gate ? badge(job.language_gate, gateBadgeClass(job.language_gate)) : '—' }));
+      tr.appendChild(el('td', { text: job.first_seen || '—' }));
+
+      const tdActions = el('td');
+      if (!job.application) {
+        const applyBtn = el('button', { class: 'apply-btn', text: 'Apply', attrs: { title: 'Mark this job as applied' } });
+        applyBtn.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          applyBtn.disabled = true;
+          const ok = await postStatus(job, 'applied', null);
+          if (!ok) applyBtn.disabled = false;
+        });
+        tdActions.appendChild(applyBtn);
+      } else if (job.url) {
+        const a = el('a', { class: 'link-icon', text: '↗', attrs: { href: job.url, target: '_blank', rel: 'noopener', title: 'Open posting' } });
+        a.addEventListener('click', (e) => e.stopPropagation());
+        tdActions.appendChild(a);
+      }
+      tr.appendChild(tdActions);
+
+      tr.addEventListener('click', () => {
+        if (state.expanded.has(job.key)) state.expanded.delete(job.key);
+        else state.expanded.add(job.key);
+        render();
+      });
+      tbody.appendChild(tr);
+
+      if (state.expanded.has(job.key)) tbody.appendChild(detailRow(job));
+    }
+  }
+
+  function updateSortArrows() {
+    document.querySelectorAll('thead th[data-key]').forEach(th => {
+      const arrow = th.querySelector('.arrow');
+      if (th.dataset.key === state.sortKey) arrow.textContent = state.sortDir === 'asc' ? '▲' : '▼';
+      else arrow.textContent = '';
+    });
+  }
+
+  function render() {
+    const filtered = RAW.jobs.filter(matchesFilters);
+    const sorted = sortJobs(filtered);
+    renderStats();
+    renderTable(sorted);
+    updateSortArrows();
+    renderMultiSelect('filter-market', 'Market', marketOptions(), state.market);
+    renderMultiSelect('filter-verdict', 'Verdict', VERDICT_OPTIONS, state.verdict);
+    renderMultiSelect('filter-application', 'Application', applicationOptions(), state.application);
+    renderMultiSelect('filter-portal', 'Portal', portalOptions(), state.portal);
+    renderSingleSelect('filter-daterange', 'Added', DATE_RANGE_OPTIONS, state.dateRange, (v) => { state.dateRange = v; });
+    document.getElementById('result-count').textContent = 'Showing ' + sorted.length + ' of ' + RAW.jobs.length;
+    const meta = document.getElementById('meta');
+    meta.className = 'meta';
+    meta.textContent = 'Live · ' + RAW.generatedAt + ' · Apply/status updates write straight to job_search_tracker.csv';
+  }
+
+  document.getElementById('search').addEventListener('input', (e) => { state.search = e.target.value; render(); });
+  document.querySelectorAll('.multiselect .ms-toggle').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const container = btn.closest('.multiselect');
+      const wasOpen = container.classList.contains('open');
+      document.querySelectorAll('.multiselect.open').forEach(m => m.classList.remove('open'));
+      if (!wasOpen) container.classList.add('open');
+    });
+  });
+  document.querySelectorAll('.multiselect .ms-panel').forEach(panel => {
+    panel.addEventListener('click', (e) => e.stopPropagation());
+  });
+  document.addEventListener('click', () => {
+    document.querySelectorAll('.multiselect.open').forEach(m => m.classList.remove('open'));
+  });
+  document.getElementById('reset').addEventListener('click', () => {
+    state.search = ''; state.market.clear(); state.verdict.clear(); state.application.clear(); state.portal.clear(); state.dateRange = 'all'; state.statCard = null;
+    document.getElementById('search').value = '';
+    render();
+  });
+  document.querySelectorAll('thead th[data-key]').forEach(th => {
+    th.addEventListener('click', () => {
+      const key = th.dataset.key;
+      if (state.sortKey === key) state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+      else { state.sortKey = key; state.sortDir = key === 'company' || key === 'title' ? 'asc' : 'desc'; }
+      render();
+    });
+  });
+
+  (async function init() {
+    try {
+      await refreshData();
+      render();
+    } catch (err) {
+      const meta = document.getElementById('meta');
+      meta.className = 'meta error';
+      meta.textContent = 'Could not reach the dashboard server at /api/data - is "bun run job_scraper/serve_dashboard.js" still running?';
+    }
+  })();
+})();
+</script>
+</body>
+</html>
+`

--- a/job_scraper/serve_dashboard.js
+++ b/job_scraper/serve_dashboard.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env bun
+// Serves the job dashboard live over HTTP - the only way this dashboard exists. A
+// bookmarked file:// page has no way to write local files, so a server is what makes
+// the Apply / status-update controls actually work; there is no static-export mode.
+// Bookmark the URL this prints (http://127.0.0.1:<port>/ by default).
+//
+// GET / returns a fixed static shell (dashboard_lib.js's SHELL_HTML - identical bytes
+// every time, nothing to build). The client fetches GET /api/data itself on load and
+// after every write, and that endpoint rebuilds fresh from disk on every call - so
+// there is no "regenerate after /scrape or /rank" step to remember while this is
+// running, just reload the tab. POST /api/status mirrors /outcome's Step 4 rules
+// exactly: status + date-corrected-on-leaving-drafted + a dated note appended, never
+// restructuring the CSV - so anything updated here stays fully compatible with
+// /outcome if you use it later for richer outcome recording (interview stage tracking,
+// feedback capture, document archiving under documents/applications/).
+//
+// Binds to 127.0.0.1 only, deliberately never 0.0.0.0 - this endpoint writes to disk
+// on an unauthenticated request, which is fine for a single-user localhost tool and
+// not fine exposed to your LAN.
+
+import { buildDashboardData, SHELL_HTML, updateTrackerStatus, VALID_STATUSES } from "./dashboard_lib.js"
+
+const PROJECT_ROOT = new URL("../", import.meta.url)
+const PORT = Number(process.env.PORT) || 4321
+
+/** Only ever serve compiled PDFs out of these two known directories, and never anything reached via ".." - this server has no auth, so path traversal here would be a real local-file-disclosure bug, not just a correctness one. */
+function isSafeStaticPath(pathname) {
+  if (pathname.includes("..")) return false
+  return /^\/(cv|cover_letters)\//.test(pathname)
+}
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: PORT,
+  async fetch(req) {
+    const url = new URL(req.url)
+
+    if (url.pathname === "/" && req.method === "GET") {
+      // no-store: this shell embeds the client JS inline, so a browser silently serving a
+      // cached copy on plain refresh would make every future fix here look like it "didn't
+      // work" even though the server was updated - this endpoint must always be re-fetched.
+      return new Response(SHELL_HTML, { headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" } })
+    }
+
+    if (url.pathname === "/api/data" && req.method === "GET") {
+      const data = await buildDashboardData()
+      return Response.json(data, { headers: { "cache-control": "no-store" } })
+    }
+
+    if (url.pathname === "/api/status" && req.method === "POST") {
+      let body
+      try {
+        body = await req.json()
+      } catch {
+        return Response.json({ ok: false, error: "Invalid JSON body" }, { status: 400 })
+      }
+      const { company, role, status, note, url: source, rank_score } = body ?? {}
+      if (!VALID_STATUSES.includes(status)) {
+        return Response.json({ ok: false, error: `Unknown status "${status}". Valid: ${VALID_STATUSES.join(", ")}` }, { status: 400 })
+      }
+      const result = await updateTrackerStatus({ company, role, status, note, source, fit_rating: rank_score })
+      return Response.json(result, { status: result.ok ? 200 : 400 })
+    }
+
+    if (isSafeStaticPath(url.pathname) && req.method === "GET") {
+      const filePath = new URL("." + url.pathname, PROJECT_ROOT)
+      const file = Bun.file(filePath)
+      if (await file.exists()) return new Response(file)
+      return new Response("Not found", { status: 404 })
+    }
+
+    return new Response("Not found", { status: 404 })
+  },
+})
+
+console.log(`Job Search Dashboard running at http://127.0.0.1:${server.port}/`)
+console.log("Bookmark that URL for a live, writable dashboard. Ctrl+C to stop.")


### PR DESCRIPTION
## Summary

Adds `/dashboard` and a small local HTTP server (`job_scraper/serve_dashboard.js` + `dashboard_lib.js`) that reads `job_scraper/seen_jobs.json` and `job_search_tracker.csv` fresh on every request and serves a searchable, sortable, filterable table of scraped/ranked jobs - stats cards, multi-select filters (market, verdict, application status, portal), a date-added range filter, and an **Apply button** that writes a status update straight back to the tracker CSV.

- **No static-export mode.** A bookmarked `file://` page can't write to the tracker, so a live server is what makes the Apply/status controls work at all. Replaces the need for any separate CSV-export regeneration step after `/scrape` or `/rank`.
- **Status writes mirror `/outcome` Step 4's rules exactly**: never restructures the CSV, appends a dated note rather than overwriting, corrects `date` only when leaving `drafted`. So anything updated here stays fully compatible with `/outcome` if you use it later for richer recording.
- **Markets are derived dynamically** from whatever country names appear in the scraper's own location text (last comma-separated segment) - not a hardcoded country list. The filter grows/shrinks with whatever markets a given search actually covers.
- **Binds to `127.0.0.1` only** - this endpoint has no auth, so it's a single-user localhost tool, not something to expose to a LAN.
- Two small additive cross-references in `/rank` Step 4 and `job-scraper/SKILL.md` Step 4, noting the dashboard is available and needs no separate sync step.

## Design notes

- `location_verdict ?? location` and the optional `applied_at` tracker column are both read defensively (undefined/absent degrades gracefully), since not every fork's schema carries them.
- Deliberately does **not** include any market-specific alert logic (e.g. a visa-sponsorship flag) - that's a natural follow-on once `/rank` has a location-gate concept of its own, not something this PR should couple to.

## Test plan

- [x] `bun build` on both new `.js` files - no syntax errors
- [x] Module loads cleanly under `bun`
- [ ] Maintainer: `bun run job_scraper/serve_dashboard.js` against a real `seen_jobs.json`/tracker, confirm the table renders, filters/sort work, and the Apply button writes back correctly