### PR TITLE
fix(jobindex-search): reject non-jobindex detail URLs instead of fetching them verbatim

### DIFF
--- a/.agents/skills/jobindex-search/cli/src/commands/detail.ts
+++ b/.agents/skills/jobindex-search/cli/src/commands/detail.ts
@@ -60,23 +60,38 @@ function stripTags(html: string): string {
 }
 
 /**
- * Extract job ID from URL or return as-is if already an ID
+ * Parse a detail invocation's <id|url> into a canonical fetch target, or null.
+ *
+ * This is the gate between a stored (untrusted) URL and a network fetch, so it
+ * must never trust the raw string: the previous version fetched any http(s)
+ * URL verbatim and, when the path didn't match, used the whole input URL as
+ * the id - a non-posting page (a redirect target, a look-alike host, the
+ * homepage) came back as a well-formed fake posting with exit 0 (#447). A URL
+ * input now needs a jobindex.dk host (apex or subdomain) and a
+ * /jobannonce/<id> path, and the fetch URL is rebuilt from the extracted id -
+ * the canonical short form the bare-id path always used. A bare id stays a
+ * permissive scheme- and slash-free token (the jobnet precedent): the server
+ * 404s unknowns loudly, which is the honest failure. Exported for tests.
  */
-function extractIdFromUrl(url: string): string {
-  // Match IDs like h1647303, r13677312, etc.
-  const match = url.match(/\/jobannonce\/([a-zA-Z]\d+)/)
-  if (match) return match[1]
-  return url
-}
-
-function buildUrl(idOrUrl: string): { url: string; id: string } {
-  if (idOrUrl.startsWith("http")) {
-    const id = extractIdFromUrl(idOrUrl)
-    return { url: idOrUrl, id }
+export function buildUrl(idOrUrl: string): { url: string; id: string } | null {
+  const trimmed = idOrUrl.trim()
+  if (/^https?:\/\//i.test(trimmed)) {
+    let host: string
+    try {
+      host = new URL(trimmed).hostname.toLowerCase()
+    } catch {
+      return null
+    }
+    if (host !== "jobindex.dk" && !host.endsWith(".jobindex.dk")) return null
+    // Match IDs like h1647303, r13677312, etc.
+    const match = trimmed.match(/\/jobannonce\/([a-zA-Z]\d+)/)
+    if (!match) return null
+    return { url: `${BASE_URL}/jobannonce/${match[1]}`, id: match[1] }
   }
-  // It's a bare ID
-  const url = `${BASE_URL}/jobannonce/${idOrUrl}`
-  return { url, id: idOrUrl }
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    return { url: `${BASE_URL}/jobannonce/${trimmed}`, id: trimmed }
+  }
+  return null
 }
 
 const DANISH_MONTHS: Record<string, string> = {
@@ -262,7 +277,15 @@ export const detail = defineCommand({
       process.exit(1)
     }
 
-    const { url, id } = buildUrl(idArg)
+    const parsed = buildUrl(idArg)
+    if (!parsed) {
+      writeError(
+        `Could not parse a jobindex job id or jobannonce URL from "${idArg}"`,
+        "BAD_ID",
+      )
+      process.exit(1)
+    }
+    const { url, id } = parsed
 
     try {
       const html = await htmlFetch(url)

--- a/.agents/skills/jobindex-search/cli/tests/detail-input.test.ts
+++ b/.agents/skills/jobindex-search/cli/tests/detail-input.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { buildUrl } from "../src/commands/detail";
+
+// buildUrl is the gate between a stored (untrusted) URL and a network fetch.
+// It must yield a canonical jobindex fetch target or null (-> BAD_ID) - never
+// the raw input. The unguarded version fetched any http(s) URL verbatim and,
+// when the path didn't match, used the whole input URL as the id, so a
+// non-posting page came back as a well-formed fake posting with exit 0 (#447).
+
+describe("jobindex detail input parsing", () => {
+  test("canonical URL with title slug", () => {
+    expect(buildUrl("https://www.jobindex.dk/jobannonce/h1647303/senior-data-engineer")).toEqual({
+      url: "https://www.jobindex.dk/jobannonce/h1647303",
+      id: "h1647303",
+    });
+  });
+
+  test("trailing slash and query string variants", () => {
+    expect(buildUrl("https://www.jobindex.dk/jobannonce/r13677312/")?.id).toBe("r13677312");
+    expect(buildUrl("https://www.jobindex.dk/jobannonce/h1647303?utm_source=x")?.id).toBe("h1647303");
+  });
+
+  test("jobindex subdomains and bare apex are accepted", () => {
+    expect(buildUrl("https://it.jobindex.dk/jobannonce/h1647303")?.id).toBe("h1647303");
+    expect(buildUrl("https://jobindex.dk/jobannonce/h1647303")?.id).toBe("h1647303");
+  });
+
+  test("a bare id builds the canonical URL (server 404s unknowns loudly)", () => {
+    expect(buildUrl("h1647303")).toEqual({
+      url: "https://www.jobindex.dk/jobannonce/h1647303",
+      id: "h1647303",
+    });
+  });
+
+  test("an off-host URL is rejected, not fetched", () => {
+    expect(buildUrl("https://evil.example/jobannonce/h1647303")).toBeNull();
+  });
+
+  test("look-alike and userinfo hosts are rejected", () => {
+    expect(buildUrl("https://jobindex.dk.evil.example/jobannonce/h1647303")).toBeNull();
+    expect(buildUrl("https://www.jobindex.dk@evil.example/jobannonce/h1647303")).toBeNull();
+  });
+
+  test("an own-host URL without a jobannonce id is rejected (the fake-posting repro)", () => {
+    expect(buildUrl("https://www.jobindex.dk/")).toBeNull();
+  });
+
+  test("garbage bare input is rejected", () => {
+    expect(buildUrl("not a slug!")).toBeNull();
+    expect(buildUrl("ftp://www.jobindex.dk/jobannonce/h1")).toBeNull();
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,25 @@ per-file diff commands.
 
 ### Fixed
 
+- **`jobindex-search detail` no longer fetches arbitrary URLs or invents posting-shaped
+  output** (#447) - the command fetched any `http(s)` input verbatim (no host check) and,
+  when the path didn't match its one pattern, silently used the whole input URL as the job
+  id; the only net was "the fetched page has a title", so a non-posting page came back as
+  a well-formed fake posting with exit 0 (demonstrated with jobindex's own homepage:
+  `id` = the URL, `title` = the site's tagline, `description` = navigation chrome). Every
+  other portal CLI rejects unparseable detail input with `BAD_ID` and constructs its fetch
+  URL from the extracted id; jobindex was the one CLI trusting the raw string - and
+  `/scrape`/`/rank` agents feed it stored URLs, so a ghost or redirected URL (the #331
+  class) yielded plausible garbage instead of an error. `buildUrl` now requires a
+  jobindex.dk host (apex or subdomain - look-alike and userinfo tricks rejected via real
+  URL parsing) plus a `/jobannonce/<id>` path, rebuilds the fetch URL from the extracted
+  id (the canonical short form the bare-id path always used), and exits 1 with the
+  stderr-JSON `BAD_ID` contract otherwise; bare ids stay permissive scheme- and
+  slash-free tokens (the jobnet precedent - the server 404s unknowns loudly). Pinned by
+  eight cases in the new `detail-input.test.ts`; the five rejection/canonicalization
+  cases fail against the verbatim unguarded extraction. Complementary to the `/apply`
+  host-check rule proposed in #431, which stays with its proposer.
+
 - **`/outcome` and `/interview` no longer confuse two roles at the same company** (#443)
   (`.claude/commands/outcome.md`, `.claude/commands/interview.md`,
   `tests/test_apply_records_application.py`) - when a tracker row's `cv_file` /


### PR DESCRIPTION
Fixes #447, filed with the live repro an hour ago.

## What changed and why

`jobindex-search detail` fetched any `http(s)` input verbatim - `startsWith("http")` was the only gate - and when the path didn't match its one pattern, `extractIdFromUrl` fell back to returning the *whole input URL* as the job id. No host check, no `BAD_ID` path, and the only downstream net was "the fetched page has a `<title>`". Result: posting-shaped output manufactured from non-posting pages. Every other portal CLI rejects unparseable detail input with the stderr-JSON `BAD_ID` contract and constructs its fetch URL from the extracted id; jobindex was the one CLI trusting the raw string, and it is `/scrape` Step 2 and `/rank` agents that feed it stored URLs - so a ghost or redirected URL (the #331 class) returned plausible, well-formed garbage instead of an error.

`buildUrl` is now the explicit trust gate, exported for tests (the jobnet pattern):

- A URL input must have a **jobindex.dk host** (apex or subdomain; hosts come from real `URL` parsing, so look-alike suffix tricks and userinfo tricks from #431's catalogue are rejected) **and** a parseable `/jobannonce/<id>` path.
- The fetch URL is **rebuilt from the extracted id** - the canonical short form the bare-id path always used - never taken from the raw input. (Behavior note, stated rather than hidden: query strings and title slugs on accepted URLs are now dropped in the fetch; the server serves the id-only form, which is what bare-id invocations always fetched.)
- Everything else exits 1 with `BAD_ID`, matching the other five CLIs. A bare id stays a permissive scheme- and slash-free token (the jobnet precedent) since the server 404s unknowns loudly.

Deliberately not touched: the `/apply` Step 1 host-check rule proposed in #431 - that is spec-level, reserved for its proposer, and complementary to this CLI-level gate.

## Failing case / reproduction (for fixes)

From #447, on jobindex's own host: `detail "https://www.jobindex.dk/"` returned exit 0 and a fake posting whose `id` was the URL, whose `title` was the site's marketing tagline, and whose `description` was homepage navigation chrome. On this branch the same invocation exits 1 with `BAD_ID` before any fetch; `detail "https://evil.example/jobannonce/h1647303"` is likewise rejected at the gate with no network; and a live end-to-end check on a real posting (`h1688674`, found via one search request) still resolves with full detail.

The helpers were exported verbatim first (pure refactor) and the new tests run against that: the 5 rejection/canonicalization cases fail, pinning the old behavior as the bug. With the fix: 59/59 CLI tests.

## Verification

- `bun test` in `jobindex-search/cli`: 59 pass / 0 fail; `bun run typecheck` clean (run directly, not through a pipe).
- Fail-on-unfixed as above (5/8 new cases fail against the verbatim extraction).
- Live: the #447 repro now `BAD_ID` exit 1; off-host rejected with no request; real posting detail intact.
- `python3 -m unittest discover -s tests` (429 tests), `lint_skills.py`, `security_guards.py`: all OK - including the new `test_changelog_structure.py`, which correctly rejected my first CHANGELOG placement (duplicate `### Fixed` heading) before this went up; folded into the existing section.
