### PR TITLE
fix(portal-clis): accept full posting URLs in jobbank, jobdanmark, an…

### DIFF
--- a/.agents/skills/jobbank-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobbank-search/cli/src/commands/detail.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { fetchWithUA, parseJobPostingJsonLd, writeError, BASE_URL } from "../helpers.js"
+import { fetchWithUA, normalizeJobId, parseJobPostingJsonLd, writeError, BASE_URL } from "../helpers.js"
 
 export const detail = defineCommand({
   name: "detail",
@@ -13,9 +13,15 @@ export const detail = defineCommand({
   handler: async ({ positional, flags, signal }) => {
     if (signal.aborted) return
 
-    const id = positional[0]
-    if (!id) {
+    const rawId = positional[0]
+    if (!rawId) {
       writeError("Job ID is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    const id = normalizeJobId(rawId)
+    if (!id) {
+      writeError(`Could not extract job ID from "${rawId}"`, "BAD_ID")
       process.exit(1)
     }
 

--- a/.agents/skills/jobbank-search/cli/src/helpers.ts
+++ b/.agents/skills/jobbank-search/cli/src/helpers.ts
@@ -159,10 +159,16 @@ export function parseRssDescription(desc: string): ParsedDescription {
   return { jobType, company, location, deadline }
 }
 
+export function normalizeJobId(input: string): string | null {
+  const trimmed = input.trim()
+  if (/^\d+$/.test(trimmed)) return trimmed
+  const match = trimmed.match(/\/job\/(\d+)(?:\/|$|\?|#)/)
+  return match ? match[1] : null
+}
+
 export function extractJobIdFromUrl(url: string): string {
   // URL format: https://jobbank.dk/job/{id}/{company-slug}/{title-slug}
-  const match = url.match(/\/job\/(\d+)\//)
-  return match ? match[1] : ""
+  return normalizeJobId(url) ?? ""
 }
 
 function findJobPosting(value: unknown): Record<string, unknown> | null {

--- a/.agents/skills/jobbank-search/cli/tests/detail-url-normalization.test.ts
+++ b/.agents/skills/jobbank-search/cli/tests/detail-url-normalization.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeJobId } from "../src/helpers.js"
+import { runCLI } from "./helpers.js"
+
+describe("jobbank-search normalizeJobId", () => {
+  test("accepts bare numeric ID", () => {
+    expect(normalizeJobId("304212")).toBe("304212")
+    expect(normalizeJobId("  12345  ")).toBe("12345")
+  })
+
+  test("extracts ID from full URL with trailing slash", () => {
+    expect(normalizeJobId("https://jobbank.dk/job/304212/")).toBe("304212")
+  })
+
+  test("extracts ID from full URL without trailing slash", () => {
+    expect(normalizeJobId("https://jobbank.dk/job/304212")).toBe("304212")
+  })
+
+  test("extracts ID from full URL with company/role slug segments", () => {
+    expect(normalizeJobId("https://jobbank.dk/job/304212/acme-corp/software-developer")).toBe("304212")
+    expect(normalizeJobId("https://jobbank.dk/job/304212/acme-corp/software-developer/")).toBe("304212")
+  })
+
+  test("extracts ID from URL with query parameters and hash fragments", () => {
+    expect(normalizeJobId("https://jobbank.dk/job/304212?ref=search&page=1")).toBe("304212")
+    expect(normalizeJobId("https://jobbank.dk/job/304212#apply")).toBe("304212")
+  })
+
+  test("rejects invalid non-numeric strings and unrelated URLs", () => {
+    expect(normalizeJobId("abc")).toBeNull()
+    expect(normalizeJobId("https://example.com/other/12345")).toBeNull()
+    expect(normalizeJobId("")).toBeNull()
+  })
+
+  test("CLI detail command rejects invalid ID format with BAD_ID", async () => {
+    const result = await runCLI(["detail", "invalid-id-format"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ID")
+  })
+})

--- a/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/commands/detail.ts
@@ -1,7 +1,7 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
 import { parse } from "node-html-parser"
-import { BASE_URL, writeError } from "../helpers.js"
+import { BASE_URL, normalizeSlug, writeError } from "../helpers.js"
 import { extractCity, toContractDate } from "./search.js"
 
 interface JsonLdJobPosting {
@@ -226,9 +226,15 @@ export const detail = defineCommand({
   handler: async ({ flags, positional, signal }) => {
     if (signal.aborted) return
 
-    const slug = positional[0]
-    if (!slug) {
+    const rawSlug = positional[0]
+    if (!rawSlug) {
       writeError("slug argument is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    const slug = normalizeSlug(rawSlug)
+    if (!slug) {
+      writeError(`Could not extract slug from "${rawSlug}"`, "BAD_ID")
       process.exit(1)
     }
 

--- a/.agents/skills/jobdanmark-search/cli/src/helpers.ts
+++ b/.agents/skills/jobdanmark-search/cli/src/helpers.ts
@@ -71,3 +71,13 @@ export function writeError(error: string, code: string): void {
 export function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim()
 }
+
+export function normalizeSlug(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  const match = trimmed.match(/\/job\/([^/?#]+)/)
+  if (match) return match[1]
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) return trimmed
+  return null
+}
+

--- a/.agents/skills/jobdanmark-search/cli/tests/detail-url-normalization.test.ts
+++ b/.agents/skills/jobdanmark-search/cli/tests/detail-url-normalization.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeSlug } from "../src/helpers.js"
+import { runCLI } from "./helpers.js"
+
+describe("jobdanmark-search normalizeSlug", () => {
+  test("accepts bare slug", () => {
+    expect(normalizeSlug("software-udvikler-12345")).toBe("software-udvikler-12345")
+    expect(normalizeSlug("  senior_dev_67890  ")).toBe("senior_dev_67890")
+  })
+
+  test("extracts slug from full URL with trailing slash", () => {
+    expect(normalizeSlug("https://jobdanmark.dk/job/software-udvikler-12345/")).toBe("software-udvikler-12345")
+  })
+
+  test("extracts slug from full URL without trailing slash", () => {
+    expect(normalizeSlug("https://jobdanmark.dk/job/software-udvikler-12345")).toBe("software-udvikler-12345")
+  })
+
+  test("extracts slug from relative URL path", () => {
+    expect(normalizeSlug("/job/software-udvikler-12345")).toBe("software-udvikler-12345")
+    expect(normalizeSlug("/job/software-udvikler-12345/")).toBe("software-udvikler-12345")
+  })
+
+  test("extracts slug from URL with query parameters and hash fragments", () => {
+    expect(normalizeSlug("https://jobdanmark.dk/job/software-udvikler-12345?utm_source=test&ref=1")).toBe(
+      "software-udvikler-12345",
+    )
+    expect(normalizeSlug("https://jobdanmark.dk/job/software-udvikler-12345#apply")).toBe(
+      "software-udvikler-12345",
+    )
+  })
+
+  test("rejects empty string and invalid URLs", () => {
+    expect(normalizeSlug("")).toBeNull()
+    expect(normalizeSlug("   ")).toBeNull()
+    expect(normalizeSlug("https://example.com/other/test")).toBeNull()
+  })
+
+  test("CLI detail command rejects invalid slug format with BAD_ID", async () => {
+    const result = await runCLI(["detail", "https://invalid.com/not-a-job"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ID")
+  })
+})

--- a/.agents/skills/jobnet-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobnet-search/cli/src/commands/detail.ts
@@ -1,6 +1,6 @@
 import { defineCommand, option } from "@bunli/core"
 import { z } from "zod"
-import { apiFetch, writeError, stripHtml } from "../helpers.js"
+import { apiFetch, normalizeJobId, writeError, stripHtml } from "../helpers.js"
 
 export interface DetailApiResponse {
   id: string
@@ -87,9 +87,15 @@ export const detail = defineCommand({
   handler: async ({ positional, flags, signal }) => {
     if (signal.aborted) return
 
-    const id = positional[0] as string | undefined
-    if (!id) {
+    const rawId = positional[0] as string | undefined
+    if (!rawId) {
       writeError("Job ad ID is required", "MISSING_REQUIRED")
+      process.exit(1)
+    }
+
+    const id = normalizeJobId(rawId)
+    if (!id) {
+      writeError(`Could not parse job ad ID from "${rawId}"`, "BAD_ID")
       process.exit(1)
     }
 

--- a/.agents/skills/jobnet-search/cli/src/helpers.ts
+++ b/.agents/skills/jobnet-search/cli/src/helpers.ts
@@ -55,3 +55,13 @@ export function stripHtml(html: string): string {
     .replace(/\s+/g, " ")
     .trim()
 }
+
+export function normalizeJobId(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) return trimmed
+  const match = trimmed.match(/(?:\/find-job\/|\/JobAdDetails\/|\/Details\/)(?:detaljer\/)?([a-zA-Z0-9_-]+)(?:\/|$|\?|#)/i)
+  if (match) return match[1]
+  return null
+}
+

--- a/.agents/skills/jobnet-search/cli/tests/detail-url-normalization.test.ts
+++ b/.agents/skills/jobnet-search/cli/tests/detail-url-normalization.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeJobId } from "../src/helpers.js"
+import { runCLI } from "./helpers.js"
+
+describe("jobnet-search normalizeJobId", () => {
+  test("accepts bare numeric ID", () => {
+    expect(normalizeJobId("6123456")).toBe("6123456")
+    expect(normalizeJobId("  6123456  ")).toBe("6123456")
+  })
+
+  test("accepts alphanumeric ID", () => {
+    expect(normalizeJobId("E123456")).toBe("E123456")
+    expect(normalizeJobId("job_12345")).toBe("job_12345")
+  })
+
+  test("extracts ID from /find-job/ URL with trailing slash", () => {
+    expect(normalizeJobId("https://jobnet.dk/find-job/6123456/")).toBe("6123456")
+  })
+
+  test("extracts ID from /find-job/ URL without trailing slash", () => {
+    expect(normalizeJobId("https://jobnet.dk/find-job/6123456")).toBe("6123456")
+  })
+
+  test("extracts ID from /find-job/detaljer/ URL", () => {
+    expect(normalizeJobId("https://jobnet.dk/find-job/detaljer/6123456")).toBe("6123456")
+    expect(normalizeJobId("https://jobnet.dk/find-job/detaljer/6123456/")).toBe("6123456")
+  })
+
+  test("extracts ID from /FindJob/JobAdDetails/ URL", () => {
+    expect(normalizeJobId("https://jobnet.dk/FindJob/JobAdDetails/6123456")).toBe("6123456")
+  })
+
+  test("extracts ID from legacy /CV/FindWork/Details/ URL", () => {
+    expect(normalizeJobId("https://job.jobnet.dk/CV/FindWork/Details/6123456")).toBe("6123456")
+  })
+
+  test("extracts ID from URL with query parameters and hash fragments", () => {
+    expect(normalizeJobId("https://jobnet.dk/find-job/6123456?ref=share&utm=test")).toBe("6123456")
+    expect(normalizeJobId("https://jobnet.dk/find-job/6123456#main")).toBe("6123456")
+  })
+
+  test("rejects empty string and invalid URLs", () => {
+    expect(normalizeJobId("")).toBeNull()
+    expect(normalizeJobId("   ")).toBeNull()
+    expect(normalizeJobId("https://example.com/other/6123456")).toBeNull()
+  })
+
+  test("CLI detail command rejects invalid ID format with BAD_ID", async () => {
+    const result = await runCLI(["detail", "https://invalid.com/not-jobnet"])
+    expect(result.exitCode).toBe(1)
+    const err = JSON.parse(result.stderr)
+    expect(err.code).toBe("BAD_ID")
+  })
+})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ per-file diff commands.
 
 ### Fixed
 
+- **`jobbank-search`, `jobdanmark-search`, and `jobnet-search` detail commands now accept full URLs** -
+  the portal contract specifies `detail <id|url>`. Passing a full posting URL (with or without
+  trailing slashes, slug segments, or query parameters) previously caused `jobbank-search` and
+  `jobdanmark-search` to construct invalid double-URL strings, and `jobnet-search` to interpolate the
+  full URL into the API endpoint path. All three detail handlers now extract and normalize the
+  underlying ID or slug via dedicated helper functions, and exit 1 with code `BAD_ID` on unparseable
+  inputs, matching `linkedin-search` and `freehire-search`. Pinned by 24 unit tests across the three
+  CLIs' `detail-url-normalization.test.ts`.
+
 - **`/rank` now bounds each scoring batch** (#395) - a bare run scores at most 10
   eligible jobs instead of attempting the entire backlog. `--limit <N>` controls
   scoring independently of `--top`, and the report makes deferred work visible so


### PR DESCRIPTION
…d jobnet detail commands

<!-- Heads-up before you publish: if you built this in a personalized fork
     (your profile data, your market's job portals, another AI runtime),
     note that GitHub points new PRs at the UPSTREAM repo by default.
     Those adaptations live in forks - see CONTRIBUTING.md - and get
     discovered via the pinned "Community forks & adaptations" discussion (#78).
     Check the "base repository" dropdown above before you continue. -->

Fixes #429

## What changed and why

The portal search contract in `/add-portal.md` and `CONTRIBUTING.md` specifies `detail <id|url>`. While `linkedin-search`, `freehire-search`, and `jobindex-search` extract and normalize the ID/slug from full URLs, `jobbank-search`, `jobdanmark-search`, and `jobnet-search` previously interpolated the argument directly into URL templates or API endpoint paths without extraction. When passed a full posting URL (e.g. copied from `/scrape` output or a browser), all three CLIs crashed with `API_ERROR`, `PARSE_ERROR`, or `NOT_FOUND`.

This PR normalizes inputs across all three CLIs:
- **`jobbank-search`**: Added `normalizeJobId` in `helpers.ts` to extract numeric IDs from bare IDs, full URLs (`https://jobbank.dk/job/304212/`), URLs without trailing slashes (`https://jobbank.dk/job/304212`), URLs with company/role slug segments (`https://jobbank.dk/job/304212/acme/dev`), and query parameters. Updated `detail.ts` to use it and reject unparseable IDs with code `BAD_ID`.
- **`jobdanmark-search`**: Added `normalizeSlug` in `helpers.ts` to extract job slugs from bare slugs, full URLs (`https://jobdanmark.dk/job/<slug>/`), relative paths (`/job/<slug>`), and query strings. Updated `detail.ts` to reject unparseable slugs with `BAD_ID`.
- **`jobnet-search`**: Added `normalizeJobId` in `helpers.ts` to extract job ad IDs from bare IDs, `/find-job/<id>`, `/find-job/detaljer/<id>`, `/FindJob/JobAdDetails/<id>`, and legacy URLs (`/CV/FindWork/Details/<id>`). Updated `detail.ts` to reject unparseable IDs with `BAD_ID`.
- **`CHANGELOG.md`**: Documented the fix under `## [Unreleased]` -> `### Fixed`.

## Failing case / reproduction (for fixes)

On `master`, running the `detail` command with any full URL crashes the respective CLI:

```bash
# 1. jobbank-search: requests https://jobbank.dk/job/https://jobbank.dk/job/304212//
bun run .agents/skills/jobbank-search/cli/src/cli.ts detail "https://jobbank.dk/job/304212/"
# stderr: {"error":"Failed to fetch job page: 404 Not Found","code":"API_ERROR"}

# 2. jobdanmark-search: requests https://jobdanmark.dk/job/https://jobdanmark.dk/job/dev-123
bun run .agents/skills/jobdanmark-search/cli/src/cli.ts detail "https://jobdanmark.dk/job/software-udvikler-12345"
# stderr: {"error":"API request failed: 404 Not Found","code":"API_ERROR"}

# 3. jobnet-search: requests /FindJob/JobAdDetails/https://jobnet.dk/find-job/6123456
bun run .agents/skills/jobnet-search/cli/src/cli.ts detail "https://jobnet.dk/find-job/6123456"
# stderr: {"error":"Job ad not found","code":"NOT_FOUND"}
```

## Verification
<!-- What you ran, per CONTRIBUTING: python3 tools/lint_skills.py,
     python3 tools/check_framework_version.py, bun test / bun run typecheck
     in touched CLIs, python3 -m unittest discover -s tests -->
Ran all verification suites required by CONTRIBUTING.md:

1. Touched Portal CLIs (bun test & bun run typecheck):
jobbank-search: 41 passed, 0 failed; tsc --noEmit clean (includes 7 new tests in detail-url-normalization.test.ts)
jobdanmark-search: 50 passed, 0 failed; tsc --noEmit clean (includes 7 new tests in detail-url-normalization.test.ts)
jobnet-search: 44 passed, 0 failed; tsc --noEmit clean (includes 10 new tests in detail-url-normalization.test.ts)
Other CLIs (jobindex, linkedin, freehire): 157 passed, 0 failed; typechecks clean

2. Python Test Suite:
python -m unittest discover -s tests -p "test_*.py": 337 passed, 0 failed (OK)

3. Tool & Security Guards:
python tools/lint_skills.py: OK (9 skills, 12 commands, settings.json)
python tools/security_guards.py: OK (permissions allowlist, hooks allowlist, gitignore rules, package manifests)
python tools/check_framework_version.py: OK