### PR TITLE
Add Docker Sandboxes setup

### DIFF
--- a/.sbx/README.md
+++ b/.sbx/README.md
@@ -1,0 +1,88 @@
+# Docker Sandboxes harness
+
+This directory is the [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) (`sbx`) harness for the AI Job Search workspace. It declares a repeatable sandbox so an AI coding agent can work on the repo in an isolated microVM: its own filesystem, network, and Docker daemon, with the project mounted as the workspace.
+
+The environment file names the sandbox `ai-job-search` and launches [Claude Code](https://docs.docker.com/ai/sandboxes/agents/claude-code/) (`agent: claude`). The local mixin kit installs all required tools during the initial sandbox creation and adds them to the PATH for every sandbox shell. On the first run, you should issue the command "_Check if all necessary tools are installed_" to verify the setup. Since official Docker sandboxes can sometimes be slightly outdated, you may need to restart the sandbox shortly after its first launch once any automatic updates have completed.
+
+| File | Role |
+|------|------|
+| [`sbxenv.yaml`](sbxenv.yaml) | Project environment: sandbox name, agent, workspace (`..` = repo root), kits |
+| [`kit/spec.yaml`](kit/spec.yaml) | Mixin kit applied at sandbox creation (bun install is the first step) |
+
+`sbxenv.yaml` lives next to the kit rather than in the repo root so the harness stays in one place. Docker Sandboxes mounts that file read-only inside the sandbox.
+
+## Documentation
+
+- [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/)
+- [Install the `sbx` CLI](https://docs.docker.com/ai/sandboxes/install/)
+- [Get started](https://docs.docker.com/ai/sandboxes/get-started/)
+- [Environment files (`sbxenv.yaml`)](https://docs.docker.com/ai/sandboxes/configuration/environment-files/)
+- [Kits](https://docs.docker.com/ai/sandboxes/customize/kits/) and [kit spec reference](https://docs.docker.com/ai/sandboxes/customize/kit-reference/)
+- [Supported agents](https://docs.docker.com/ai/sandboxes/agents/)
+- [`sbx env run`](https://docs.docker.com/reference/cli/sbx/env/run/) and [`sbx run`](https://docs.docker.com/reference/cli/sbx/run/)
+
+## Prerequisites
+
+1. Install `sbx` and sign in — see the [install guide](https://docs.docker.com/ai/sandboxes/install/).
+2. Authenticate the agent. For Claude Code:
+
+   ```bash
+   sbx secret set anthropic
+   ```
+
+   Details: [Claude Code in Docker Sandboxes](https://docs.docker.com/ai/sandboxes/agents/claude-code/).
+
+## Create and run
+
+From the **repository root** (the directory that contains `.sbx`):
+
+```bash
+# Preview what will be created (no changes)
+sbx env plan .sbx
+
+# Create the sandbox, apply the kit, do not attach
+sbx env create .sbx
+
+# Create if needed, then attach to Claude Code
+sbx env run .sbx
+```
+
+`sbx` shows an environment plan and asks for approval before the first apply. Pass `-y` / `--auto-approve` to skip the prompt for that invocation.
+
+The workspace is the repository root. Later `sbx env run .sbx` reattaches to the existing `ai-job-search` sandbox; kit install steps do not run again until you recreate it.
+
+```bash
+# Run a command in the existing environment (no lifecycle hooks).
+# exec does not start a shell, so bun is not on PATH unless you wrap in bash
+# (that sources /etc/sandbox-persistent.sh).
+sbx env exec .sbx -- uname -a
+sbx env exec .sbx -- bash -c 'bun --version'
+
+# Interactive session; useful for tuning the environment
+sbx env exec -it .sbx -- bash
+
+# List sandboxes
+sbx ls
+
+# Remove the sandbox and its scoped resources
+sbx env rm .sbx
+```
+
+After changing kits, ports, or `sandboxOptions`, remove and create again — those fields apply only at creation.
+
+## Run without the environment file
+
+`sbx env` has no `--agent` flag; the agent comes from `sbxenv.yaml`. To pass an agent on the command line, use `sbx run` / `sbx create`. The first argument is a built-in name or a `kind: sandbox` kit (local path, zip, git URL, or OCI ref). `--kit` adds mixins such as this project's kit:
+
+```bash
+sbx run claude . --kit ./.sbx/kit
+sbx run ./path/to/my-agent/ . --kit ./.sbx/kit
+```
+
+Relative kit paths must start with `./` or `../`. A bare name is a built-in agent, not a local directory.
+
+To change the env-file agent without editing `sbxenv.yaml`, merge a later file (`agent:` is a scalar, so the later file wins):
+
+```bash
+sbx env run .sbx ./override.sbxenv.yaml
+```

--- a/.sbx/kit/spec.yaml
+++ b/.sbx/kit/spec.yaml
@@ -1,0 +1,58 @@
+schemaVersion: "2"
+kind: mixin
+name: ai-job-search
+displayName: AI Job Search
+description: Project kit for the AI Job Search sandbox
+
+permissions:
+  network:
+    allow:
+      - "**"
+
+setup:
+  install:
+    - command: "apt-get update && apt-get install -y poppler-utils python3-pypdf xz-utils perl"
+      user: "0"
+      description: Install poppler-utils, python3-pypdf, xz-utils, and perl
+    - command: "curl -fsSL https://bun.sh/install | bash"
+      user: "1000"
+      description: Install bun
+    - command: |
+        cat >> /etc/sandbox-persistent.sh <<'EOF'
+        export BUN_INSTALL="$HOME/.bun"
+        export PATH="$BUN_INSTALL/bin:$PATH"
+        if [ -d "$HOME/.TinyTeX/bin" ]; then
+          for d in "$HOME/.TinyTeX/bin"/*; do
+            [ -d "$d" ] && export PATH="$d:$PATH"
+          done
+        fi
+        EOF
+      user: "1000"
+      description: Put bun and TinyTeX on PATH for every shell
+    - command: |
+        mkdir -p "$HOME/.local/bin"
+        curl -sL "https://tinytex.yihui.org/install-bin-unix.sh" | sh
+      user: "1000"
+      description: Install TinyTeX
+    - command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        if [ -d "$HOME/.TinyTeX/bin" ]; then
+          for d in "$HOME/.TinyTeX/bin"/*; do
+            [ -d "$d" ] && export PATH="$d:$PATH"
+          done
+        fi
+        tlmgr install \
+          moderncv fontawesome5 fontawesome6 academicons import luatexbase pgf \
+          titlesec textpos xltxtra xunicode cite realscripts needspace
+      user: "1000"
+      description: Install LaTeX packages for CVs and cover letters
+
+agentInstructions:
+  content: |
+    Apt packages already installed:
+    - `poppler-utils` - `pdftotext`, `pdfinfo`, `pdftoppm` (ATS PDF text-layer checks)
+    - `python3-pypdf` - Python `pypdf` (`tools/verify_pdf.py`)
+    - `xz-utils` - `xz` / `unxz` (TinyTeX `.tar.xz` bundles)
+    - `perl` - required by the TinyTeX installer
+    bun is installed at `$HOME/.bun` and on PATH. Use `bun` for JavaScript/TypeScript tooling.
+    TinyTeX is installed at `$HOME/.TinyTeX` and on PATH (`xelatex`, `lualatex`, `pdflatex`, `tlmgr`).

--- a/.sbx/sbxenv.yaml
+++ b/.sbx/sbxenv.yaml
@@ -1,0 +1,7 @@
+schemaVersion: "1"
+name: ai-job-search
+agent: claude
+workspace: ..
+
+kits:
+  - ./kit

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The framework encodes career guidance best practices, including structured evalu
 
 ## Prerequisites
 
+The easiest way to run the project is using [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/install/). Install it and issue `sbx env run .sbx`. See [`README.md`](.sbx/README.md). Otherwise, see the instructions below. 
+
 - [Claude Code](https://claude.com/claude-code) (CLI). Using a different agent tool (Codex, Antigravity, Gemini CLI)? Start at [`AGENTS.md`](AGENTS.md) - the portal search skills work there out of the box, and [community forks](https://github.com/MadsLorentzen/ai-job-search/discussions/78) adapt the full workflow.
 - Python 3.10+
 - [Bun](https://bun.sh) (for job search CLI tools)


### PR DESCRIPTION
## What changed and why

The Docker Sandboxes setup has been added to provide a seamless and secure way to run the project.

## Verification
* Install Docker Sandbox from [https://docs.docker.com/ai/sandboxes/install/](https://docs.docker.com/ai/sandboxes/install/)
* Run `sbx env rm .sbx`
* Issue: "Check if all necessary tools are installed"

You probably need to authenticate Claude inside the sandbox first