### PR TITLE
fix(freehire-search, linkedin-search): reject fractional numeric flags with BAD_ARG

### DIFF
--- a/.agents/skills/freehire-search/cli/src/cli.ts
+++ b/.agents/skills/freehire-search/cli/src/cli.ts
@@ -112,9 +112,15 @@ best-effort, no SLA. Override with FREEHIRE_API_URL to use a self-hosted backend
 `
 
 function parseIntFlag(name: string, raw: string | boolean | string[]): number | null {
-  const val = parseInt(raw as string, 10)
+  const rawStr = String(raw)
+  // Reject fractional / non-integer strings (e.g. "0.5", "2.0", "1e3") that parseInt would silently truncate.
+  if (/[.eE]/.test(rawStr)) {
+    process.stderr.write(JSON.stringify({ error: `--${name} must be an integer, got "${rawStr}"`, code: "BAD_ARG" }) + "\n")
+    return null
+  }
+  const val = parseInt(rawStr, 10)
   if (isNaN(val)) {
-    process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+    process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${rawStr}"`, code: "BAD_ARG" }) + "\n")
     return null
   }
   return val

--- a/.agents/skills/freehire-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/freehire-search/cli/tests/cli-flag-validation.test.ts
@@ -29,6 +29,35 @@ describe("freehire CLI flag validation", () => {
       const result = await runCLI(["search", "--jobage", "7", "--page", "1", "--limit", "1"]);
       expect(parsedStderr(result.stderr).code).not.toBe("BAD_ARG");
     });
+
+    for (const name of ["jobage", "page", "limit"]) {
+      test(`--${name} fractional value (0.5) exits 1 with BAD_ARG`, async () => {
+        const result = await runCLI(["search", `--${name}`, "0.5"]);
+        expect(result.exitCode).not.toBe(0);
+        const err = parsedStderr(result.stderr);
+        expect(err.code).toBe("BAD_ARG");
+        expect(err.error).toMatch(new RegExp(name));
+        expect(err.error).toMatch(/integer/);
+      });
+
+      test(`--${name} scientific notation (1e3) exits 1 with BAD_ARG`, async () => {
+        const result = await runCLI(["search", `--${name}`, "1e3"]);
+        expect(result.exitCode).not.toBe(0);
+        const err = parsedStderr(result.stderr);
+        expect(err.code).toBe("BAD_ARG");
+        expect(err.error).toMatch(new RegExp(name));
+        expect(err.error).toMatch(/integer/);
+      });
+
+      test(`--${name} decimal integer (2.0) exits 1 with BAD_ARG`, async () => {
+        const result = await runCLI(["search", `--${name}`, "2.0"]);
+        expect(result.exitCode).not.toBe(0);
+        const err = parsedStderr(result.stderr);
+        expect(err.code).toBe("BAD_ARG");
+        expect(err.error).toMatch(new RegExp(name));
+        expect(err.error).toMatch(/integer/);
+      });
+    }
   });
 
   describe("--description-format validation", () => {

--- a/.agents/skills/linkedin-search/cli/src/cli.ts
+++ b/.agents/skills/linkedin-search/cli/src/cli.ts
@@ -126,15 +126,20 @@ async function main(): Promise<number> {
     }
 
     const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
-      const val = parseInt(raw as string, 10)
+      const rawStr = String(raw)
+      // Reject fractional / non-integer strings (e.g. "0.5", "2.0", "1e3") that parseInt would silently truncate.
+      if (/[.eE]/.test(rawStr)) {
+        process.stderr.write(JSON.stringify({ error: `--${name} must be an integer, got "${rawStr}"`, code: "BAD_ARG" }) + "\n")
+        return null
+      }
+      const val = parseInt(rawStr, 10)
       if (isNaN(val)) {
-        process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+        process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${rawStr}"`, code: "BAD_ARG" }) + "\n")
         return null
       }
       return val
     }
 
-    if (flags.jobage !== undefined) {
       const v = parseIntFlag("jobage", flags.jobage)
       if (v === null) return 1
       flags.jobage = String(v)

--- a/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
@@ -12,7 +12,7 @@ function parsedStderr(stderr: string): { error?: string; code?: string } {
 }
 
 describe("LinkedIn CLI flag validation", () => {
-  describe("--jobage NaN validation", () => {
+  describe("--jobage validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--jobage", "foo"]);
       expect(result.exitCode).not.toBe(0);
@@ -33,11 +33,31 @@ describe("LinkedIn CLI flag validation", () => {
       expect(err.code).not.toBe("BAD_ARG");
     });
 
-    test("float string truncated to integer, no error", async () => {
-      // parseInt("7.5") = 7, which is valid
-      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "7.5", "--limit", "1"]);
+    test("fractional value (0.5) exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "0.5", "--limit", "1"]);
+      expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
-      expect(err.code).not.toBe("BAD_ARG");
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage/);
+      expect(err.error).toMatch(/integer/);
+    });
+
+    test("decimal integer (2.0) exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "2.0", "--limit", "1"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage/);
+      expect(err.error).toMatch(/integer/);
+    });
+
+    test("scientific notation (1e3) exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "1e3", "--limit", "1"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage/);
+      expect(err.error).toMatch(/integer/);
     });
 
     test("zero is accepted (falsy int should not be treated as missing)", async () => {
@@ -64,14 +84,16 @@ describe("LinkedIn CLI flag validation", () => {
       expect(err.error).toMatch(/jobage-minutes/);
     });
 
-    test("negative value is parsed as a missing value and exits 1 with BAD_ARG", async () => {
-      // parseFlags in cli.ts treats a next-token starting with "-" as absent
-      // (`next.startsWith("-")` → flag becomes boolean `true`), and there is no
-      // `--flag=value` syntax. So "-5" never reaches --jobage-minutes as a value;
-      // it parses as a stray flag named "5", which the unknown-flag guard now
-      // rejects before the NaN branch can. Either way the invariant holds: a
-      // negative value fails loudly with exit 1 and a JSON error, never a
-      // silent unfiltered search.
+    test("fractional value (0.5) exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "0.5"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage-minutes/);
+      expect(err.error).toMatch(/integer/);
+    });
+
+    test("negative value exits 1 with UNKNOWN_FLAG (parsed as stray flag)", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "-5"]);
       expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
@@ -90,7 +112,7 @@ describe("LinkedIn CLI flag validation", () => {
     });
   });
 
-  describe("--page NaN validation", () => {
+  describe("--page validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--page", "abc"]);
       expect(result.exitCode).not.toBe(0);
@@ -98,15 +120,33 @@ describe("LinkedIn CLI flag validation", () => {
       expect(err.code).toBe("BAD_ARG");
       expect(err.error).toMatch(/page/);
     });
+
+    test("fractional value (1.5) exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--page", "1.5"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/page/);
+      expect(err.error).toMatch(/integer/);
+    });
   });
 
-  describe("--limit NaN validation", () => {
+  describe("--limit validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--limit", "xyz"]);
       expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
       expect(err.code).toBe("BAD_ARG");
       expect(err.error).toMatch(/limit/);
+    });
+
+    test("fractional value (1.5) exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--limit", "1.5"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/limit/);
+      expect(err.error).toMatch(/integer/);
     });
   });
 


### PR DESCRIPTION
Fixes #373 and #371

## Problem
Both `freehire-search` and `linkedin-search` CLIs had a bug in their `parseIntFlag` function that only checked for `NaN` but allowed fractional values that `parseInt` silently truncates:
- `"0.5"` → `0` (which disables the freshness filter entirely)
- `"2.5"` → `2` (silently floored)
- `"1e3"` → `1` (scientific notation parsed as 1)

When truncation landed on `0`, the freshness filter was dropped from the outbound request entirely while reporting exit 0 - users got stale postings with no error.

## Solution
Updated `parseIntFlag` in both CLIs to reject strings containing `.` or `e`/`E` (decimal, float, scientific notation) with `BAD_ARG` error, matching the Danish CLIs' Zod-based `z.coerce.number().int().min(1)` validation behavior.

## Changes
- `freehire-search/cli/src/cli.ts`: Updated `parseIntFlag` function
- `freehire-search/cli/tests/cli-flag-validation.test.ts`: Added test cases for fractional values
- `linkedin-search/cli/src/cli.ts`: Updated `parseIntFlag` function  
- `linkedin-search/cli/tests/cli-flag-validation.test.ts`: Added test cases and fixed existing test that expected buggy behavior
