### PR TITLE
fix(setup): stop fork clones from filing issues on the upstream repo by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report or improvement
+about: A defect or improvement in the framework itself — not your personal job search
+---
+
+<!-- Heads-up before you file: if you are working in a personalized fork,
+     note that the gh CLI points issue creation at this UPSTREAM repo by
+     default (`gh repo fork --clone` sets it as the default repository).
+     Personal application tracking, job evaluations, and incident logs
+     belong in YOUR fork or private repo - this tracker is public. Run
+     `gh repo set-default <your-username>/ai-job-search` in your clone to
+     keep your own automation pointed home (SETUP.md, section 2). -->
+
+## Description
+
+## Steps to Reproduce
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Impact

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Filing from a personalized fork? Read this first
+    url: https://github.com/MadsLorentzen/ai-job-search/blob/master/SETUP.md#2-fork-and-clone
+    about: >-
+      The gh CLI in a fork clone targets THIS public repo by default. Personal
+      application tracking, evaluations, and incident logs belong in your own
+      fork or private repo — run `gh repo set-default <you>/ai-job-search`
+      there to keep your automation pointed home.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ per-file diff commands.
 
 ### Fixed
 
+- **Fork clones no longer point `gh issue create` at the upstream public tracker
+  undetected** (#389) - `gh repo fork --clone`, the exact command SETUP.md's fork step
+  recommends, sets the *upstream* repo as gh's default repository, and gh uses the
+  default for creating issues and PRs - so a user's own automation ("file a tracking
+  issue per application") silently published personal job-search data on the upstream
+  repo, under the user's identity, where they cannot delete it (four live instances from
+  two users in one week). SETUP.md section 2 now adds `gh repo set-default
+  <your-username>/ai-job-search` directly to the fork commands with a warning at the
+  point of decision (the #348 pattern), and a new `.github/ISSUE_TEMPLATE/` carries the
+  same heads-up the PR template already had, for the web-UI path. Blank issues stay
+  enabled - the template warns, it does not gatekeep.
 - **`freehire-search` fractional numeric flags no longer silently change the query** (#373) -
   `parseIntFlag` used bare `parseInt`, so a fractional value was truncated instead of
   rejected: `--jobage 0.5` became `0`, failed the `jobage > 0` guard, and the

--- a/SETUP.md
+++ b/SETUP.md
@@ -158,9 +158,18 @@ If a command still uses `pdftotext -layout`, it must pass `-enc UTF-8` as well. 
 ```bash
 gh repo fork MadsLorentzen/ai-job-search --clone
 cd ai-job-search
+gh repo set-default <your-github-username>/ai-job-search
 ```
 
 Or manually: fork on GitHub, then clone your fork.
+
+> **The `set-default` line is not optional.** `gh repo fork --clone` sets the
+> **upstream** repo as gh's default repository ("The `upstream` remote will be set as
+> the default remote repository" — `gh repo fork --help`), and gh uses the default for
+> **creating issues and PRs**. Without it, any later `gh issue create` run from this
+> clone — by you or by an agent you have asked to track your applications — silently
+> files on the upstream **public** tracker, publishing whatever the issue contains
+> under your GitHub identity, on a repo where you cannot delete it (#389).
 
 > **Before you go further: forks are public.** GitHub cannot make a fork of a public
 > repository private, and `/setup` (section 6) writes your personal data into **tracked**


### PR DESCRIPTION
Fixes #389.

## What changed and why

Two users' personal job-search data landed on this public tracker this week (#381, #386–#388) because `gh repo fork --clone` — the exact command SETUP.md's fork step recommends — sets the **upstream** repo as gh's default repository, and gh uses the default for **creating issues and PRs** (both behaviors quoted verbatim from `gh --help` in #389). Any `gh issue create` run from a fork clone by the user's own automation silently files here, under their identity, where they cannot delete it.

Three small pieces, matching the direction proposed in #389:

1. **SETUP.md section 2**: `gh repo set-default <your-github-username>/ai-job-search` added directly into the fork code block, with a warning blockquote at the point of decision (the #348 pattern) saying exactly what goes wrong without it. This is the load-bearing fix — it is the only one that reaches non-interactive agents.
2. **`.github/ISSUE_TEMPLATE/bug-report.md`**: a minimal template whose leading comment mirrors the PR template's existing upstream-by-default heads-up, structured Description / Steps / Expected / Actual / Impact like this tracker's real bug reports (#371, #373).
3. **`.github/ISSUE_TEMPLATE/config.yml`**: `blank_issues_enabled: true` (this repo gets excellent freeform reports — the template warns, it does not gatekeep), plus a contact link in the chooser pointing personalized-fork users at SETUP.md section 2. If you prefer to force the template, flipping the boolean is one word.

## Verification

- `config.yml` parses as valid YAML; the template's frontmatter parses with the `name`/`about` keys GitHub requires.
- `python3 tools/lint_skills.py`, `check_framework_version.py`, `security_guards.py`, `unittest discover` (318 tests): all OK.
- CHANGELOG entry under `[Unreleased]` → `### Fixed`.

Not included, deliberately: anything touching the four live leaked issues — deleting is only possible from the maintainer side (flagged in #389).
