### PR TITLE
fix(linkedin-search): accept LinkedIn job URLs with trailing slashes in detail command (#411)

### DIFF
--- a/.agents/skills/linkedin-search/cli/src/commands/detail.ts
+++ b/.agents/skills/linkedin-search/cli/src/commands/detail.ts
@@ -6,10 +6,10 @@ export interface DetailOpts {
 }
 
 /** Accept a raw job ID, a job-view URL, or a job URN. */
-function normalizeId(input: string): string | null {
+export function normalizeId(input: string): string | null {
   const urn = input.match(/urn:li:jobPosting:(\d+)/)
   if (urn) return urn[1]
-  const url = input.match(/-(\d{6,})(?:\?|$)/) || input.match(/\/(\d{6,})(?:\?|$)/)
+  const url = input.match(/-(\d{6,})(?:[\/?]|$)/) || input.match(/\/(\d{6,})(?:[\/?]|$)/)
   if (url) return url[1]
   const bare = input.match(/^\d{6,}$/)
   if (bare) return input

--- a/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
+++ b/.agents/skills/linkedin-search/cli/tests/parsing.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { parseJobCards, parseJobDetail, extractDivContent, minutesToTPR } from "../src/helpers";
+import { normalizeId } from "../src/commands/detail";
 
 // Minimal search-card markup: parseJobCards splits on the job-posting URN and
 // needs an id, a base-search-card__title, and a full-link. Everything else is
@@ -222,3 +223,55 @@ describe("minutesToTPR", () => {
     expect(minutesToTPR(-5)).toBeNull();
   });
 });
+
+describe("normalizeId", () => {
+  test("extracts ID from raw numeric string", () => {
+    expect(normalizeId("1234567890")).toBe("1234567890");
+  });
+
+  test("extracts ID from URN", () => {
+    expect(normalizeId("urn:li:jobPosting:1234567890")).toBe("1234567890");
+  });
+
+  test("extracts ID from simple job view URL without trailing slash", () => {
+    expect(normalizeId("https://www.linkedin.com/jobs/view/1234567890")).toBe("1234567890");
+  });
+
+  test("extracts ID from simple job view URL with trailing slash", () => {
+    expect(normalizeId("https://www.linkedin.com/jobs/view/1234567890/")).toBe("1234567890");
+  });
+
+  test("extracts ID from simple job view URL with query parameter", () => {
+    expect(normalizeId("https://www.linkedin.com/jobs/view/1234567890?refId=abc")).toBe("1234567890");
+  });
+
+  test("extracts ID from simple job view URL with trailing slash and query parameter", () => {
+    expect(normalizeId("https://www.linkedin.com/jobs/view/1234567890/?refId=abc")).toBe("1234567890");
+  });
+
+  test("extracts ID from slug URL without trailing slash", () => {
+    expect(normalizeId("https://www.linkedin.com/jobs/view/software-engineer-1234567890")).toBe("1234567890");
+  });
+
+  test("extracts ID from slug URL with trailing slash", () => {
+    expect(normalizeId("https://www.linkedin.com/jobs/view/software-engineer-1234567890/")).toBe("1234567890");
+  });
+
+  test("extracts ID from slug URL with trailing slash and tracking query params", () => {
+    expect(
+      normalizeId("https://www.linkedin.com/jobs/view/software-engineer-at-company-1234567890/?trackingId=xyz&refId=123"),
+    ).toBe("1234567890");
+  });
+
+  test("extracts ID from regional subdomain LinkedIn URL with trailing slash", () => {
+    expect(normalizeId("https://dk.linkedin.com/jobs/view/data-scientist-9876543210/")).toBe("9876543210");
+  });
+
+  test("returns null for non-job URLs and invalid strings", () => {
+    expect(normalizeId("https://www.linkedin.com/feed/")).toBeNull();
+    expect(normalizeId("not-a-url")).toBeNull();
+    expect(normalizeId("12345")).toBeNull(); // fewer than 6 digits
+    expect(normalizeId("")).toBeNull();
+  });
+});
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ per-file diff commands.
 
 ### Fixed
 
+- **`linkedin-search detail` accepts LinkedIn job URLs with trailing slashes** (#411) -
+  passing a job URL with a trailing slash (e.g., `https://www.linkedin.com/jobs/view/<id>/`
+  or a slugged variant with or without query strings) failed validation and exited 1 with
+  `BAD_ID` before any network request because the regex delimiter strictly expected `?`
+  or end-of-string immediately after the numeric ID. The boundary check now matches
+  `[\/?]`, correctly extracting IDs from browser-copied URLs, regional subdomains, and
+  links with tracking parameters. Pinned by eleven new cases in `parsing.test.ts`.
+
 - **The `documents/interview/**` ignore rule no longer claims interview prep is written there**
   (#336). `/interview` saves its pack to
   `documents/applications/<company>_<role>/interview_prep_<stage>.md`, already ignored by


### PR DESCRIPTION
<!-- Heads-up before you publish: if you built this in a personalized fork
     (your profile data, your market's job portals, another AI runtime),
     note that GitHub points new PRs at the UPSTREAM repo by default.
     Those adaptations live in forks - see CONTRIBUTING.md - and get
     discovered via the pinned "Community forks & adaptations" discussion (#78).
     Check the "base repository" dropdown above before you continue. -->

## What changed and why

Fixes #411

In `.agents/skills/linkedin-search/cli/src/commands/detail.ts`, `normalizeId()` used regular expressions that required the numeric job ID to be immediately terminated by either `?` or `$`:

```typescript
const url = input.match(/-(\d{6,})(?:\?|$)/) || input.match(/\/(\d{6,})(?:\?|$)/)
```
When passing LinkedIn URLs with trailing slashes (which frequently occur when copying from web browsers or share buttons, e.g. https://www.linkedin.com/jobs/view/1234567890/ or https://www.linkedin.com/jobs/view/software-engineer-1234567890/), the digit sequence is followed by / instead of ? or end-of-string. This caused normalizeId to return null and the command to exit with BAD_ID before attempting any network fetch.

This PR:

Updates the regex patterns in normalizeId to accept trailing slashes: (?:[\/?]|$).
Exports normalizeId and adds 11 unit test cases to parsing.test.ts covering raw IDs, URNs, URLs with and without trailing slashes, slug URLs, tracking query params, regional subdomains, and invalid strings.


## Failing case / reproduction (for fixes)
Before this PR:
$ bun run .agents/skills/linkedin-search/cli/src/cli.ts detail "https://www.linkedin.com/jobs/view/1234567890/"
{"error":"Could not parse a job ID from \"https://www.linkedin.com/jobs/view/1234567890/\"","code":"BAD_ID"}
With this PR: normalizeId parses 1234567890 and proceeds to fetch the job details normally.

## Verification
<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
     python3 tools/check_framework_version.py, bun test / bun run typecheck
     in touched CLIs, python3 -m unittest discover -s tests -->
     
     Ran all checks per CONTRIBUTING.md:

python3 tools/lint_skills.py (OK)
python3 tools/check_framework_version.py (OK)
bun test in .agents/skills/linkedin-search/cli (56/56 tests passing across 5 files)
bun run typecheck in .agents/skills/linkedin-search/cli (tsc --noEmit exited 0)
python3 -m unittest discover -s tests (322/322 tests passing)
