### PR TITLE
fix(jobnet-search): degrade a null publicationDate to a null date instead of crashing the search

### DIFF
--- a/.agents/skills/jobnet-search/cli/src/commands/search.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/search.ts
@@ -18,7 +18,11 @@ export interface JobAdRaw {
   postalCode: number | null
   postalDistrictName: string | null
   country: string
-  publicationDate: string
+  // A TypeScript claim is not runtime validation: apiFetch casts the JSON
+  // body, so a null here arrives typed as string and .slice() throws,
+  // killing the whole search as API_ERROR (#418). Typed nullable so the
+  // compiler enforces the guard below.
+  publicationDate: string | null
   applicationDeadline: string | null
   applicationDeadlineStatus: string | null
   workHourPartTime: boolean
@@ -102,7 +106,7 @@ export function createSearchOutput(data: SearchApiResponse, flags: SearchFlags) 
     isFavorite: job.isFavorite,
     company: job.hiringOrgName,
     location: job.postalDistrictName ?? job.municipality ?? null,
-    date: job.publicationDate.slice(0, 10),
+    date: job.publicationDate ? job.publicationDate.slice(0, 10) : null,
     deadline: job.applicationDeadline && !job.applicationDeadline.startsWith("1900-01-01")
       ? job.applicationDeadline.slice(0, 10)
       : null,
@@ -211,7 +215,7 @@ type JobAdResult = {
   occupation: string | null
   municipality: string | null
   postalCode: number | null
-  publicationDate: string
+  publicationDate: string | null
   applicationDeadline: string | null
 }
 

--- a/.agents/skills/jobnet-search/cli/tests/search-normalization.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/search-normalization.test.ts
@@ -161,3 +161,23 @@ describe("Jobnet search normalization", () => {
     expect(output.results[1].deadline).toBe("2026-08-01");
   });
 });
+
+describe("Jobnet null publicationDate degradation", () => {
+  // publicationDate: string was a TypeScript claim, not runtime validation -
+  // apiFetch casts the JSON body, so one ad with a null publication date
+  // threw TypeError from .slice() inside the jobAds map and killed the whole
+  // search as API_ERROR (#418). The neighboring applicationDeadline field is
+  // already guarded (null check + 1900-01-01 sentinel); this pins the same
+  // per-item degradation for publicationDate: date null, no throw.
+  test("an ad with a null publicationDate yields date: null instead of crashing the search", () => {
+    const data = apiResponse();
+    data.jobAds[0].publicationDate = null;
+
+    // The shared fixture flags carry limit: 1, which would slice off the
+    // second ad; lift the limit so the survives-alongside assertion is real.
+    const output = createSearchOutput(data, { ...flags, limit: undefined });
+
+    expect(output.results[0].date).toBeNull();
+    expect(output.results[1].date).toBe("2026-07-02");
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,23 @@ per-file diff commands.
 
 ### Fixed
 
+- **`jobnet-search` no longer dies over one ad with a null publication date** (#418, the
+  sibling of #416 from the same audit) - `date: job.publicationDate.slice(0, 10)` trusted
+  a TypeScript interface claim (`publicationDate: string`) that nothing validates at
+  runtime: `apiFetch` casts the JSON body, so one `null` threw `TypeError` inside the
+  `jobAds` map and the whole search of a default-ON portal exited 1 as `API_ERROR` - while
+  the neighboring `applicationDeadline` field was already null-guarded with a `1900-01-01`
+  sentinel check. The field is now typed nullable (so the compiler enforces the guard) and
+  degrades per-item to `date: null`, the shape the `seen_jobs.json` contract documents.
+  Pinned by a new case in `search-normalization.test.ts`, verified to fail on the unfixed
+  code with the exact production TypeError.
+
 - **Placeholder-integrity tests in `python-tests` now skip on forks** (#405) - the dedicated
   `placeholder-integrity` job already gates on the upstream repo name, but `python-tests` ran
   `unittest discover` with no such guard, so forks that personalized files via `/setup` failed
   three sentinel checks permanently. Both test classes now use `@unittest.skipIf` on
   `GITHUB_REPOSITORY` (defaulting to upstream when unset so local pristine-template runs still
   execute).
-
 - **`convert_salary_excel.py` no longer mistakes a title/citation row for the header row**
   (#414) - header-row detection accepted the first row in the first 10 where *any* cell merely
   contained a company-pattern word, with no check that the row actually looked like a header. A


### PR DESCRIPTION
Fixes #418, the `jobnet-search` sibling of #416 from the same six-CLI date audit.

## What changed and why

`createSearchOutput` built the contract `date` with `job.publicationDate.slice(0, 10)`, trusting the `JobAdRaw` interface's `publicationDate: string`. That type is a claim, not a check: `apiFetch<SearchApiResponse>` casts the JSON body and nothing validates it (zod covers flag options only). One ad with a `null` publication date threw `TypeError: null is not an object (evaluating 'job.publicationDate.slice')` inside the `jobAds` map, the run handler's catch reported `API_ERROR`, and the CLI exited 1 - the whole search of a default-ON `/scrape` portal lost to one ad, with `/scrape` then degrading to the stale WebSearch fallback (#331's mechanism 2). The inconsistency was one line down: `applicationDeadline` was already typed nullable and guarded, sentinel check included.

The fix mirrors that neighboring guard: `publicationDate` is typed `string | null` in both interfaces (so the compiler enforces the guard from now on) and the mapping degrades per-item to `date: null` - the null-date shape the `seen_jobs.json` contract documents, on the persistence path since #391. Passthrough uses of the field (`publicationDate` echo, plain output) tolerate null by construction; the `.slice` at the crash site was the only dereference.

## Failing case / reproduction (for fixes)

From #418, against the exported `createSearchOutput` with no mocks: a well-formed response whose single ad carries `publicationDate: null` throws the TypeError above on master. On this branch it yields `date: null` and, with two ads, the healthy one still parses (`date: "2026-07-02"`).

Same honest scoping as #416: the live API has not been caught sending `null` here; the argument is blast radius (jobnet has shipped sentinel dates before, per the existing `1900-01-01` guard on the neighboring field).

The new case in `search-normalization.test.ts` was verified to fail on the unfixed code: with only `src/commands/search.ts` reverted to master, exactly that test fails, with the exact production TypeError as the failure.

## Verification

- `bun test` in `jobnet-search/cli`: 31 pass / 0 fail; `bun run typecheck` clean.
- Fail-on-unfixed check as above (1/1, failing with the production TypeError).
- `python3 tools/lint_skills.py`, `python3 tools/security_guards.py`, `python3 -m unittest discover -s tests` (326 tests): all OK.
- CHANGELOG entry under `[Unreleased]` → `### Fixed`, cross-referencing #416.
