### PR TITLE
chore(release): cut v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ per-file diff commands.
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-09-06
+
 ### Added
 
 - **CHANGELOG structure guard** (`tests/test_changelog_structure.py`) - every PR edits this one
@@ -1212,7 +1214,8 @@ At this baseline the framework provides:
 - **Cross-runtime support** - a root `AGENTS.md` pointer so Codex and Antigravity can
   discover the portable portal skills, with Claude Code as the reference runtime.
 
-[Unreleased]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.7.1...HEAD
+[1.7.1]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/MadsLorentzen/ai-job-search/compare/v1.4.0...v1.5.0

--- a/tests/test_changelog_structure.py
+++ b/tests/test_changelog_structure.py
@@ -24,8 +24,13 @@ CONFLICT_MARKERS = ("<<<<<<< ", "=======", ">>>>>>> ")
 
 
 def unreleased_block(text: str) -> str:
-    """The lines between `## [Unreleased]` and the next `## [` heading."""
-    start = text.index("## [Unreleased]")
+    """The lines between `## [Unreleased]` and the next `## [` heading.
+
+    An absent heading (right after a release cut) yields an empty block:
+    nothing to check is not a defect."""
+    start = text.find("## [Unreleased]")
+    if start == -1:
+        return ""
     end = text.find("\n## [", start + 1)
     return text[start:] if end == -1 else text[start:end]
 
@@ -107,6 +112,12 @@ class UnreleasedProblemsTests(unittest.TestCase):
         text = CLEAN.replace("### Fixed", "<<<<<<< HEAD\n### Fixed")
         problems = unreleased_problems(text)
         self.assertTrue(any("conflict marker" in p for p in problems), problems)
+
+    def test_missing_unreleased_section_is_not_a_defect(self):
+        # Right after a release cut there may be no [Unreleased] heading at all
+        # (the 1.7.0 cut removed it). Nothing to check is not a failure.
+        text = "# Changelog\n\n## [1.7.1] - 2026-09-06\n\n### Fixed\n\n- **A fixed thing** - described.\n"
+        self.assertEqual(unreleased_problems(text), [])
 
     def test_released_sections_are_not_inspected(self):
         # A duplicate heading in an old release is history, not a defect here.


### PR DESCRIPTION
## What changed and why

The v1.7.1 release cut, in the same shape as the 1.7.0 one (`93fb0e6`): `## [Unreleased]` rolls into `## [1.7.1] - 2026-09-06`, and the compare links at the bottom move. Two deliberate differences from the 1.7.0 cut:

- An empty `## [Unreleased]` heading stays above the release, which is Keep a Changelog's own convention and what the file has carried between releases anyway.
- The CHANGELOG structure guard from #433 raised `ValueError` on a changelog with no `[Unreleased]` heading at all, which is a legitimate post-cut state. It now treats an absent section as nothing to check. Test-first: `test_missing_unreleased_section_is_not_a_defect` errored before the fix, passes after.

Seventeen entries ship: 2 Added, 1 Security, 14 Fixed. No `framework_version` marker changed in this cycle; the methodology files are as they were in 1.7.0.

After merge: tag `v1.7.1` on the merge commit and publish the GitHub release. The release notes are drafted separately (themed title, Highlights, a "Fork maintainers: what to reconcile" section covering the `/rank` behaviour change and the two `settings.json` changes, and credits).

## Failing case / reproduction (for fixes)

Not a fix. The guard change is covered above.

## Verification

- `python -m unittest discover -s tests`: 383 OK (382 + the new guard case)
- `python tools/lint_skills.py`, `python tools/check_framework_version.py`, `python tools/security_guards.py`: all OK
- `git diff origin/master -- CHANGELOG.md`: the heading and the three link lines, nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fqqLgQSnwgWkv98twQhHi
