### PR TITLE
feat(linkedin-search): report closed postings via isActive, wire into /scrape (adopts #280)

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/commands/detail.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/detail.ts
@@ -39,6 +39,7 @@ export async function runDetail(opts: DetailOpts): Promise<number> {
         job.employmentType ? `Employment: ${job.employmentType}` : "",
         job.jobFunction ? `Function: ${job.jobFunction}` : "",
         job.industries ? `Industries: ${job.industries}` : "",
+        `Status: ${job.isActive ? "ACTIVE" : "CLOSED / EXPIRED"}`,
         "",
         job.description || "(no description)",
         "",

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -63,6 +63,7 @@ export interface JobDetail extends JobCard {
   employmentType: string | null
   jobFunction: string | null
   industries: string | null
+  isActive: boolean
 }
 
 /**
@@ -227,6 +228,16 @@ export function parseJobDetail(html: string, id: string): JobDetail {
     criteria[clean(cm[1]).toLowerCase()] = clean(cm[2])
   }
 
+  // Active Status Detection: check for "No longer accepting applications" or closed markers
+  const closedMarkers = [
+    /no longer accepting applications/i,
+    /job posting has expired/i,
+    /this job is no longer available/i,
+    /position has been filled/i,
+    /closed-job/i
+  ]
+  const isActive = !closedMarkers.some((pattern) => pattern.test(html))
+
   return {
     id,
     title: title ? clean(title) : "(untitled)",
@@ -240,6 +251,7 @@ export function parseJobDetail(html: string, id: string): JobDetail {
     employmentType: criteria["employment type"] ?? null,
     jobFunction: criteria["job function"] ?? null,
     industries: criteria["industries"] ?? null,
+    isActive,
   }
 }
 

--- a/.agents/skills/linkedin-search/cli/src/helpers.ts
+++ b/.agents/skills/linkedin-search/cli/src/helpers.ts
@@ -228,15 +228,20 @@ export function parseJobDetail(html: string, id: string): JobDetail {
     criteria[clean(cm[1]).toLowerCase()] = clean(cm[2])
   }
 
-  // Active Status Detection: check for "No longer accepting applications" or closed markers
-  const closedMarkers = [
-    /no longer accepting applications/i,
-    /job posting has expired/i,
-    /this job is no longer available/i,
-    /position has been filled/i,
-    /closed-job/i
-  ]
-  const isActive = !closedMarkers.some((pattern) => pattern.test(html))
+  // Closed-state detection, scoped to the top card. A closed posting renders
+  //   <figure class="closed-job closed-job__flavor topcard__flavor-row">
+  //     <figcaption ...>No longer accepting applications</figcaption>
+  //   </figure>
+  // there; that class and its visible text are the only markers real closed
+  // pages carry (verified against live guest pages, 2026-08-09). The search
+  // stops where the description markup begins: recruiter boilerplate quotes
+  // these phrases, and a false CLOSED talks a user out of a live job.
+  // Absence of the banner is absence of evidence, not proof the posting is
+  // open - markup drift or a consent-walled response also renders no banner -
+  // so isActive: true means only "no closed banner found".
+  const descStart = html.search(/class="(?:show-more-less-html__markup|description__text)/i)
+  const topcard = descStart === -1 ? html : html.slice(0, descStart)
+  const isActive = !/closed-job__flavor|no longer accepting applications/i.test(topcard)
 
   return {
     id,

--- a/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
@@ -86,6 +86,51 @@ describe("decodeHtmlEntities (via parseJobCards)", () => {
   });
 });
 
+describe("parseJobDetail active-status detection", () => {
+  // Captured from a real closed guest posting (2026-08-09): the banner LinkedIn
+  // actually renders inside the top card. Its class and its visible text are the
+  // only closed markers that occur in the wild.
+  const closedBanner = `
+    <figure class="closed-job closed-job__flavor topcard__flavor-row">
+      <span class="closed-job__icon closed-job__icon--error-pebble lazy-load"></span>
+      <figcaption class="closed-job__flavor--closed">No longer accepting applications</figcaption>
+    </figure>`;
+
+  const page = (topcardExtra: string, description: string) => `
+    <h1 class="topcard__title">Data Engineer</h1>
+    <span class="topcard__flavor topcard__flavor--bullet">Berlin</span>
+    ${topcardExtra}
+    <div class="show-more-less-html__markup">${description}</div>`;
+
+  test("a closed posting's top-card banner yields isActive: false", () => {
+    const job = parseJobDetail(page(closedBanner, "We build things."), "1");
+    expect(job.isActive).toBe(false);
+  });
+
+  test("an open posting yields isActive: true", () => {
+    const job = parseJobDetail(page("", "We are hiring!"), "2");
+    expect(job.isActive).toBe(true);
+  });
+
+  test("recruiter boilerplate in the description does not flag a live posting", () => {
+    // The review's false-positive case: the closed phrase appears in the
+    // *description text* of a job that is very much open.
+    const job = parseJobDetail(
+      page("", "Apply soon - once filled, this posting is no longer accepting applications."),
+      "3",
+    );
+    expect(job.isActive).toBe(true);
+  });
+
+  test("a closed-job class named in the description does not flag a live posting", () => {
+    const job = parseJobDetail(
+      page("", "Our design system documents a closed-job__flavor CSS class."),
+      "4",
+    );
+    expect(job.isActive).toBe(true);
+  });
+});
+
 describe("parseJobDetail dropped fields", () => {
   test("emits no applyUrl field", () => {
     // The extraction regex assumed class-before-href and never matched

--- a/.claude/skills/job-scraper/SKILL.md
+++ b/.claude/skills/job-scraper/SKILL.md
@@ -94,6 +94,16 @@ and URL. For jobs worth a deeper look, fetch full detail with that portal's `det
 command (see its SKILL.md — do not guess flags) to extract **key requirements**,
 **application deadline**, and a brief description snippet.
 
+**Closed-at-source detection:** `linkedin-search detail` also returns `isActive`.
+`false` means the posting page itself renders LinkedIn's "No longer accepting
+applications" banner — the job died between being indexed and being fetched (expired
+LinkedIn URLs redirect to *similar live jobs*, so a search hit can be a ghost). Mark
+such a job, never silently drop it: write its entry to `seen_jobs.json` in Step 4 with
+`"status": "expired"` and leave it out of the Step 5 presentation — an absent entry
+looks identical to a job never seen, and the recorded status is what makes a later
+ghost report self-triaging. `isActive: true` is only the absence of that banner, not
+proof the posting is open; deadlines and dead URLs remain `/rank`'s job.
+
 **From WebSearch results:** Use `WebFetch` on the posting URL and extract the same
 fields manually. If it returns HTTP 403, retry with browser headers via curl per
 `.claude/skills/job-application-assistant/09-web-research.md` before giving up — most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ per-file diff commands.
 
 ### Added
 
+- **`linkedin-search detail` reports closed postings** (#280, adopted with the original
+  author's commit preserved) - a new `isActive` field: `false` when the posting page
+  renders LinkedIn's own "No longer accepting applications" top-card banner. Detection
+  is scoped to the top card and pinned by fixture tests in both directions, including
+  the false-positive case the review required (recruiter boilerplate quoting the closed
+  phrase in a *description* must not flag a live job - on the unscoped first version it
+  did, and the new tests fail there). Only the two markers real closed pages carry are
+  matched (`closed-job__flavor` and the banner text, verified against live guest
+  pages); three speculative phrases from the first version were dropped as
+  false-positive-only risk. `/scrape` Step 2 now consumes the signal: a closed-at-source
+  job is recorded in `seen_jobs.json` as `"status": "expired"` - marked, never silently
+  dropped, per the `/rank` pattern - which is the fix for the ghost-LinkedIn-jobs class
+  in #331 (an expired LinkedIn URL redirects to a *similar live job*, so a stored hit
+  can die unnoticed between scrape and click). `isActive: true` is documented as
+  absence of the banner, not proof the posting is open.
 - **pypdf ATS text-layer fallback** - `/apply` Step 5d and `tools/verify_pdf.py` extract the CV PDF text layer with **pypdf** first (BSD, `pip install pypdf`) so Windows machines without Poppler still get a mechanical parseability check. Poppler `pdftotext -layout -enc UTF-8` remains the fallback; if both are missing the check still degrades to a visual keyword review. No extra cache or installer. `05-cv-templates.md` `framework_version` 1.4.2 → 1.4.3.
 - **CI now tests the full documented Python range** (#370) - the Python tool tests job
   runs a 3.10-3.14 version matrix instead of pinning 3.12, so both the documented 3.10


### PR DESCRIPTION
Adopts and finishes #280 per the maintainer's note there ("if we don't hear back in about a week, we'll take that as okay to adopt it" — Aug 22, no response since). @navakanth1984's original commit is preserved and credited as the first commit on this branch; the two follow-ups implement the review's four asks. Happy to hand this back if they return.

## What changed and why

**Ask 1 — fixture-pinned tests, both directions.** Four new cases in `parsing.test.ts`, built around the closed-topcard `<figure>` captured from a real expired guest posting (the Aug 9 empirical review on #280): the closed banner yields `isActive: false`, an open page yields `true`, and two false-positive cases pin that the closed phrase or class appearing in a *description* does not flag a live job. The false-positive pair **fails on the unscoped first version** (verified before fixing) — exactly the review's predicted failure.

**Ask 2 — detection scoped to the top card, speculative markers dropped.** The search now stops where the description markup begins (`show-more-less-html__markup` / `description__text`), and matches only the two markers real closed pages carry: the `closed-job__flavor` class and the "No longer accepting applications" text. The three phrases that never occur on LinkedIn's actual closed state are gone. Per the review's endorsement of the Aug 9 findings, plus the absence-of-evidence code comment: `isActive: true` means "no closed banner found", not verified-open.

**Ask 3 — the signal is wired in, mark-never-drop.** `/scrape` Step 2 (job-scraper SKILL.md) now instructs: a detail whose `isActive` is `false` is recorded in `seen_jobs.json` with `"status": "expired"` (existing vocabulary) and left out of the presentation — following the `/rank` pattern the review pointed at, so a later read of stored state can explain the exclusion. This is the fix for the #331 ghost-jobs class: an expired LinkedIn URL redirects to a *similar live job*, so closed-at-source is precisely the state worth recording.

**Ask 4 — CHANGELOG** entry under `[Unreleased]`, crediting the adoption.

Also resolved in the rebase over current master: the original diff re-added `applyUrl`, which master has since removed and pinned removed (review finding F19) — the rebase keeps only `isActive`.

## Verification

- `bun test` in `linkedin-search/cli`: 45 pass / 0 fail (25 in parsing.test.ts); `bun run typecheck` clean.
- New false-positive tests verified to fail against the unscoped detection before the fix (2 fail → 0 fail after scoping).
- Live check (2 guest requests, per the skill's personal-use procedure): a fresh Berlin posting returns `isActive: true` in `detail --format json`; the closed direction is pinned by the captured real banner.
- `python3 tools/lint_skills.py`, `check_framework_version.py`, `security_guards.py`, `unittest discover` (318 tests): all OK.

Closes #280's review asks; supersedes #280.
