### PR TITLE
docs: add missing tools/ entries to README file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,14 @@ ai-job-search/
 ├── .github/workflows/ci.yml           # CI: LaTeX smoke compiles, skill lint, CLI typechecks
 ├── salary_lookup.py                   # Salary benchmarking tool (BYO data)
 ├── tools/
+│   ├── check_framework_version.py     # CI check: framework_version bumped when skill files change
+│   ├── check_upstream_updates.py      # Preview which personalized files an upstream update touches
 │   ├── convert_salary_excel.py        # Convert salary Excel to JSON
 │   ├── lint_skills.py                 # CI lint for skills, commands, settings.json
+│   ├── robots_check.py                # Gate the browser-header retry against robots.txt
 │   ├── security_guards.py             # CI guards: permission allowlist, gitignore rules, manifests
+│   ├── upstream_triage.py             # Sort upstream commits into worth-reviewing vs probably-skip
+│   ├── verify_pdf.py                  # Verify a compiled PDF's page count and extractable text
 │   └── README_SALARY_TOOL.md          # Salary tool setup instructions
 ├── job_scraper/                       # Scraper state (seen jobs, results)
 ├── gmail_sync/                        # /gmail-sync state (processed message IDs, last sync date)


### PR DESCRIPTION
## Summary
- The file structure tree in README.md only listed 4 of the 9 files actually in `tools/`, missing `check_framework_version.py`, `check_upstream_updates.py`, `robots_check.py`, `upstream_triage.py`, and `verify_pdf.py`.
- Two of the missing files (`check_upstream_updates.py`, `upstream_triage.py`) are referenced elsewhere in the README's "Staying up to date" section, so the doc was internally inconsistent.

## Test plan
- [x] Compared the tree listing against `ls tools/` output
- [x] Descriptions taken from each script's own docstring
- Docs-only change, no code/behavior affected