### PR TITLE
feat(rank): flag stale postings from the stored posted_date

### DIFF
--- a/.claude/commands/rank.md
+++ b/.claude/commands/rank.md
@@ -76,6 +76,22 @@ Back in the main context, for each scored job:
 5. **Deadline urgency:** a deadline within 7 days gets a 🔥 marker and wins ties. A deadline that has already passed moves the job to `expired`. Take the deadline from the scoring agent's Step 2 JSON for a job scored in this run, and from the stored `deadline` in `seen_jobs.json` for one that already carries it - a stored value costs no fetch, so urgency is re-derived on every run without re-reading the posting. When both exist and disagree, the freshly scored value wins and replaces the stored one. A stored value that does not parse as `YYYY-MM-DD` is skipped for urgency as well - rule 6's defensive-parse rule applies wherever a stored deadline is compared.
 6. **Expiry sweep over already-ranked entries.** Before presenting, check the stored `deadline` of every `ranked` entry this run did not re-score. Any whose deadline has passed becomes `expired`; any within 7 days is listed under a short **Closing soon** heading in Step 5 with its 🔥 marker. This needs no fetch and no agent - it is a date comparison against values already on disk, and it is what finally enforces `/scrape`'s "only open positions" rule beyond the moment of fetching. **An entry with no stored `deadline` is left alone, never guessed at** - most entries predate the column, and inferring a deadline from `first_seen` would retire jobs on a date nobody set. **Parse stored deadlines defensively:** a stored value that is not a `YYYY-MM-DD` date is treated exactly like an absent one - left alone, never compared, never guessed at - and reported once in the Step 5 summary with its portal, so the bad value gets traced to its source instead of silently steering the sweep (portals have shipped `"ASAP"`, `DD.MM.YYYY`, and free-text deadline shapes into stored data). `--all` re-scores entries of any status including `expired`, so a job the sweep retired can still be revived by a later `--all` that re-fetches it and finds the posting live: the sweep is reversible, which is what makes an automated status change acceptable here at all.
 
+7. **Staleness flag:** a job whose stored `posted_date` is more than **30 days** old at
+   rank time stays in the ranking but carries a visible ⚠ marker with its age spelled out
+   alongside the score (e.g. "⚠ posted 2024-05-13, 27 months ago") - same treatment as a
+   location or language FLAG, for the user to judge. Age is a signal, never a veto: the
+   posting that motivated this rule was 27 months old *and still live*, so excluding on
+   age would wrongly bury real openings - and a stale posting with a future stored
+   `deadline` is still open by the stronger signal, so the flag notes the deadline too
+   rather than contradicting it. This costs no fetch: `posted_date` is already on disk
+   (written by `/scrape` Step 4), and age is re-derived on every run, never persisted.
+   **An entry with no `posted_date` (or `null`) gets no flag and no guess** - entries
+   predating the field simply lack the signal, and inferring age from `first_seen` would
+   flag jobs on a date nobody posted. Rule 6's defensive-parse rule applies wherever a
+   stored `posted_date` is compared: a value that does not parse as `YYYY-MM-DD` is
+   treated exactly like an absent one and reported once in the Step 5 summary with its
+   portal.
+
 Sort by overall score (descending), urgency as tiebreaker.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ per-file diff commands.
 
 ## [Unreleased]
 
+### Added
+
+- **`/rank` now consumes the `posted_date` #391 persists** (#390, the deferred second
+  half) - Step 3 gains a staleness flag: a posting whose stored `posted_date` is more
+  than 30 days old at rank time carries a visible ⚠ marker with its age spelled out
+  alongside the score ("⚠ posted 2024-05-13, 27 months ago"), the same FLAG treatment as
+  location and language - in the ranking, for the user to judge, never an exclusion (the
+  #390 posting was 27 months old *and still live*; age is a signal, not a veto, and a
+  future stored `deadline` outranks it). Costs no fetch: age is re-derived each run from
+  the stored value and never persisted. Boundary rules carried over verbatim from the
+  schema and rule 6: no `posted_date` or `null` means no flag and no guess (never
+  inferred from `first_seen`), and unparseable values are treated as absent and reported
+  once with their portal. Pinned by four new cases in `test_rank_command.py`, each
+  verified to fail against the rule-less spec.
+
 ### Security
 
 - **`settings.json` no longer pre-approves `bun run` on arbitrary files** (#396) - the

--- a/tests/test_rank_command.py
+++ b/tests/test_rank_command.py
@@ -419,5 +419,70 @@ class RankCommandSpec(unittest.TestCase):
         self.assertEqual(result.returncode, 0, f"lint_skills.py failed:\n{result.stdout}{result.stderr}")
 
 
+class PostedDateStalenessSpec(unittest.TestCase):
+    """Step 3 must consume the posted_date #391 persists.
+
+    The field exists because a 27-month-old posting ranked Strong Fit at
+    position 1 of 133 (#390): the scoring agent noticed the age and wrote it
+    into prose nothing reads. Persistence alone changes nothing - these pin
+    that /rank actually derives a signal from the stored date, and that the
+    signal keeps the schema's own boundary rules (flag never veto, no
+    inference for absent values, rule 6's defensive parse).
+    """
+
+    def setUp(self):
+        self.step3 = _sections(COMMAND.read_text(encoding="utf-8")).get(
+            "Step 3: Aggregate and Rank", ""
+        )
+        self.assertTrue(self.step3, "Step 3 section missing from rank.md")
+        # The spec hard-wraps its prose; assertions match against collapsed
+        # whitespace so a rewrap never fails a pin the text still honors.
+        self.flat = " ".join(self.step3.split())
+
+    def test_step3_consumes_posted_date(self):
+        self.assertIn(
+            "`posted_date`",
+            self.step3,
+            "Step 3 never reads the posted_date /scrape persists, so a posting's "
+            "age is stored but still invisible at rank time - the exact #390 gap",
+        )
+        self.assertIn(
+            "⚠",
+            self.step3.split("`posted_date`", 1)[1][:600],
+            "the staleness rule must surface age as a visible ⚠ marker, like the "
+            "location and language FLAG treatments",
+        )
+
+    def test_staleness_is_a_flag_never_a_veto(self):
+        self.assertRegex(
+            self.flat,
+            r"[Aa]ge is a signal, never a veto",
+            "staleness must keep FLAG semantics - the #390 posting was 27 months "
+            "old AND still live, so excluding on age would bury real openings",
+        )
+
+    def test_staleness_never_inferred_for_absent_values(self):
+        self.assertRegex(
+            self.flat,
+            r"no `posted_date`.*no flag and no guess",
+            "entries predating the field must get no staleness signal - inferring "
+            "age from first_seen would flag jobs on a date nobody posted",
+        )
+        self.assertIn(
+            "`first_seen`",
+            self.step3,
+            "the rule must name first_seen as the forbidden inference source",
+        )
+
+    def test_staleness_parses_posted_date_defensively(self):
+        self.assertRegex(
+            self.flat,
+            r"defensive-parse rule applies wherever a stored `posted_date` is compared",
+            "posted_date comparisons must carry rule 6's defensive-parse rule - the "
+            "contract test pins the field's presence, not its format, and portals "
+            "have shipped free-text shapes into stored date fields before",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #390 — the deferred second half. #391 persisted `posted_date`; this makes `/rank` consume it, per the offer on #390 and the maintainer's note in #391's merge comment ("whichever of you takes it, the issue-first path is open"). @sandunwijerathne — you found and diagnosed this, so your input steers here; if you'd rather carry it yourself, I'll close in your favour.

## What changed and why

Step 3 gains **rule 7, the staleness flag**: a posting whose stored `posted_date` is more than **30 days** old at rank time stays in the ranking but carries a visible ⚠ marker with its age spelled out alongside the score — `⚠ posted 2024-05-13, 27 months ago`. The #390 posting would have surfaced exactly that way at position 1, instead of its age living in a `gaps` bullet nothing reads.

Design decisions, each anchored to an existing pattern:

- **FLAG, never a veto** — same treatment as location and language FLAG. The motivating posting was 27 months old *and still live*, so excluding on age would bury real openings. A stale posting with a future stored `deadline` is still open by the stronger signal, and the rule says the flag notes the deadline rather than contradicting it.
- **No fetch, no persistence** — age is re-derived each run from the value already on disk, mirroring how rule 5 re-derives deadline urgency. Nothing is written to `seen_jobs.json`; no schema change.
- **Boundary rules inherited verbatim** — no `posted_date` or `null` means no flag and no guess (never inferred from `first_seen`, echoing the schema's own never-backfill rule), and rule 6's defensive-parse rule applies wherever the stored value is compared: unparseable values are treated as absent and reported once with their portal (the contract test pins the field's presence, not its format).

**Two dials that are yours to set, flagged rather than decided:** the 30-day threshold (chosen conservatively — EU postings legitimately run 4–6 weeks, and a false flag costs a glance while a missed flag costs an `/apply` against a dead posting), and whether age should also *penalize* the numeric score. This PR is flag-only: a penalty changes ranking order and belongs to the `04-job-evaluation.md` rubric if you want it — happy to add it here or in a follow-up per your call.

## Failing case / reproduction (for fixes)

#390's real case: `posted_date: 2024-05-13`, scraped 27 months later, ranked Strong Fit #1 of 133, age recorded only in prose. With rule 7, that entry's shortlist row carries `⚠ posted 2024-05-13, 27 months ago` next to its score.

Four new spec pins in `test_rank_command.py` (`PostedDateStalenessSpec`): Step 3 consumes `posted_date` with a ⚠ marker; flag-never-veto; no-flag-no-guess for absent/null values naming `first_seen` as the forbidden inference; rule 6's defensive parse applied to `posted_date`. Verified by reverting `rank.md` to master under the new tests: exactly those 4 fail, all pass with the rule.

## Verification

- `python3 -m unittest discover -s tests`: 325 tests, all pass (27 in `test_rank_command.py`).
- Fail-on-unfixed check as above: 4/4 new pins fail against the rule-less spec.
- `python3 tools/lint_skills.py`, `check_framework_version.py`, `security_guards.py`: all OK.
- CHANGELOG entry under `[Unreleased]` → `### Added`.
