### PR TITLE
fix(linkedin-search): reject fractional numeric flags (#371)

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/cli.ts
+++ b/.agents/skills/linkedin-search/cli/src/cli.ts
@@ -126,9 +126,14 @@ async function main(): Promise<number> {
     }
 
     const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
-      const val = parseInt(raw as string, 10)
-      if (isNaN(val)) {
-        process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+      // Number(), not parseInt(): parseInt truncates, so "--jobage 0.5"
+      // became 0 and silently dropped f_TPR from the request (#371).
+      // Whole numbers >= 1 only, matching the other portal CLIs.
+      const val = typeof raw === "string" ? Number(raw.trim()) : NaN
+      if (!Number.isInteger(val) || val < 1) {
+        process.stderr.write(
+          JSON.stringify({ error: `--${name} must be a whole number of at least 1, got "${raw}"`, code: "BAD_ARG" }) + "\n",
+        )
         return null
       }
       return val
@@ -140,15 +145,8 @@ async function main(): Promise<number> {
       flags.jobage = String(v)
     }
     if (flags["jobage-minutes"] !== undefined) {
-      const raw = flags["jobage-minutes"]
-      const v = parseIntFlag("jobage-minutes", raw)
+      const v = parseIntFlag("jobage-minutes", flags["jobage-minutes"])
       if (v === null) return 1
-      if (v <= 0) {
-        process.stderr.write(
-          JSON.stringify({ error: `--jobage-minutes must be a positive number, got "${raw}"`, code: "BAD_ARG" }) + "\n",
-        )
-        return 1
-      }
       flags["jobage-minutes"] = String(v)
     }
     if (flags.page !== undefined) {

--- a/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
@@ -12,7 +12,7 @@ function parsedStderr(stderr: string): { error?: string; code?: string } {
 }
 
 describe("LinkedIn CLI flag validation", () => {
-  describe("--jobage NaN validation", () => {
+  describe("numeric flag validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--jobage", "foo"]);
       expect(result.exitCode).not.toBe(0);
@@ -33,31 +33,39 @@ describe("LinkedIn CLI flag validation", () => {
       expect(err.code).not.toBe("BAD_ARG");
     });
 
-    test("float string truncated to integer, no error", async () => {
-      // parseInt("7.5") = 7, which is valid
-      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "7.5", "--limit", "1"]);
-      const err = parsedStderr(result.stderr);
-      expect(err.code).not.toBe("BAD_ARG");
+    // Fractional values must be rejected, not truncated: parseInt("0.5") is 0,
+    // and jobage 0 makes buildTimeFilter return null, so f_TPR is silently
+    // omitted from the outbound request while the CLI exits 0 (#371).
+    for (const name of ["jobage", "jobage-minutes", "page", "limit"]) {
+      test(`--${name} fractional exits 1 with BAD_ARG instead of truncating`, async () => {
+        const result = await runCLI(["search", "-l", LOCATION, `--${name}`, "1.5"]);
+        expect(result.exitCode).not.toBe(0);
+        const err = parsedStderr(result.stderr);
+        expect(err.code).toBe("BAD_ARG");
+        expect(err.error).toMatch(new RegExp(name));
+      });
+    }
+
+    test("--jobage 0.5 exits 1 with BAD_ARG instead of dropping the freshness filter", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "0.5"]);
+      expect(result.exitCode).not.toBe(0);
+      expect(parsedStderr(result.stderr).code).toBe("BAD_ARG");
     });
 
-    test("zero is accepted (falsy int should not be treated as missing)", async () => {
-      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "0", "--limit", "1"]);
-      const err = parsedStderr(result.stderr);
-      expect(err.code).not.toBe("BAD_ARG");
-    });
+    for (const name of ["jobage", "jobage-minutes", "page", "limit"]) {
+      test(`--${name} 0 exits 1 with BAD_ARG`, async () => {
+        const result = await runCLI(["search", "-l", LOCATION, `--${name}`, "0"]);
+        expect(result.exitCode).not.toBe(0);
+        const err = parsedStderr(result.stderr);
+        expect(err.code).toBe("BAD_ARG");
+        expect(err.error).toMatch(new RegExp(name));
+      });
+    }
   });
 
   describe("--jobage-minutes validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "foo"]);
-      expect(result.exitCode).not.toBe(0);
-      const err = parsedStderr(result.stderr);
-      expect(err.code).toBe("BAD_ARG");
-      expect(err.error).toMatch(/jobage-minutes/);
-    });
-
-    test("zero exits 1 with BAD_ARG", async () => {
-      const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "0"]);
       expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
       expect(err.code).toBe("BAD_ARG");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ per-file diff commands.
 
 ### Fixed
 
+- **`linkedin-search` rejects fractional numeric flags instead of silently changing
+  the query** (#371) - bare `parseInt` truncated values before validation, so
+  `--jobage 0.5` became `0` and silently omitted LinkedIn's `f_TPR` freshness filter
+  while the CLI reported no argument error. `--jobage`, `--jobage-minutes`, `--page`,
+  and `--limit` now accept whole numbers >= 1 only and reject fractions and zero with
+  the stderr-JSON `BAD_ARG` contract, matching the other portal CLIs. Pinned by eight
+  cases verified to fail on the unfixed CLI. Reported by @Meet6338-X.
+
 - **`linkedin-search detail` accepts LinkedIn job URLs with trailing slashes** (#411) -
   passing a job URL with a trailing slash (e.g., `https://www.linkedin.com/jobs/view/<id>/`
   or a slugged variant with or without query strings) failed validation and exited 1 with


### PR DESCRIPTION
Fixes #371 — @Meet6338-X's find and diagnosis, credited in the CHANGELOG. The issue's PR invitation was theirs, so an honest note up front: this ships the fix four days on because a waiting fix felt worse than waiting longer, but if their PR appears I'll close this in its favour without argument.

## What changed and why

`parseIntFlag` in `linkedin-search`'s `cli.ts` validated with bare `parseInt`, which truncates before it checks: `--jobage 0.5` ("last half day") became `0`, `buildTimeFilter` returned `null` for it, and the `f_TPR` freshness filter was silently omitted from the outbound request while the CLI exited 0 — the user asked for fresh-only results and received postings of any age, with no signal anything was ignored. `--jobage 2.5` silently floored to 2 days and `--page 1.5` to page 1 the same way.

The guard now uses `Number()` + `Number.isInteger()` with a minimum of 1 for every numeric search flag (`--jobage`, `--jobage-minutes`, `--page`, `--limit`), rejecting fractions, zero, and trailing-garbage input with the standard stderr-JSON `BAD_ARG` contract. This is the same guard shape #374 landed in `freehire-search` for the sibling bug, so the two hand-rolled CLIs now match each other and the Danish CLIs' `z.coerce.number().int().min(1)` contract.

On the review note in #371 about the minutes-based sub-day variant: `--jobage-minutes` **is** the sub-day path, and it takes integer minutes — so whole-numbers-≥1 is its natural contract too, and sub-day freshness needs no fractional `--jobage`. Its previously separate `<= 0` check is now folded into the shared guard (one fewer duplicate of the same rule); its zero-rejection behavior is unchanged.

Two deliberate behavior changes beyond the truncation fix, stated plainly:
- `--jobage 0` was previously **accepted** and acted as an undocumented "no filter" alias (a test pinned that). It is now rejected, matching #374's decision for freehire and the `min(1)` contract — silence was the bug's whole failure mode, and a flag that quietly disables itself is the same class.
- The old test `"float string truncated to integer, no error"` pinned the buggy truncation as correct; it is replaced by the fractional-rejection cases.

## Failing case / reproduction (for fixes)

From #371's repro (maintainer-reproduced on the live CLI): `--jobage 0.5` → exit 0, `f_TPR` absent from the outbound URL; `--jobage 2.5` → `f_TPR=r172800` (silently floored). On this branch: both exit 1 with `{"error":"--jobage must be a whole number of at least 1, got \"0.5\"","code":"BAD_ARG"}` before any request is made; `--jobage 1` still sends `f_TPR=r86400`.

Eight new/changed cases in `cli-flag-validation.test.ts` pin it (fractional × 4 flags, the truncate-to-zero `--jobage 0.5` case, zero × `--jobage`/`--page`/`--limit`). Verified by swapping master's `cli.ts` under the new tests: exactly those 8 fail, and `--jobage-minutes 0` keeps passing because the old dedicated guard already rejected it — the count is honest.

## Verification

- `bun test` in `linkedin-search/cli`: 51 pass / 0 fail; `bun run typecheck` clean.
- Fail-on-unfixed check as above: 8/8 new cases fail against master's `cli.ts`, all pass with the fix.
- `python3 tools/lint_skills.py`, `python3 tools/security_guards.py`, `python3 -m unittest discover -s tests` (318 tests): all OK.
- CHANGELOG entry under `[Unreleased]` → `### Fixed`, crediting the reporter.
