### PR TITLE
fix(jobbank-search): degrade an unparseable pubDate to a null date instead of crashing the search

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/search.ts
@@ -5,7 +5,13 @@ import { rssFetch, fetchWithUA, writeError, parseRssDescription, extractJobIdFro
 export function normalizeSearchItem(item: RssItem): Record<string, unknown> {
   const parsed = parseRssDescription(item.description)
   const id = extractJobIdFromUrl(item.link)
-  const posted = item.pubDate ? new Date(item.pubDate).toISOString() : ""
+  // Guard the parse: new Date(<unparseable>) is an Invalid Date whose
+  // toISOString() throws RangeError, and this runs inside an unguarded
+  // items.map() - one bad feed item would kill the whole search as
+  // API_ERROR (#416). An unparseable pubDate degrades to the same shape
+  // as an absent one: posted "", date null.
+  const parsedDate = item.pubDate ? new Date(item.pubDate) : null
+  const posted = parsedDate && !Number.isNaN(parsedDate.getTime()) ? parsedDate.toISOString() : ""
   return {
     id,
     title: item.title,

--- a/.agents/skills/jobbank-search/cli/tests/search-normalization.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/search-normalization.test.ts
@@ -27,6 +27,21 @@ describe("Jobbank search normalization", () => {
     expect(result.date).toBeNull();
   });
 
+  // A present-but-unparseable pubDate must degrade to the same null-date shape
+  // as an absent one, never throw: toISOString() on an Invalid Date raises
+  // RangeError, and normalizeSearchItem runs inside an unguarded items.map(),
+  // so one bad feed item killed the whole search as API_ERROR (#416). The
+  // un-CDATA'd fallback capture in parseRssItems can deliver exactly such a
+  // value.
+  for (const bad of ["date unavailable", "2026-09-02T08:00:00+02:00x", "I går"]) {
+    test(`emits a null date instead of throwing on unparseable pubDate ${JSON.stringify(bad)}`, () => {
+      const result = normalizeSearchItem({ ...rssItem(), pubDate: bad });
+
+      expect(result.posted).toBe("");
+      expect(result.date).toBeNull();
+    });
+  }
+
   test("keeps the native fields alongside the contract date (additive)", () => {
     const result = normalizeSearchItem(rssItem());
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ per-file diff commands.
 
 ### Fixed
 
+- **`jobbank-search` no longer dies over one malformed feed date** (#416) - `new Date()`
+  on a present-but-unparseable `pubDate` yields an Invalid Date whose `toISOString()`
+  throws `RangeError`, and `normalizeSearchItem` runs inside an unguarded `items.map()`,
+  so a single bad RSS item killed the entire search with `{"error": "Invalid Date",
+  "code": "API_ERROR"}` and exit 1 - a whole default-ON portal lost to one item, with
+  the error pointing at the API. The un-CDATA'd fallback capture in `parseRssItems` can
+  deliver exactly such a value. An unparseable `pubDate` now degrades to the same shape
+  as an absent one (`posted` empty, `date: null`, per the `seen_jobs.json` contract that
+  #391 put this field on), and every other item survives. Pinned by three new cases in
+  `search-normalization.test.ts`, each verified to fail on the unfixed code.
 - **`linkedin-search` rejects fractional numeric flags instead of silently changing
   the query** (#371) - bare `parseInt` truncated values before validation, so
   `--jobage 0.5` became `0` and silently omitted LinkedIn's `f_TPR` freshness filter


### PR DESCRIPTION
Fixes #416, filed with the offline repro an hour ago.

## What changed and why

`normalizeSearchItem` built its timestamp with `new Date(item.pubDate).toISOString()` guarded only against an *absent* `pubDate`. A present-but-unparseable value yields an Invalid Date, `toISOString()` throws `RangeError`, and since the function runs inside an unguarded `items.map()`, the throw escaped to the run handler's catch: `{"error": "Invalid Date", "code": "API_ERROR"}`, exit 1. One malformed RSS item cost the entire search of a default-ON `/scrape` portal, with the error text blaming the API - and `/scrape`'s CLI-failure path then falls back to WebSearch, the stale-index mechanism from #331's triage. The un-CDATA'd fallback capture in `parseRssItems` (`helpers.ts`) is a concrete path for such a value to arrive.

The parse is now guarded (`Number.isNaN(parsedDate.getTime())`), and an unparseable `pubDate` degrades to exactly the shape an absent one already produced: `posted` empty, `date: null` - the null-date contract `seen_jobs.json` documents, and the field #391 put on the persistence path. Every other item in the feed survives. One file of code, three new test cases, one CHANGELOG entry.

## Failing case / reproduction (for fixes)

From #416, against the exported function with no mocks: `pubDate: "date unavailable"`, `"2026-09-02T08:00:00+02:00x"`, and `"I går"` each threw `RangeError: Invalid Date`; the RFC-2822 control parsed to `2026-09-02`. On this branch all three yield `date: null` with no throw, and the control is unchanged.

The three new cases in `search-normalization.test.ts` sit beside the existing absent-`pubDate` case they mirror. Verified to fail on the unfixed code: with only `src/commands/search.ts` reverted to master, exactly those 3 fail; restored, the full CLI suite is 31/31.

## Verification

- `bun test` in `jobbank-search/cli`: 31 pass / 0 fail; `bun run typecheck` clean.
- Fail-on-unfixed check as above (3/3).
- `python3 tools/lint_skills.py`, `python3 tools/security_guards.py`, `python3 -m unittest discover -s tests` (326 tests): all OK.
- CHANGELOG entry under `[Unreleased]` → `### Fixed`.
