### PR TITLE
security: narrow Bash(bun run:*) to the six shipped portal CLIs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,12 @@
   "permissions": {
     "allow": [
       "Skill(job-application-assistant)",
-      "Bash(bun run:*)",
+      "Bash(bun run .agents/skills/jobbank-search/cli/src/cli.ts:*)",
+      "Bash(bun run .agents/skills/jobdanmark-search/cli/src/cli.ts:*)",
+      "Bash(bun run .agents/skills/jobindex-search/cli/src/cli.ts:*)",
+      "Bash(bun run .agents/skills/jobnet-search/cli/src/cli.ts:*)",
+      "Bash(bun run .agents/skills/linkedin-search/cli/src/cli.ts:*)",
+      "Bash(bun run .agents/skills/freehire-search/cli/src/cli.ts:*)",
       "Bash(python salary_lookup.py:*)",
       "Bash(python3 salary_lookup.py:*)",
       "Bash(python tools/verify_pdf.py:*)",

--- a/tools/security_guards.py
+++ b/tools/security_guards.py
@@ -38,7 +38,17 @@ errors: list[str] = []
 # an entry must add it here too - that is the point: the diff shows both.
 ALLOWED_PERMISSIONS = {
     "Skill(job-application-assistant)",
-    "Bash(bun run:*)",
+    # Narrowed from the upstream template's blanket Bash(bun run:*), which
+    # pre-approved `bun run <any file>`. One entry per shipped portal CLI,
+    # matching what each SKILL.md already declares in its allowed-tools.
+    # A portal added by /add-portal needs its own entry here and in
+    # .claude/settings.json - that review step is the point.
+    "Bash(bun run .agents/skills/jobbank-search/cli/src/cli.ts:*)",
+    "Bash(bun run .agents/skills/jobdanmark-search/cli/src/cli.ts:*)",
+    "Bash(bun run .agents/skills/jobindex-search/cli/src/cli.ts:*)",
+    "Bash(bun run .agents/skills/jobnet-search/cli/src/cli.ts:*)",
+    "Bash(bun run .agents/skills/linkedin-search/cli/src/cli.ts:*)",
+    "Bash(bun run .agents/skills/freehire-search/cli/src/cli.ts:*)",
     "Bash(python salary_lookup.py:*)",
     "Bash(python3 salary_lookup.py:*)",
     "Bash(python tools/verify_pdf.py:*)",


### PR DESCRIPTION
The upstream template pre-approves `Bash(bun run:*)`, which auto-approves `bun run <any file>` — arbitrary TypeScript from anywhere on disk — on every fork. Each portal SKILL.md already declares the tight form in its own allowed-tools; this makes settings.json agree with them.

Blast radius drops from "any file on the machine" to the repo's own CLIs, with no new prompts in the /scrape path. tools/security_guards.py's ALLOWED_PERMISSIONS is updated in the same commit, as its docstring requires.

Local: security_guards OK, lint_skills OK, 318 tests pass.

Claude-Session: https://claude.ai/code/session_01HHqEAQqGS2KKXASiYcrAHQ

<!-- Heads-up before you publish: if you built this in a personalized fork
     (your profile data, your market's job portals, another AI runtime),
     note that GitHub points new PRs at the UPSTREAM repo by default.
     Those adaptations live in forks - see CONTRIBUTING.md - and get
     discovered via the pinned "Community forks & adaptations" discussion (#78).
     Check the "base repository" dropdown above before you continue. -->

## What changed and why

## Failing case / reproduction (for fixes)

## Verification
<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
     python3 tools/check_framework_version.py, bun test / bun run typecheck
     in touched CLIs, python3 -m unittest discover -s tests -->
