### PR TITLE
fix(ci): skip placeholder-integrity tests on forks in python-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ per-file diff commands.
 
 ### Fixed
 
+- **Placeholder-integrity tests in `python-tests` now skip on forks** (#405) - the dedicated
+  `placeholder-integrity` job already gates on the upstream repo name, but `python-tests` ran
+  `unittest discover` with no such guard, so forks that personalized files via `/setup` failed
+  three sentinel checks permanently. Both test classes now use `@unittest.skipIf` on
+  `GITHUB_REPOSITORY` (defaulting to upstream when unset so local pristine-template runs still
+  execute).
+
 - **`convert_salary_excel.py` no longer mistakes a title/citation row for the header row**
   (#414) - header-row detection accepted the first row in the first 10 where *any* cell merely
   contained a company-pattern word, with no check that the row actually looked like a header. A

--- a/tests/test_placeholder_integrity.py
+++ b/tests/test_placeholder_integrity.py
@@ -15,8 +15,11 @@ the sentinels exist in the pristine files, and (c) that simulating the
 /setup edit destroys at least one checked sentinel per file - i.e. the
 guard actually fires on the failure it exists to catch.
 """
+import os
 import unittest
 from pathlib import Path
+
+UPSTREAM = "MadsLorentzen/ai-job-search"
 
 REPO = Path(__file__).resolve().parent.parent
 CI = REPO / ".github" / "workflows" / "ci.yml"
@@ -41,6 +44,10 @@ def personalize_cv(text: str) -> str:
     )
 
 
+@unittest.skipIf(
+    os.environ.get("GITHUB_REPOSITORY", UPSTREAM) != UPSTREAM,
+    "placeholder-integrity guards the pristine upstream template; forks personalize these files via /setup",
+)
 class TestCvSentinelsAreDataLocated(unittest.TestCase):
     def setUp(self):
         self.ci = CI.read_text(encoding="utf-8")
@@ -74,6 +81,10 @@ class TestCvSentinelsAreDataLocated(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    os.environ.get("GITHUB_REPOSITORY", UPSTREAM) != UPSTREAM,
+    "placeholder-integrity guards the pristine upstream template; forks personalize these files via /setup",
+)
 class TestProfileSentinelIsDataLocated(unittest.TestCase):
     def test_ci_checks_a_data_placeholder_not_the_header_comment(self):
         ci = CI.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #405

The dedicated `placeholder-integrity` CI job already gates on the upstream repo name, but `python-tests` runs `unittest discover` with no such skip. After `/setup`, forks have personalized files so `tests/test_placeholder_integrity.py` fails permanently in `python-tests`.

Thanks @markvandeven for the diagnosis and suggested gate.

Both test classes now use the owner-specified skip shape:

```python
import os
UPSTREAM = "MadsLorentzen/ai-job-search"

@unittest.skipIf(
    os.environ.get("GITHUB_REPOSITORY", UPSTREAM) != UPSTREAM,
    "placeholder-integrity guards the pristine upstream template; forks personalize these files via /setup",
)
```

`GITHUB_REPOSITORY` defaults to `UPSTREAM` when unset so local pristine-template runs still execute the guards.

**Verification**

```
env -u GITHUB_REPOSITORY python3 -m unittest tests.test_placeholder_integrity -v
GITHUB_REPOSITORY=MadsLorentzen/ai-job-search python3 -m unittest tests.test_placeholder_integrity -v
GITHUB_REPOSITORY=someone/ai-job-search python3 -m unittest tests.test_placeholder_integrity -v
```

Unset or upstream: tests run and pass on the pristine template. Fork name: the 5 tests skip.

**Residual (acceptable per owner):** running `python3 -m unittest discover` locally on a personalized fork without setting `GITHUB_REPOSITORY` will still fail the sentinel checks — only CI fork runs are fixed.
