### PR TITLE
fix(web-research): fail loudly when $SCRATCHPAD is unset instead of writing into the repo

### DIFF
--- a/.claude/skills/job-application-assistant/09-web-research.md
+++ b/.claude/skills/job-application-assistant/09-web-research.md
@@ -1,5 +1,5 @@
 ---
-framework_version: 1.1.0
+framework_version: 1.1.1
 ---
 
 # Web Research and Fetching
@@ -48,7 +48,7 @@ Two details worth knowing, both covered by `tests/test_robots_check.py`:
 ### The retry: curl with browser headers
 
 ```bash
-cd "$SCRATCHPAD" && curl -sSL --max-time 45 -o page.html -w "HTTP %{http_code} size=%{size_download}\n" \
+cd "${SCRATCHPAD:?set this to the session scratchpad directory from your system prompt}" && curl -sSL --max-time 45 -o page.html -w "HTTP %{http_code} size=%{size_download}\n" \
  -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
  -H 'Accept-Language: en-GB,en;q=0.9' \
@@ -65,7 +65,7 @@ Write to the session scratchpad directory, never into the repo. `--compressed` i
 `WebFetch` converts to markdown for you; curl does not. Strip the tags:
 
 ```bash
-cd "$SCRATCHPAD" && python3 -c "
+cd "${SCRATCHPAD:?set this to the session scratchpad directory from your system prompt}" && python3 -c "
 import re, html
 h = open('page.html', encoding='utf-8', errors='replace').read()
 h = re.sub(r'(?is)<(script|style|noscript|svg)[^>]*>.*?</\1>', ' ', h)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ per-file diff commands.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`09-web-research.md`'s curl snippets no longer write into the repo when `$SCRATCHPAD`
+  is unset** - both runnable blocks in the 403-escalation path start with `cd "$SCRATCHPAD"`,
+  and nothing in the repository ever sets that variable (`git grep 'SCRATCHPAD='` returns
+  nothing). Unset, it expands to `cd ""`, which succeeds and leaves the shell where it
+  started, so the `&&` chain proceeds and `curl -o page.html` writes to the working
+  directory - in practice the checkout, which is exactly what the paragraph directly beneath
+  the curl block forbids ("Write to the session scratchpad directory, never into the repo").
+  The file's instruction and its own snippet disagreed, and the snippet won silently.
+  Both expansions are now guarded with `${SCRATCHPAD:?...}`, turning a silent repo write into
+  an immediate failure whose message names where the value comes from. Behaviour is unchanged
+  wherever the variable is set. The same undefined reference in `.claude/commands/rank.md`
+  was removed by #425 as a side effect of rewriting Step 2/4; this is the remaining instance.
+
 ## [1.7.1] - 2026-09-06
 
 ### Added


### PR DESCRIPTION
## The bug

`09-web-research.md` documents the escalation path for a `WebFetch` 403: check `robots.txt`, then retry with browser headers. Both runnable snippets in it begin with:

```bash
cd "$SCRATCHPAD" && ...
```

`SCRATCHPAD` is never set anywhere in the repository:

```console
$ git grep -n 'SCRATCHPAD=' -- .
$ git grep -n 'SCRATCHPAD' -- .
.claude/skills/job-application-assistant/09-web-research.md:51:cd "$SCRATCHPAD" && curl -sSL --max-time 45 -o page.html ...
.claude/skills/job-application-assistant/09-web-research.md:68:cd "$SCRATCHPAD" && python3 -c "
```

Two uses, zero definitions. It reads as a variable the harness exports, and it isn't one — the scratchpad path reaches the agent as prose in the system prompt, not as an environment variable.

## Why that is worse than a broken command

An unset variable here does not fail. `cd ""` is a no-op that succeeds:

```console
$ cd /tmp && unset SCRATCHPAD
$ ( cd "$SCRATCHPAD" && pwd ); echo "exit=$?"
/tmp
exit=0
```

So the `&&` chain proceeds and `curl -o page.html` writes to whatever directory the command was run from. For an agent following this skill mid-task, that is the repository checkout.

That is the exact outcome the paragraph immediately under the curl block forbids:

> Write to the session scratchpad directory, never into the repo.

The file's own instruction and its own snippet disagree, and the snippet wins silently. Nothing surfaces: no error, no warning, and `page.html` plus any extracted text land in the working tree where they can be staged by a later `git add`.

## The fix

Guard both expansions:

```bash
cd "${SCRATCHPAD:?set this to the session scratchpad directory from your system prompt}" && ...
```

```console
$ ( cd "${SCRATCHPAD:?set this to the session scratchpad directory from your system prompt}" && pwd ); echo "exit=$?"
bash: SCRATCHPAD: set this to the session scratchpad directory from your system prompt
exit=1
```

A silent write into the repo becomes an immediate failure whose message names where the value comes from, so the reader sets it and re-runs. Where `SCRATCHPAD` *is* set the behaviour is byte-for-byte unchanged — `${VAR:?msg}` and `$VAR` expand identically for a non-empty value.

## Why this shape

Three alternatives were considered:

- **Drop the `cd` and tell the reader to run from their scratchpad.** Leaves `page.html` relative, so the same accidental-repo-write reappears whenever the reader does not notice the instruction. The failure mode is what needs closing, not the wording.
- **Define `SCRATCHPAD` somewhere in the repo.** Introduces a harness contract that does not exist and that upstream cannot enforce across runtimes.
- **Substitute a literal path.** Not portable; the scratchpad location is per-session.

`${VAR:?msg}` is POSIX, needs no new machinery, and is a two-line change.

## Scope

One file, both occurrences. `framework_version` bumped 1.1.0 to 1.1.1, per the methodology-file convention.

Related but deliberately out of scope: the same undefined reference used to appear in `.claude/commands/rank.md`, and was removed there by #425 as a side effect of rewriting Step 2/4. This is the remaining instance.

## Verification

```console
$ python3 tools/lint_skills.py
lint_skills: OK (9 skills, 12 commands, settings.json)
$ python3 tools/security_guards.py
security_guards: OK (permissions allowlist, hooks allowlist, gitignore rules, package manifests)
$ python3 -m unittest discover -s tests
Ran 383 tests in 5.826s
OK
```

No test is added: the change is to documented shell text, which the suite does not execute. The reproduction above is the evidence, and it runs in any POSIX shell.
