### PR TITLE
fix(salary_lookup): dotted A.M.B.A. suffix never stripped from company names

### DIFF
--- a/salary_lookup.py
+++ b/salary_lookup.py
@@ -35,7 +35,7 @@ SPELLING_VARIANTS = {
 # Legal suffixes and noise to strip when matching company names
 STRIP_PATTERNS = [
     r"\ba/s\b", r"\baps\b", r"\bi/s\b", r"\bp/s\b", r"\bk/s\b",
-    r"\bivs\b", r"\bamba\b", r"\ba\.m\.b\.a\.\b",
+    r"\bivs\b", r"\bamba\b", r"\ba\.m\.b\.a\.?\b",
     r"\(vg\)", r"\(.*?\)",  # (VG) and other parentheticals
     r"\bdanmark\b", r"\bdenmark\b", r"\bscandinavia\b", r"\bnordic\b",
     r"\bgroup\b", r"\bholding\b",

--- a/tests/test_salary_lookup.py
+++ b/tests/test_salary_lookup.py
@@ -102,6 +102,12 @@ class TestMatchScoreExactMatch(unittest.TestCase):
     def test_exact_match_after_suffix_stripping(self):
         self.assertEqual(match_score("Mærsk", "Mærsk A/S"), 100)
 
+    def test_exact_match_after_dotted_amba_suffix_stripping(self):
+        # "A.M.B.A." (dotted) is the same legal-suffix family as the
+        # undotted "amba" pattern above it in STRIP_PATTERNS and must
+        # strip just as cleanly.
+        self.assertEqual(match_score("Arla Foods", "Arla Foods A.M.B.A."), 100)
+
 
 class TestMatchScoreSubstring(unittest.TestCase):
     def test_query_contained_in_entry_gives_high_score(self):
@@ -331,6 +337,14 @@ class UtilityTests(unittest.TestCase):
         self.assertEqual(normalize("Ørsted (VG) Holding"), "ørsted")
         self.assertEqual(normalize("Chr. Hansen, Denmark Division"), "chrhansen")
         self.assertEqual(normalize("Simple Corp ApS"), "simplecorp")
+
+    def test_normalize_strips_dotted_amba_suffix_same_as_undotted(self):
+        # The dotted form ("A.M.B.A.") must normalize identically to the
+        # undotted form ("amba"), same as A/S vs ApS variants above.
+        self.assertEqual(
+            normalize("Arla Foods A.M.B.A."), normalize("Arla Foods amba")
+        )
+        self.assertEqual(normalize("Arla Foods A.M.B.A."), "arlafoods")
 
     def test_anglicize_replaces_danish_chars(self):
         self.assertEqual(anglicize("ørsted"), "orsted")


### PR DESCRIPTION
## Bug

`STRIP_PATTERNS` in `salary_lookup.py` includes a regex meant to strip
the Danish "A.M.B.A." legal suffix (dotted form) before fuzzy company-name
matching:

    r"\ba\.m\.b\.a\.\b"

The trailing `\.\b` never matches real input: `\b` requires a word/non-word
transition, but the character immediately before it is always the literal
`.` (non-word), and in real company names it's followed by a space or
end-of-string (also non-word). Both sides of the boundary end up non-word,
so `\b` fails - the pattern is dead code.

## Impact

The sibling undotted suffix `amba` strips cleanly; the dotted form doesn't,
so the same company normalizes two different ways depending on formatting:

    normalize("Arla Foods A.M.B.A.")  ->  'arlafoodsamba'
    normalize("Arla Foods amba")      ->  'arlafoods'

    match_score("Arla Foods", "Arla Foods A.M.B.A.")  ->  86
    match_score("Arla Foods", "Arla Foods amba")       ->  100

Reproduced on the real path: `normalize()`/`match_score()`, which is what
`search_company()` (the actual `salary_lookup.py <company>` CLI) calls.

## Fix

One-character change - make the trailing dot optional so the boundary
resolves:

    r"\ba\.m\.b\.a\.\b"  ->  r"\ba\.m\.b\.a\.?\b"

## Tests

Added two regression tests in `tests/test_salary_lookup.py` that fail on
master and pass with the fix:
- `UtilityTests.test_normalize_strips_dotted_amba_suffix_same_as_undotted`
- `TestMatchScoreExactMatch.test_exact_match_after_dotted_amba_suffix_stripping`

Verified:
- `python3 -m pytest tests/ -q` -> 310 passed (full suite, not just the touched file)
- `python3 tools/lint_skills.py` -> OK
- `python3 tools/check_framework_version.py` -> OK
