### PR TITLE
fix(linkedin-search): reject fractional --jobage/--page/--limit inste…

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/cli.ts
+++ b/.agents/skills/linkedin-search/cli/src/cli.ts
@@ -125,13 +125,18 @@ async function main(): Promise<number> {
       return 1
     }
 
+    // Bare `parseInt` truncates instead of rejecting ("2.5" -> 2, "0.5" -> 0),
+    // so a fractional --jobage silently changed the freshness window instead
+    // of erroring - worst case landing on 0, which the downstream `!days`
+    // check then treats as "no filter" and drops --jobage entirely with no
+    // error at all. Require the raw string to already be an integer literal.
     const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
-      const val = parseInt(raw as string, 10)
-      if (isNaN(val)) {
-        process.stderr.write(JSON.stringify({ error: `--${name} must be a number, got "${raw}"`, code: "BAD_ARG" }) + "\n")
+      const str = typeof raw === "string" ? raw : String(raw)
+      if (!/^-?\d+$/.test(str)) {
+        process.stderr.write(JSON.stringify({ error: `--${name} must be an integer, got "${raw}"`, code: "BAD_ARG" }) + "\n")
         return null
       }
-      return val
+      return parseInt(str, 10)
     }
 
     if (flags.jobage !== undefined) {

--- a/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/cli-flag-validation.test.ts
@@ -33,11 +33,23 @@ describe("LinkedIn CLI flag validation", () => {
       expect(err.code).not.toBe("BAD_ARG");
     });
 
-    test("float string truncated to integer, no error", async () => {
-      // parseInt("7.5") = 7, which is valid
+    test("fractional value exits 1 with BAD_ARG instead of silently truncating", async () => {
+      // parseInt("7.5") = 7 - previously accepted silently. A fractional
+      // --jobage must be rejected, not truncated: truncation to 0 (e.g.
+      // "0.5") would otherwise drop the freshness filter entirely with no
+      // error (see helpers.ts jobageToTPR's `!days` guard).
       const result = await runCLI(["search", "-l", LOCATION, "--jobage", "7.5", "--limit", "1"]);
+      expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
-      expect(err.code).not.toBe("BAD_ARG");
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage/);
+    });
+
+    test("fractional value truncating to zero exits 1 rather than disabling the filter", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage", "0.5", "--limit", "1"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
     });
 
     test("zero is accepted (falsy int should not be treated as missing)", async () => {
@@ -58,6 +70,14 @@ describe("LinkedIn CLI flag validation", () => {
 
     test("zero exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "0"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/jobage-minutes/);
+    });
+
+    test("fractional value exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--jobage-minutes", "2.5"]);
       expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
       expect(err.code).toBe("BAD_ARG");
@@ -98,11 +118,27 @@ describe("LinkedIn CLI flag validation", () => {
       expect(err.code).toBe("BAD_ARG");
       expect(err.error).toMatch(/page/);
     });
+
+    test("fractional value exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--page", "1.5"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/page/);
+    });
   });
 
   describe("--limit NaN validation", () => {
     test("non-numeric string exits 1 with BAD_ARG", async () => {
       const result = await runCLI(["search", "-l", LOCATION, "--limit", "xyz"]);
+      expect(result.exitCode).not.toBe(0);
+      const err = parsedStderr(result.stderr);
+      expect(err.code).toBe("BAD_ARG");
+      expect(err.error).toMatch(/limit/);
+    });
+
+    test("fractional value exits 1 with BAD_ARG", async () => {
+      const result = await runCLI(["search", "-l", LOCATION, "--limit", "2.5"]);
       expect(result.exitCode).not.toBe(0);
       const err = parsedStderr(result.stderr);
       expect(err.code).toBe("BAD_ARG");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ per-file diff commands.
 
 ### Fixed
 
+- **`linkedin-search`'s `--jobage`/`--jobage-minutes`/`--page`/`--limit` flags reject fractional
+  values instead of silently truncating them** (#371) - `parseIntFlag` in `cli.ts` validated with
+  bare `parseInt`, which truncates rather than erroring: `--jobage 7.5` silently became `7`, and
+  `--jobage 0.5` truncated to `0` - which `jobageToTPR`'s `!days` guard then treats as "no
+  filter," dropping the freshness window from the LinkedIn request entirely while the CLI still
+  exited 0. `parseIntFlag` now requires the raw flag value to already be an integer literal
+  (`/^-?\d+$/`) and rejects anything else with the standard `BAD_ARG` stderr-JSON error, matching
+  the Danish CLIs' `z.coerce.number().int()` strictness. Pinned by new cases in
+  `cli-flag-validation.test.ts` for all four flags. Reported by @Meet6338-X.
+
 - **The `documents/interview/**` ignore rule no longer claims interview prep is written there**
   (#336). `/interview` saves its pack to
   `documents/applications/<company>_<role>/interview_prep_<stage>.md`, already ignored by


### PR DESCRIPTION
…ad of truncating

parseIntFlag used bare parseInt, so a fractional value like --jobage 0.5 silently truncated to 0, which jobageToTPR's `!days` guard then treats as "no filter" - dropping the freshness window from the request entirely while the CLI still exited 0. Now requires the raw value to already be an integer literal and rejects anything else with the standard BAD_ARG error.

Fixes #371. Reported by @Meet6338-X.

<!-- Heads-up before you publish: if you built this in a personalized fork
     (your profile data, your market's job portals, another AI runtime),
     note that GitHub points new PRs at the UPSTREAM repo by default.
     Those adaptations live in forks - see CONTRIBUTING.md - and get
     discovered via the pinned "Community forks & adaptations" discussion (#78).
     Check the "base repository" dropdown above before you continue. -->

## What changed and why

## Failing case / reproduction (for fixes)

## Verification
<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
     python3 tools/check_framework_version.py, bun test / bun run typecheck
     in touched CLIs, python3 -m unittest discover -s tests -->
