### PR TITLE
feat(tooling): add agent token-usage analytics (/token-report)

### DIFF
--- a/.claude/commands/token-report.md
+++ b/.claude/commands/token-report.md
@@ -1,0 +1,53 @@
+# /token-report - Agent Token-Usage Trends and Improvement Suggestions
+
+You are reporting on how many tokens this project's background agent dispatches have consumed, and surfacing concrete, evidence-based suggestions for reducing cost — not a vague "consider optimizing" but specific patterns found in the actual data.
+
+---
+
+## Step 1: Sync the Log
+
+Run the extraction script to pull in any agent completions since the log was last updated:
+
+```bash
+bun run job_scraper/extract_agent_usage.js
+```
+
+This is idempotent — safe to run every time, it only appends rows for `task_id`s not already in the CSV. Report how many new rows (if any) it found before moving on.
+
+See the script's own header comment for how this actually works: Claude Code completion notifications live as `"type":"queue-operation"` transcript entries (not as a `tool_result` on the originating `Agent` tool call), each `content` field holding the full `<task-notification>` text verbatim — task-id, status, a `<summary>` line the description is extracted from, and a `<usage>` block for genuinely completed agents.
+
+## Step 2: Load the Data
+
+Read `job_scraper/agent_token_log.csv`. Columns: `date,company,role,task_type,subagent_tokens,tool_uses,duration_ms,notes,description,task_id`.
+
+- `company`/`role`/`task_type` are optional manually-curated columns; most rows (auto-extracted) leave these blank and carry everything in `description` instead. Don't treat blank company/role as missing data; read `description` for those rows.
+- Rows with no `subagent_tokens` value are dispatches that never produced a `<usage>` block — almost always `status: failed`/`killed`/`stopped` in `notes`, or a non-agent background command (dashboard server starts, curl calls, Monitor events) that this script also picks up since it scans every `queue-operation` entry, not just `/apply`-style agents. Filter those out of cost totals, but count them separately — a high failure rate is itself a finding.
+
+## Step 3: Analyze
+
+Compute and report:
+
+1. **Total tokens consumed** (sum of `subagent_tokens` across rows that have a value) and **total dispatch count**, split into completed vs. failed/killed/stopped.
+2. **Failure rate** — what fraction of dispatches never completed. If this is high, that's the headline finding, not a footnote: a failed dispatch still consumed tokens before dying (even though `subagent_tokens` is empty for it, since the harness only reports usage on clean completion) — token spent on a lost cause is the worst kind of cost.
+3. **Cost by pattern**, grouped by what the `description` text indicates the dispatch was doing (infer categories like: fresh full-pipeline run, resume/finish an existing draft, evaluation-only, batch triage, review pass, ad-hoc background command) — report average and median tokens per category. This is where the real signal lives: task *type* drives cost far more than elapsed time does.
+4. **Trend over `date`** — is average cost per completed dispatch going up, down, or flat across the session's dates? Call out any single dispatch that's a clear outlier (e.g. an order of magnitude above its category's median) and try to explain why from its `notes`/`description` if there's a clue.
+5. **Batch-size patterns** — for batch-style dispatches, does a larger batch (more items per dispatch) correlate with a higher failure rate or cost-per-item? This directly informs whether current batch sizing is well-tuned.
+
+## Step 4: Present Tangible Suggestions
+
+Every suggestion must trace to a specific number or pattern from Step 3 — no generic advice. Format:
+
+> **Finding:** <the specific number/pattern>
+> **Suggestion:** <the specific, actionable change>
+
+Cover at minimum:
+- Whether the failure rate suggests a batch-size or pacing change
+- Which task category is most expensive and whether a cheaper resume-based approach (picking up from an existing partial artifact instead of starting over) is applicable more broadly
+- Any specific outlier dispatch worth a root-cause look — an order-of-magnitude spike above its category's median is usually traceable to a specific bug or missing shortcut once you check what that one dispatch was actually doing
+
+## Step 5: Offer Next Steps
+
+Ask whether the user wants:
+- The failure-rate/cost findings folded into a memory note (if they represent a durable pattern, not a one-off)
+- Any specific outlier investigated further
+- The report saved anywhere, or just presented in the response

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ reports/
 upskill/*.md
 **/upskill/report-*.md
 
+# Agent token-usage log (personal session analytics, not repo content)
+**/job_scraper/agent_token_log.csv
+
 # Agent skills: track the source, ignore only deps and logs.
 # (A blanket `.agents/` ignore silently drops the job-search CLI skills from the repo.)
 .agents/**/node_modules/

--- a/job_scraper/extract_agent_usage.js
+++ b/job_scraper/extract_agent_usage.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+// Extracts background-agent (Task/Agent tool) token-usage stats from Claude Code's
+// own session transcript files and appends new rows to job_scraper/agent_token_log.csv.
+//
+// How this actually works (confirmed empirically, not from documentation - this
+// structure isn't publicly documented): completion notifications are NOT stored as
+// a tool_result linked to the original "Agent" tool_use call. They live as separate
+// top-level transcript entries with `"type":"queue-operation"`, whose `content` field is
+// a plain string containing the ENTIRE <task-notification> block verbatim - task-id,
+// tool-use-id, a <summary>"Agent "<description>" finished"</summary> line, and (for
+// completed agents) a <usage><subagent_tokens>...</subagent_tokens>...</usage> block.
+// Everything needed is in that one string; no cross-referencing tool_use/tool_result
+// pairs required.
+//
+// Usage: bun run job_scraper/extract_agent_usage.js
+// Safe to re-run anytime - already-logged task_ids are skipped, never duplicated.
+
+import { readdirSync, createReadStream, existsSync, appendFileSync, readFileSync } from "fs"
+import { createInterface } from "readline"
+import { homedir } from "os"
+import { join, resolve } from "path"
+
+const CSV_PATH = join(import.meta.dir, "agent_token_log.csv")
+
+function csvField(value) {
+  const s = String(value ?? "")
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+function projectSessionDir() {
+  // Claude Code encodes the absolute cwd into the session-log directory name by
+  // replacing ":" and path separators with "-" - mirrors that so this script finds the
+  // right directory for whatever repo it's run from, not hardcoded to one machine.
+  const encoded = resolve(process.cwd()).replace(/[:\\/]/g, "-")
+  return join(homedir(), ".claude", "projects", encoded)
+}
+
+function alreadyLoggedIds() {
+  const ids = new Set()
+  if (!existsSync(CSV_PATH)) return ids
+  const lines = readFileSync(CSV_PATH, "utf8").split("\n")
+  const header = lines[0]?.split(",") ?? []
+  const idCol = header.indexOf("task_id")
+  if (idCol === -1) return ids
+  for (const line of lines.slice(1)) {
+    if (!line.trim()) continue
+    const id = line.split(",").pop()?.trim()
+    if (id) ids.add(id)
+  }
+  return ids
+}
+
+function parseNotification(content) {
+  const taskId = content.match(/<task-id>(.*?)<\/task-id>/)?.[1]
+  if (!taskId) return null
+  const status = content.match(/<status>(.*?)<\/status>/)?.[1] ?? "unknown"
+  const summary = content.match(/<summary>(.*?)<\/summary>/)?.[1] ?? ""
+  // Summary is typically: Agent "<description>" finished  (or "failed: <reason>")
+  const description = summary.match(/Agent "(.*?)"/)?.[1] ?? summary
+  const usageMatch = content.match(/<subagent_tokens>(\d+)<\/subagent_tokens>[\s\S]*?<tool_uses>(\d+)<\/tool_uses>[\s\S]*?<duration_ms>(\d+)<\/duration_ms>/)
+  return {
+    taskId,
+    status,
+    description,
+    subagentTokens: usageMatch?.[1] ?? "",
+    toolUses: usageMatch?.[2] ?? "",
+    durationMs: usageMatch?.[3] ?? "",
+  }
+}
+
+async function extractFromFile(filePath, seenIds, rows) {
+  const rl = createInterface({ input: createReadStream(filePath, "utf8"), crlfDelay: Infinity })
+  for await (const line of rl) {
+    if (!line.includes("queue-operation") || !line.includes("<task-notification>")) continue
+    let entry
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (entry.type !== "queue-operation" || typeof entry.content !== "string") continue
+    const parsed = parseNotification(entry.content)
+    if (!parsed || seenIds.has(parsed.taskId)) continue
+    seenIds.add(parsed.taskId)
+    rows.push({
+      date: (entry.timestamp ?? "").slice(0, 10) || "unknown",
+      company: "",
+      role: "",
+      task_type: "",
+      subagent_tokens: parsed.subagentTokens,
+      tool_uses: parsed.toolUses,
+      duration_ms: parsed.durationMs,
+      notes: parsed.status !== "completed" ? `status: ${parsed.status}` : "",
+      description: parsed.description,
+      task_id: parsed.taskId,
+    })
+  }
+}
+
+async function main() {
+  const dir = projectSessionDir()
+  if (!existsSync(dir)) {
+    console.error(`Session directory not found: ${dir}`)
+    process.exit(1)
+  }
+  const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl")).map((f) => join(dir, f))
+  if (files.length === 0) {
+    console.log("No transcript files found - nothing to extract.")
+    return
+  }
+
+  const seenIds = alreadyLoggedIds()
+  const rows = []
+  for (const file of files) {
+    await extractFromFile(file, seenIds, rows)
+  }
+
+  if (rows.length === 0) {
+    console.log("No new agent-dispatch usage entries found (everything already logged).")
+    return
+  }
+
+  const csvLines = rows.map((r) =>
+    [r.date, r.company, r.role, r.task_type, r.subagent_tokens, r.tool_uses, r.duration_ms, r.notes, r.description, r.task_id]
+      .map(csvField)
+      .join(",")
+  )
+  appendFileSync(CSV_PATH, csvLines.join("\n") + "\n")
+  console.log(`Appended ${rows.length} new row(s) to ${CSV_PATH}`)
+  for (const r of rows) {
+    console.log(`  ${r.date} | ${r.subagent_tokens || "n/a"} tokens | ${r.tool_uses || "n/a"} tool calls | ${r.description}${r.notes ? " (" + r.notes + ")" : ""}`)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

Adds `job_scraper/extract_agent_usage.js` and `/token-report`, which together answer "how many tokens is this project's background-agent usage (`Task`/`Agent` tool dispatches from `/apply`, `/rank`, etc.) actually costing, and where should I optimize first?"

`extract_agent_usage.js` parses Claude Code's own session transcript files directly - completion notifications for background agents are **not** stored as a `tool_result` linked to the originating `Agent` `tool_use` call (this isn't publicly documented; confirmed empirically by inspecting real transcript lines). They live as separate top-level `"type":"queue-operation"` entries whose `content` field holds the full `<task-notification>` block verbatim: task-id, status, a summary line, and a `<usage>` block with `subagent_tokens`/`tool_uses`/`duration_ms` for genuinely completed agents. The script extracts all of this into `job_scraper/agent_token_log.csv`, idempotently (already-logged `task_id`s are skipped on re-run).

`/token-report` syncs the log, then analyzes:
- Total tokens and dispatch count, split completed vs. failed/killed
- **Failure rate** - a failed dispatch still burns tokens before dying, so a high failure rate is a headline cost finding, not a footnote
- **Cost by task-type pattern**, with average/median per category
- **Trend over time**, with outlier detection
- **Batch-size vs. failure-rate/cost-per-item correlation**

Every suggestion the report produces must trace to a specific number from the data - no generic "consider optimizing" advice.

The log file (`job_scraper/agent_token_log.csv`) is personal session data, not repo content - gitignored accordingly, same pattern as the existing `job_scraper` personal-data rules.

## Test plan

- [x] `bun build` on the new `.js` file - no syntax errors
- [ ] Maintainer: run `bun run job_scraper/extract_agent_usage.js` in a repo with existing Claude Code session transcripts, confirm rows land in `agent_token_log.csv`, then `/token-report` to confirm the analysis reads correctly