### PR TITLE
Add xing-search portal skill

### DIFF
--- a/.agents/skills/xing-search/SKILL.md
+++ b/.agents/skills/xing-search/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: xing-search
+version: 1.0.0
+description: >
+  Use this skill whenever the user wants to search for jobs on Xing, the
+  DACH-market (Germany, Austria, Switzerland) professional network, find job
+  listings there, or look up a specific Xing job posting. Trigger phrases:
+  Xing jobs, search Xing, Xing Stellenanzeigen, Jobsuche Xing, Stellenangebote
+  Xing, look up this Xing job posting.
+context: fork
+enabled: true  # set to false to keep this portal installed but have /scrape skip it
+allowed-tools: Bash(bun run .agents/skills/xing-search/cli/src/cli.ts *)
+---
+
+# Xing Search Skill
+
+Find job listings on **Xing** (xing.com), the DACH-market professional network,
+without authentication and with **zero runtime dependencies** — it runs with just
+`bun`.
+
+## ⚠️ Access-rules note (read before use)
+
+Xing's `/jobs/search/` page and its GraphQL API are disallowed by `robots.txt` for
+every crawler — including the `ClaudeBot`/`GPTBot`/`PerplexityBot` group that
+`robots.txt` otherwise explicitly permits on `/jobs/search/` (that carve-out doesn't
+actually help: the page it names is a client-rendered shell with no server-side job
+data, all of which lives behind the disallowed GraphQL calls). This skill **never
+touches either of those** — it works entirely from Xing's public job-URL sitemap
+(`xing.com/jobs/sitemap.xml.gz`) and individual job detail pages, both of which
+`robots.txt`'s generic `User-agent: *` block leaves open to any crawler. See
+`url-reference.md` for the full breakdown.
+
+Even though this path is robots.txt-compliant, **keep volume low** and run it on
+your own responsibility — the sitemap sync alone is a larger one-time download
+(~14MB compressed, cached 24h) than any other portal skill in this repo makes in
+a single call.
+
+## How search actually works here
+
+Xing has no lightweight keyword-search endpoint. `search` instead:
+1. Downloads and locally caches (24h TTL) Xing's full job-posting sitemap — a flat
+   list of job URLs, no keyword filter of its own.
+2. Keyword-matches the query (and optional `--location`) against each URL's slug.
+3. Fetches a bounded number of the most-likely-newest matches (highest job ID
+   first) and verifies each one's real detail page — confirming it's still live
+   and pulling the actual title/company/location/date.
+
+The sitemap keeps years-old expired postings mixed in with current ones, so a
+search can legitimately return fewer results than `--limit` if the probe budget
+runs out before enough live matches turn up. Treat a thin/empty result the way
+`../job-scraper/SKILL.md` treats any other stale-listing signal — not as a bug.
+
+## Commands
+
+### Search job listings
+
+```bash
+bun run .agents/skills/xing-search/cli/src/cli.ts search --query "<text>" [flags]
+```
+
+Key flags:
+- `--query <text>` / `-q <text>` — **required.** Keywords (title, skill, role).
+- `--location <text>` / `-l <text>` — city/region additionally required in the slug match, e.g. `"Frankfurt"`, `"Köln"`.
+- `--jobage <days>` — posted within N days, checked against each fetched candidate's real posting date.
+- `--page <n>` — 1-indexed page over the matched candidate list.
+- `--limit <n>` / `-n <n>` — max results to return. Default `20`.
+- `--format json|table|plain` — default `json`.
+
+### Fetch full job detail
+
+```bash
+bun run .agents/skills/xing-search/cli/src/cli.ts detail <id|url> [--format json|plain]
+```
+
+`id` is the full slug from `search` results (e.g.
+`koeln-ot-cyber-security-senior-consultant-122981029`), or a full `xing.com/jobs/...`
+URL. Xing's trailing numeric ID **alone** does not reliably resolve to the same
+posting — pass the id/url exactly as `search` returned it.
+
+## Usage examples
+
+```bash
+# Embedded software roles
+bun run .agents/skills/xing-search/cli/src/cli.ts search -q "Embedded Software Engineer" --format table
+
+# Project-lead roles in Frankfurt, last 14 days
+bun run .agents/skills/xing-search/cli/src/cli.ts search -q "Projektleiter" -l "Frankfurt" --jobage 14 --format table
+
+# Full detail for one job
+bun run .agents/skills/xing-search/cli/src/cli.ts detail koeln-ot-cyber-security-senior-consultant-122981029 --format plain
+```
+
+## Output formats
+
+| Format | Best for |
+|--------|----------|
+| `json` | Default — programmatic use, passing ids to `detail` |
+| `table` | Quick human-readable scanning |
+| `plain` | Reading a single job's full detail (`detail` command) |
+
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` and the process exits with code `1`.
+
+## Notes
+
+- Data source: Xing's public job sitemap + server-rendered `JobPosting` JSON-LD detail pages. No credentials required.
+- First `search` call syncs the full sitemap (~14MB compressed, cached 24h under `cli/.cache/`); later calls within the TTL reuse the cache.
+- `date` in `search`/`detail` output is the posting's real `datePosted` from its detail page — never the sitemap's `<lastmod>`, which was verified live to reflect Xing's last sitemap-regeneration touch, not the posting date.
+- `detail`'s `isActive` is `true`/`false` from comparing `validThrough` to now, or `null` when Xing gave no `validThrough` — never inferred.

--- a/.agents/skills/xing-search/cli/README.md
+++ b/.agents/skills/xing-search/cli/README.md
@@ -1,0 +1,85 @@
+# xing-cli
+
+CLI for finding jobs on **Xing** (xing.com), the DACH-market (Germany, Austria,
+Switzerland) professional network.
+
+**Data source**: Xing's job-URL sitemap (`xing.com/jobs/sitemap.xml.gz`, 13 shards,
+~650k URLs) cached locally and keyword-matched, then verified against each
+candidate's server-rendered detail page (`schema.org` `JobPosting` JSON-LD).
+**Authentication**: None required.
+**Dependencies**: None (plain `bun` + `fetch` + `node:zlib`/`node:fs`). `bun install`
+is optional and only pulls dev type defs.
+
+> **Personal use only.** Xing's own `/jobs/search/` page and its GraphQL API are
+> robots.txt-disallowed for every crawler, so this CLI never touches them — it only
+> reads the sitemap and detail pages, which robots.txt leaves open to any crawler.
+> Even so, keep volume low and run it on your own responsibility; see `../SKILL.md`
+> and `../url-reference.md` for the full access-rules writeup.
+
+## Why this CLI works differently from the other portal skills
+
+Xing's job search is a client-rendered SPA with no server-side job data, backed by a
+GraphQL API robots.txt disallows outright. There is no lightweight "search by
+keyword" endpoint to call. Instead, `search` here:
+
+1. Downloads (and caches for 24h) Xing's full job-posting sitemap — a flat list of
+   job URLs with no keyword filter of its own.
+2. Keyword-matches the query (and optional `--location`) as substrings against each
+   URL's slug.
+3. Fetches a bounded number of the most-likely-newest matches (highest numeric job
+   ID first — IDs are issued roughly sequentially) and parses each one's real
+   `JobPosting` JSON-LD to get the title/company/location/date and confirm it's
+   still live (`validThrough` hasn't passed).
+
+The sitemap keeps years-old expired postings mixed in with current ones, so a
+`search` call can return fewer than `--limit` results if the probe budget (15–30
+detail fetches, scaled off `--limit`) runs out before enough live matches turn up.
+That's expected — see `../../job-scraper/SKILL.md`'s ghost-job handling for how a
+run downstream should treat a thin or empty result set.
+
+## Installation
+
+```bash
+cd .agents/skills/xing-search/cli
+bun install   # optional — only installs TypeScript dev types
+```
+
+The CLI runs without any install because it has zero runtime dependencies. The first
+`search` call downloads and caches the full sitemap (~14MB compressed); subsequent
+calls within 24h reuse the cache.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `search` | Keyword-match + verify jobs from the cached sitemap (`--query` required) |
+| `detail` | Fetch full detail for a single job listing |
+
+`search` accepts `--format json|table|plain` (default `json`); `detail` accepts `--format json|plain`.
+All errors are written to **stderr** as `{ "error": "...", "code": "..." }` with exit code `1`.
+
+## Quick examples
+
+```bash
+# Embedded software roles, table view
+bun run src/cli.ts search -q "Embedded Software Engineer" --format table
+
+# Project-lead roles in Frankfurt, last 14 days
+bun run src/cli.ts search -q "Projektleiter" -l "Frankfurt" --jobage 14 --format table
+
+# Full detail for one job (id is the full slug, not just the trailing number)
+bun run src/cli.ts detail koeln-ot-cyber-security-senior-consultant-122981029 --format plain
+```
+
+See `../SKILL.md` for the full flag reference and access-rules note.
+
+## Search flags
+
+| Flag | Alias | Description |
+|------|-------|-------------|
+| `--query` | `-q` | **Required.** Keywords (title / skill / role). |
+| `--location` | `-l` | City/region additionally required in the slug match, e.g. `"Frankfurt"`, `"Köln"`. |
+| `--jobage` | | Posted within N days, checked against each fetched candidate's real `datePosted`. |
+| `--page` | | 1-indexed page over the matched candidate list. |
+| `--limit` | `-n` | Max results to return. Default `20`. |
+| `--format` | | `json` \| `table` \| `plain`. |

--- a/.agents/skills/xing-search/cli/package.json
+++ b/.agents/skills/xing-search/cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "xing-cli",
+  "version": "1.0.0",
+  "description": "CLI for finding jobs on Xing (xing.com, DACH market) via its public job-URL sitemap and server-rendered detail pages — no authentication, zero runtime dependencies. Personal use only.",
+  "type": "module",
+  "main": "src/cli.ts",
+  "bin": {
+    "xing-search": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test --timeout 30000",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/bun": "1.3.14"
+  }
+}

--- a/.agents/skills/xing-search/cli/src/cli.ts
+++ b/.agents/skills/xing-search/cli/src/cli.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+// Self-contained CLI for finding jobs on Xing (xing.com), the DACH-market
+// professional network. No official search API is reachable without violating
+// robots.txt (see helpers.ts for the full data-source note), so this works by
+// caching Xing's own job-URL sitemap and keyword-matching + verifying against
+// real detail pages. Zero runtime dependencies beyond `bun` and `node:zlib`/`node:fs`.
+//
+// Personal use only. Keep volume low and do not use this commercially or for bulk
+// data collection. Run it on your own responsibility.
+
+import { runSearch, type SearchOpts } from "./commands/search.js"
+import { runDetail, type DetailOpts } from "./commands/detail.js"
+
+interface Flags {
+  _: string[]
+  [k: string]: string | boolean | string[]
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = { _: [] }
+  const alias: Record<string, string> = { q: "query", l: "location", n: "limit" }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith("--") || a.startsWith("-")) {
+      const key = alias[a.replace(/^-+/, "")] ?? a.replace(/^-+/, "")
+      const next = argv[i + 1]
+      if (next === undefined || next.startsWith("-")) {
+        flags[key] = true
+      } else {
+        flags[key] = next
+        i++
+      }
+    } else {
+      ;(flags._ as string[]).push(a)
+    }
+  }
+  return flags
+}
+
+const HELP = `xing-cli — search jobs on Xing (xing.com, DACH market)
+
+USAGE
+  bun run src/cli.ts search --query "<text>" [flags]
+  bun run src/cli.ts detail <id|url> [--format json|plain]
+
+SEARCH FLAGS
+  --query, -q <text>      Keywords (job title, skill, role). REQUIRED.
+  --location, -l <text>   City/region to additionally require in the match, e.g. "Frankfurt", "Köln".
+  --jobage <days>         Posted within N days. Default: all (subject to --limit/probe budget).
+  --page <n>              1-indexed page over the matched candidate list. Default 1.
+  --limit, -n <n>         Max results to return. Default 20.
+  --format <fmt>          json (default) | table | plain.
+
+EXAMPLES
+  bun run src/cli.ts search -q "Embedded Software Engineer" --format table
+  bun run src/cli.ts search -q "Projektleiter" -l "Frankfurt" --jobage 14 --format table
+  bun run src/cli.ts detail koeln-ot-cyber-security-senior-consultant-122981029 --format plain
+
+Personal use only — uses Xing's public sitemap and job detail pages; keep volume low.
+`
+
+const KNOWN_FLAGS: Record<string, Set<string>> = {
+  search: new Set(["query", "location", "jobage", "page", "limit", "format", "help", "h"]),
+  detail: new Set(["format", "help", "h"]),
+}
+
+async function main(): Promise<number> {
+  const argv = process.argv.slice(2)
+  const flags = parseFlags(argv)
+  const cmd = (flags._ as string[])[0]
+
+  if (!cmd || flags.help || flags.h) {
+    process.stdout.write(HELP)
+    return cmd ? 0 : 1
+  }
+
+  const knownFlags = KNOWN_FLAGS[cmd]
+  if (knownFlags) {
+    for (const key of Object.keys(flags)) {
+      if (key === "_" || knownFlags.has(key)) continue
+      process.stderr.write(
+        JSON.stringify({
+          error: `unknown flag --${key} for '${cmd}' - flags are never silently ignored, because a discarded filter changes what the search returns; see --help for the supported flags`,
+          code: "UNKNOWN_FLAG",
+        }) + "\n",
+      )
+      return 1
+    }
+  }
+
+  const parseIntFlag = (name: string, raw: string | boolean | string[]): number | null => {
+    const val = typeof raw === "string" ? Number(raw.trim()) : NaN
+    if (!Number.isInteger(val) || val < 0) {
+      process.stderr.write(
+        JSON.stringify({ error: `--${name} must be a whole number of at least 0, got "${raw}"`, code: "BAD_ARG" }) + "\n",
+      )
+      return null
+    }
+    return val
+  }
+
+  if (cmd === "search") {
+    const query = typeof flags.query === "string" ? flags.query : undefined
+    if (!query) {
+      process.stderr.write(
+        JSON.stringify({ error: "the --query/-q flag is required", code: "NO_QUERY" }) + "\n",
+      )
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+
+    for (const [name, val] of [
+      ["jobage", flags.jobage],
+      ["page", flags.page],
+      ["limit", flags.limit],
+    ] as const) {
+      if (val !== undefined && parseIntFlag(name, val) === null) return 1
+    }
+
+    const opts: SearchOpts = {
+      query,
+      location: typeof flags.location === "string" ? flags.location : undefined,
+      jobage: flags.jobage ? parseInt(flags.jobage as string, 10) : undefined,
+      page: flags.page ? Math.max(1, parseInt(flags.page as string, 10)) : 1,
+      limit: flags.limit ? Math.max(0, parseInt(flags.limit as string, 10)) : 20,
+      format: (["json", "table", "plain"].includes(fmt) ? fmt : "json") as SearchOpts["format"],
+    }
+    return runSearch(opts)
+  }
+
+  if (cmd === "detail") {
+    const id = (flags._ as string[])[1]
+    if (!id) {
+      process.stderr.write(JSON.stringify({ error: "detail requires an <id|url>", code: "NO_ID" }) + "\n")
+      return 1
+    }
+    const fmt = (flags.format as string) || "json"
+    const opts: DetailOpts = {
+      id,
+      format: (fmt === "plain" ? "plain" : "json") as DetailOpts["format"],
+    }
+    return runDetail(opts)
+  }
+
+  process.stderr.write(JSON.stringify({ error: `Unknown command "${cmd}"`, code: "BAD_CMD" }) + "\n")
+  return 1
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write(
+      JSON.stringify({
+        error: e instanceof Error ? e.message : String(e),
+        code: "INTERNAL_ERROR",
+      }) + "\n",
+    )
+    process.exit(1)
+  })

--- a/.agents/skills/xing-search/cli/src/commands/detail.ts
+++ b/.agents/skills/xing-search/cli/src/commands/detail.ts
@@ -1,0 +1,76 @@
+import { JOBS_BASE_URL, fetchText, parseJobDetail, writeError } from "../helpers.js"
+
+export interface DetailOpts {
+  id: string
+  format: "json" | "plain"
+}
+
+/**
+ * Accept a full xing.com job URL, or the bare slug (path segment after /jobs/)
+ * as returned in `search` results' `id` field. Xing's trailing numeric ID alone
+ * does NOT reliably resolve to the same posting (verified live: /jobs/<number>
+ * without its slug words served a completely different job) - the full slug is
+ * required, not just the number at its end.
+ */
+export function normalizeUrl(input: string): string | null {
+  const trimmed = input.trim()
+  if (/^https?:\/\/(www\.)?xing\.com\/jobs\/[^/?#]+/i.test(trimmed)) {
+    return trimmed.replace(/^http:/i, "https:").split(/[?#]/)[0]
+  }
+  if (/^[a-z0-9]+(-[a-z0-9]+)*-\d+$/i.test(trimmed)) {
+    return `${JOBS_BASE_URL}/${trimmed}`
+  }
+  return null
+}
+
+export async function runDetail(opts: DetailOpts): Promise<number> {
+  const url = normalizeUrl(opts.id)
+  if (!url) {
+    writeError(
+      `Could not resolve a Xing job URL from "${opts.id}" - Xing requires the full slug ` +
+        `(e.g. "koeln-ot-cyber-security-senior-consultant-122981029"), not just the trailing ` +
+        `numeric ID; pass the id/url exactly as returned by search`,
+      "BAD_ID",
+    )
+    return 1
+  }
+  try {
+    const html = await fetchText(url)
+    if (!html) {
+      writeError("Job not found (404/410 - likely removed)", "NOT_FOUND")
+      return 1
+    }
+    const id = url.split("/").filter(Boolean).pop()!
+    const detail = parseJobDetail(html, id, url)
+    if (!detail) {
+      writeError("Could not parse job details from the response - Xing may have changed its markup", "PARSE_FAILED")
+      return 1
+    }
+
+    if (opts.format === "plain") {
+      const activeLine =
+        detail.isActive === null ? "Status: UNKNOWN (no validThrough on the posting)" : `Status: ${detail.isActive ? "ACTIVE" : "EXPIRED"}`
+      const lines = [
+        detail.title,
+        `${detail.company || "—"} · ${detail.location || "—"}`,
+        "",
+        detail.employmentType ? `Employment: ${detail.employmentType}` : "",
+        detail.industry ? `Industry: ${detail.industry}` : "",
+        detail.date ? `Posted: ${detail.date}` : "",
+        detail.validThrough ? `Valid through: ${detail.validThrough}` : "",
+        activeLine,
+        "",
+        detail.description || "(no description)",
+        "",
+        `URL: ${detail.url}`,
+      ].filter((l) => l !== "")
+      process.stdout.write(lines.join("\n") + "\n")
+    } else {
+      process.stdout.write(JSON.stringify(detail, null, 2) + "\n")
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "DETAIL_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/xing-search/cli/src/commands/search.ts
+++ b/.agents/skills/xing-search/cli/src/commands/search.ts
@@ -1,0 +1,107 @@
+import { fetchText, loadSitemap, matchSitemap, parseJobDetail, slugify, writeError, type JobCard } from "../helpers.js"
+
+export interface SearchOpts {
+  query: string
+  location?: string
+  jobage?: number // days; undefined = no filter
+  page: number
+  limit: number
+  format: "json" | "table" | "plain"
+}
+
+// Keep per-call live traffic to Xing low regardless of --limit: the sitemap mixes
+// years of expired postings with current ones (see helpers.ts), so most keyword
+// matches need to be probed via a real fetch before we know whether they're live -
+// this bounds that probing instead of letting a broad query fan out unboundedly.
+const PROBE_MIN = 15
+const PROBE_MAX = 30
+
+function renderTable(cards: JobCard[]): string {
+  if (cards.length === 0) return "No results."
+  const rows = cards.map((c) => {
+    const title = (c.title || "").slice(0, 42).padEnd(42)
+    const company = (c.company || "—").slice(0, 26).padEnd(26)
+    const loc = (c.location || "—").slice(0, 24).padEnd(24)
+    const date = (c.date || "—").slice(0, 10)
+    return `${title} ${company} ${loc} ${date}`
+  })
+  const header = "TITLE".padEnd(42) + " " + "COMPANY".padEnd(26) + " " + "LOCATION".padEnd(24) + " DATE"
+  return [header, "-".repeat(header.length), ...rows].join("\n")
+}
+
+export async function runSearch(opts: SearchOpts): Promise<number> {
+  try {
+    const queryWords = opts.query.split(/\s+/).filter(Boolean).map(slugify).filter(Boolean)
+    if (queryWords.length === 0) {
+      writeError("--query must contain at least one searchable word", "BAD_ARG")
+      return 1
+    }
+    const locationWords = opts.location ? [slugify(opts.location)].filter(Boolean) : []
+
+    const { entries, syncedAt, resynced } = await loadSitemap()
+    const allMatches = matchSitemap(entries, queryWords, locationWords)
+
+    const pageStart = (opts.page - 1) * opts.limit
+    const candidates = allMatches.slice(pageStart)
+
+    const probeCap = Math.min(Math.max(opts.limit * 3, PROBE_MIN), PROBE_MAX)
+    const jobageMs = opts.jobage !== undefined ? opts.jobage * 86400000 : undefined
+    const now = Date.now()
+
+    const results: JobCard[] = []
+    let probed = 0
+    for (const candidate of candidates) {
+      if (results.length >= opts.limit || probed >= probeCap) break
+      probed++
+      const html = await fetchText(candidate.url)
+      if (!html) continue
+      const detail = parseJobDetail(html, candidate.id, candidate.url)
+      if (!detail) continue
+      if (detail.isActive === false) continue
+      if (jobageMs !== undefined) {
+        if (!detail.date) continue
+        if (now - new Date(detail.date).getTime() > jobageMs) continue
+      }
+      results.push({
+        id: detail.id,
+        title: detail.title,
+        company: detail.company,
+        location: detail.location,
+        date: detail.date,
+        url: detail.url,
+      })
+    }
+
+    if (opts.format === "table") {
+      process.stdout.write(renderTable(results) + "\n")
+    } else if (opts.format === "plain") {
+      process.stdout.write(
+        results
+          .map((c) => `${c.title}\n  ${c.company || "—"} · ${c.location || "—"} · ${c.date || "—"}\n  ${c.url}`)
+          .join("\n\n") + "\n",
+      )
+    } else {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            meta: {
+              count: results.length,
+              page: opts.page,
+              matched: allMatches.length,
+              probed,
+              sitemapSyncedAt: syncedAt,
+              sitemapResynced: resynced,
+            },
+            results,
+          },
+          null,
+          2,
+        ) + "\n",
+      )
+    }
+    return 0
+  } catch (e) {
+    writeError(e instanceof Error ? e.message : String(e), "SEARCH_FAILED")
+    return 1
+  }
+}

--- a/.agents/skills/xing-search/cli/src/helpers.ts
+++ b/.agents/skills/xing-search/cli/src/helpers.ts
@@ -1,0 +1,267 @@
+// Data source: Xing has no lightweight keyword-search endpoint reachable without
+// hitting its GraphQL API, which robots.txt disallows for every crawler (including
+// the "ClaudeBot"/"GPTBot"/"PerplexityBot" group that robots.txt otherwise carves an
+// explicit exception for on /jobs/search/ - that page is a client-rendered shell with
+// no server-side job data, so the exception doesn't actually unlock anything usable).
+//
+// Job *detail* pages are different: they are fully server-rendered with a schema.org
+// JobPosting JSON-LD block, and both those pages and Xing's own job-URL sitemap
+// (https://www.xing.com/jobs/sitemap.xml.gz) are unrestricted for every crawler under
+// robots.txt's generic `User-agent: *` block. So "search" here means: cache the full
+// job-URL sitemap locally (13 shards, ~650k URLs as of 2026-09, refreshed at most once
+// per SITEMAP_CACHE_TTL_MS), keyword-match the query against each URL's slug, then
+// fetch and verify the most-likely-newest matches against their real detail pages.
+//
+// The sitemap keeps years-old expired postings mixed in with current ones and carries
+// no reliable freshness signal of its own - a shard's <lastmod> reflects Xing's last
+// sitemap-regeneration touch, not the posting date (verified against live data: a
+// posting last-modified two days before this was written carried a datePosted over a
+// year older). A job's numeric ID is a much better proxy - IDs are issued roughly
+// sequentially, so a higher ID correlates with a later posting date - but it is still
+// only a sort heuristic, never a substitute for the real datePosted/validThrough each
+// candidate's own detail page carries. Recency and liveness are only knowable after
+// that fetch, which is why `search` below probes candidates instead of trusting the
+// sitemap alone.
+
+import { gunzipSync } from "node:zlib"
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const SITEMAP_INDEX_URL = "https://www.xing.com/jobs/sitemap.xml.gz"
+export const JOBS_BASE_URL = "https://www.xing.com/jobs"
+
+const UA = "Mozilla/5.0 (compatible; xing-search-cli/1.0)"
+
+const CACHE_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", ".cache")
+const CACHE_FILE = join(CACHE_DIR, "sitemap-cache.json")
+// Matches the sitemap's own roughly-daily regeneration cadence observed live.
+export const SITEMAP_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+export function writeError(error: string, code: string): void {
+  process.stderr.write(JSON.stringify({ error, code }) + "\n")
+}
+
+async function withBackoff<T>(url: string, accept: string, timeoutMs: number, onResponse: (r: Response) => Promise<T | null>): Promise<T | null> {
+  const maxRetries = 6
+  let delay = 500
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, {
+      headers: { "User-Agent": UA, Accept: accept },
+      redirect: "follow",
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    if (response.status === 429 || response.status >= 500) {
+      if (attempt === maxRetries) {
+        throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+      }
+      const jitter = Math.floor(Math.random() * 500)
+      await new Promise((r) => setTimeout(r, delay + jitter))
+      delay = Math.min(delay * 2, 8000)
+      continue
+    }
+    return onResponse(response)
+  }
+  throw new Error("Request failed after max retries")
+}
+
+/** Fetch HTML/XML with exponential backoff on 429/5xx. Returns null on 404/410 (gone). */
+export async function fetchText(url: string): Promise<string | null> {
+  return withBackoff(url, "text/html,application/xml,*/*;q=0.8", 20000, async (response) => {
+    if (response.status === 404 || response.status === 410) return null
+    if (!response.ok) throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+    return response.text()
+  })
+}
+
+/** Fetch and gunzip a .gz URL, with the same backoff as fetchText. */
+async function fetchGunzipped(url: string): Promise<string> {
+  const result = await withBackoff(url, "application/gzip,*/*;q=0.8", 30000, async (response) => {
+    if (!response.ok) throw new Error(`Request failed: ${response.status} ${response.statusText}`)
+    const buf = Buffer.from(await response.arrayBuffer())
+    return gunzipSync(buf).toString("utf-8")
+  })
+  if (result === null) throw new Error(`Unexpected empty response fetching ${url}`)
+  return result
+}
+
+export interface SitemapEntry {
+  /** The full URL slug (path segment after /jobs/), e.g. "koeln-ot-cyber-security-senior-consultant-122981029". */
+  id: string
+  url: string
+}
+
+// Cache stores bare URLs only (id is always the URL's own trailing slug, so
+// persisting it a second time would roughly double a ~50MB+ cache file for
+// nothing).
+interface SitemapCache {
+  fetchedAt: string
+  urls: string[]
+}
+
+function parseLocs(xml: string): string[] {
+  const locs: string[] = []
+  const re = /<loc>([^<]+)<\/loc>/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(xml)) !== null) locs.push(m[1])
+  return locs
+}
+
+function toEntries(urls: string[]): SitemapEntry[] {
+  const entries: SitemapEntry[] = []
+  for (const url of urls) {
+    const id = url.split("/").filter(Boolean).pop()
+    if (id) entries.push({ id, url })
+  }
+  return entries
+}
+
+/** Download every job-posting sitemap shard and build the flat URL list. */
+async function syncSitemap(): Promise<string[]> {
+  const indexXml = await fetchGunzipped(SITEMAP_INDEX_URL)
+  // The sitemap index also lists non-posting sitemaps (roles, skills, locations,
+  // companies, employment types); only the numbered shards are individual postings.
+  const shardUrls = parseLocs(indexXml).filter((u) => /\/jobs\/\d+-sitemap\.xml\.gz$/.test(u))
+  const urls: string[] = []
+  for (const shardUrl of shardUrls) {
+    const xml = await fetchGunzipped(shardUrl)
+    urls.push(...parseLocs(xml))
+  }
+  return urls
+}
+
+/** Load the cached sitemap, refreshing it if missing, corrupt, or older than the TTL. */
+export async function loadSitemap(): Promise<{ entries: SitemapEntry[]; syncedAt: string; resynced: boolean }> {
+  if (existsSync(CACHE_FILE)) {
+    try {
+      const cache = JSON.parse(readFileSync(CACHE_FILE, "utf-8")) as SitemapCache
+      if (Date.now() - new Date(cache.fetchedAt).getTime() < SITEMAP_CACHE_TTL_MS) {
+        return { entries: toEntries(cache.urls), syncedAt: cache.fetchedAt, resynced: false }
+      }
+    } catch {
+      // Corrupt cache file - fall through and resync.
+    }
+  }
+  const urls = await syncSitemap()
+  const fetchedAt = new Date().toISOString()
+  mkdirSync(CACHE_DIR, { recursive: true })
+  writeFileSync(CACHE_FILE, JSON.stringify({ fetchedAt, urls } satisfies SitemapCache))
+  return { entries: toEntries(urls), syncedAt: fetchedAt, resynced: true }
+}
+
+/** Xing's own slug transliteration: lowercase, äöüß -> ae/oe/ue/ss, everything else -> "-". */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/ä/g, "ae")
+    .replace(/ö/g, "oe")
+    .replace(/ü/g, "ue")
+    .replace(/ß/g, "ss")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+/** The numeric suffix of a slug - see the file-header note on why this is only a sort heuristic. */
+function trailingId(slug: string): number {
+  const m = slug.match(/-(\d+)$/)
+  return m ? parseInt(m[1], 10) : 0
+}
+
+/** Keyword-match (AND, substring) each cached slug against the query/location words, newest-ID first. */
+export function matchSitemap(entries: SitemapEntry[], queryWords: string[], locationWords: string[]): SitemapEntry[] {
+  const matches = entries.filter((e) => {
+    if (!queryWords.every((w) => e.id.includes(w))) return false
+    if (locationWords.length > 0 && !locationWords.some((w) => e.id.includes(w))) return false
+    return true
+  })
+  return matches.sort((a, b) => trailingId(b.id) - trailingId(a.id))
+}
+
+export interface JobCard {
+  id: string
+  title: string
+  company: string | null
+  location: string | null
+  date: string | null
+  url: string
+}
+
+export interface JobDetail extends JobCard {
+  description: string | null
+  employmentType: string | null
+  industry: string | null
+  validThrough: string | null
+  /** null when Xing gave no validThrough to check liveness against - never inferred. */
+  isActive: boolean | null
+}
+
+function numericEntity(cp: number): string {
+  return cp >= 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : ""
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, dec) => numericEntity(parseInt(dec, 10)))
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (_, hex) => numericEntity(parseInt(hex, 16)))
+    .replace(/&nbsp;/g, " ")
+}
+
+function htmlToText(html: string): string {
+  const withBreaks = html.replace(/<\s*br\s*\/?>/gi, "\n").replace(/<\/(p|li|ul|ol|div|h\d|article)>/gi, "\n")
+  return decodeHtmlEntities(withBreaks.replace(/<[^>]+>/g, "")).replace(/\n{3,}/g, "\n\n").trim()
+}
+
+interface RawJobPosting {
+  ["@type"]?: string
+  title?: string
+  description?: string
+  datePosted?: string
+  validThrough?: string
+  employmentType?: string
+  industry?: string
+  hiringOrganization?: { name?: string }
+  jobLocation?: Array<{ address?: { addressLocality?: string; addressRegion?: string } }>
+}
+
+/** Extract and parse the page's schema.org JobPosting JSON-LD block. */
+function extractJobPosting(html: string): RawJobPosting | null {
+  const m = html.match(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/)
+  if (!m) return null
+  try {
+    const obj = JSON.parse(m[1])
+    return obj && obj["@type"] === "JobPosting" ? obj : null
+  } catch {
+    return null
+  }
+}
+
+/** Parse a job detail page. Returns null if the page carries no JobPosting JSON-LD (markup drift). */
+export function parseJobDetail(html: string, id: string, url: string): JobDetail | null {
+  const posting = extractJobPosting(html)
+  if (!posting || !posting.title) return null
+
+  const addr = posting.jobLocation?.[0]?.address
+  const location = addr ? [addr.addressLocality, addr.addressRegion].filter(Boolean).join(", ") || null : null
+
+  const isActive = posting.validThrough ? new Date(posting.validThrough).getTime() >= Date.now() : null
+
+  return {
+    id,
+    title: decodeHtmlEntities(posting.title),
+    company: posting.hiringOrganization?.name ?? null,
+    location,
+    date: posting.datePosted ?? null,
+    validThrough: posting.validThrough ?? null,
+    employmentType: posting.employmentType ?? null,
+    industry: posting.industry ?? null,
+    description: posting.description ? htmlToText(posting.description) : null,
+    isActive,
+    url,
+  }
+}

--- a/.agents/skills/xing-search/cli/tests/cli-contract.test.ts
+++ b/.agents/skills/xing-search/cli/tests/cli-contract.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { runCLI } from "./helpers";
+
+describe("Xing CLI error contract", () => {
+  test("search without a query fails with JSON on stderr, before any request", async () => {
+    const result = await runCLI(["search"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "the --query/-q flag is required",
+      code: "NO_QUERY",
+    });
+  });
+
+  test("detail without an id fails before any request", async () => {
+    const result = await runCLI(["detail"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: "detail requires an <id|url>",
+      code: "NO_ID",
+    });
+  });
+
+  test("detail with a bare numeric id is rejected (Xing needs the full slug)", async () => {
+    const result = await runCLI(["detail", "122981029"]);
+
+    expect(result.exitCode).toBe(1);
+    const err = JSON.parse(result.stderr);
+    expect(err.code).toBe("BAD_ID");
+    expect(err.error).toContain("full slug");
+  });
+
+  test("an unknown flag is rejected, not silently ignored", async () => {
+    const result = await runCLI(["search", "--query", "test", "--bogus", "x"]);
+
+    expect(result.exitCode).toBe(1);
+    const err = JSON.parse(result.stderr);
+    expect(err.code).toBe("UNKNOWN_FLAG");
+  });
+
+  test("a non-integer --limit fails before any request", async () => {
+    const result = await runCLI(["search", "--query", "test", "--limit", "not-a-number"]);
+
+    expect(result.exitCode).toBe(1);
+    const err = JSON.parse(result.stderr);
+    expect(err.code).toBe("BAD_ARG");
+  });
+});

--- a/.agents/skills/xing-search/cli/tests/helpers.test.ts
+++ b/.agents/skills/xing-search/cli/tests/helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { matchSitemap, parseJobDetail, slugify, type SitemapEntry } from "../src/helpers";
+
+describe("slugify", () => {
+  test("transliterates German umlauts and ß the way Xing's own slugs do", () => {
+    expect(slugify("Köln")).toBe("koeln");
+    expect(slugify("Düsseldorf")).toBe("duesseldorf");
+    expect(slugify("Straße")).toBe("strasse");
+  });
+
+  test("lowercases and collapses non-alphanumerics to single hyphens", () => {
+    expect(slugify("Embedded Software Engineer (m/w/d)")).toBe("embedded-software-engineer-m-w-d");
+  });
+
+  test("trims leading/trailing hyphens", () => {
+    expect(slugify("  Projektleiter!  ")).toBe("projektleiter");
+  });
+});
+
+describe("matchSitemap", () => {
+  const entries: SitemapEntry[] = [
+    { id: "koeln-ot-cyber-security-senior-consultant-100000001", url: "https://www.xing.com/jobs/koeln-ot-cyber-security-senior-consultant-100000001" },
+    { id: "berlin-junior-service-consultant-microsoft-dynamics-100000002", url: "https://www.xing.com/jobs/berlin-junior-service-consultant-microsoft-dynamics-100000002" },
+    { id: "frankfurt-embedded-software-engineer-100000003", url: "https://www.xing.com/jobs/frankfurt-embedded-software-engineer-100000003" },
+    { id: "muenchen-embedded-software-engineer-100000004", url: "https://www.xing.com/jobs/muenchen-embedded-software-engineer-100000004" },
+  ];
+
+  test("requires every query word to appear in the slug (AND match)", () => {
+    const matches = matchSitemap(entries, ["embedded", "software"], []);
+    expect(matches.map((m) => m.id)).toEqual([
+      "muenchen-embedded-software-engineer-100000004",
+      "frankfurt-embedded-software-engineer-100000003",
+    ]);
+  });
+
+  test("sorts matches by trailing numeric id descending (newest-looking first)", () => {
+    const matches = matchSitemap(entries, ["embedded"], []);
+    expect(matches[0].id).toContain("100000004");
+    expect(matches[1].id).toContain("100000003");
+  });
+
+  test("location words are OR-matched and additionally required", () => {
+    const matches = matchSitemap(entries, ["embedded"], ["frankfurt"]);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].id).toContain("frankfurt");
+  });
+
+  test("no matches when a query word appears nowhere", () => {
+    expect(matchSitemap(entries, ["nonexistent-keyword"], [])).toHaveLength(0);
+  });
+});
+
+describe("parseJobDetail", () => {
+  function pageWithJsonLd(posting: object): string {
+    return `<html><head><script data-ch type="application/ld+json">${JSON.stringify(posting)}</script></head></html>`;
+  }
+
+  const BASE_POSTING = {
+    "@context": "https://schema.org/",
+    "@type": "JobPosting",
+    title: "Embedded Software Engineer (m/w/d)",
+    description: "<H3>Frankfurt</H3><ARTICLE><P>Do the thing &amp; more</P></ARTICLE>",
+    datePosted: "2026-01-01T00:00:00Z",
+    employmentType: "FULL_TIME",
+    industry: "Automotive",
+    hiringOrganization: { "@type": "Organization", name: "Acme GmbH" },
+    jobLocation: [{ "@type": "Place", address: { "@type": "PostalAddress", addressLocality: "Frankfurt", addressRegion: "Hessen" } }],
+  };
+
+  test("maps schema.org JobPosting fields onto the JobDetail contract", () => {
+    const html = pageWithJsonLd({ ...BASE_POSTING, validThrough: "2099-01-01T00:00:00Z" });
+    const detail = parseJobDetail(html, "frankfurt-embedded-software-engineer-1", "https://www.xing.com/jobs/frankfurt-embedded-software-engineer-1");
+
+    expect(detail).not.toBeNull();
+    expect(detail!.title).toBe("Embedded Software Engineer (m/w/d)");
+    expect(detail!.company).toBe("Acme GmbH");
+    expect(detail!.location).toBe("Frankfurt, Hessen");
+    expect(detail!.date).toBe("2026-01-01T00:00:00Z");
+    expect(detail!.description).toContain("Do the thing & more");
+    expect(detail!.isActive).toBe(true);
+  });
+
+  test("a validThrough in the past marks the posting inactive", () => {
+    const html = pageWithJsonLd({ ...BASE_POSTING, validThrough: "2000-01-01T00:00:00Z" });
+    const detail = parseJobDetail(html, "id", "url");
+    expect(detail!.isActive).toBe(false);
+  });
+
+  test("a missing validThrough is unknown liveness, never inferred", () => {
+    const html = pageWithJsonLd(BASE_POSTING);
+    const detail = parseJobDetail(html, "id", "url");
+    expect(detail!.isActive).toBeNull();
+  });
+
+  test("returns null when the page carries no JobPosting JSON-LD (markup drift)", () => {
+    expect(parseJobDetail("<html><body>nothing here</body></html>", "id", "url")).toBeNull();
+  });
+});

--- a/.agents/skills/xing-search/cli/tests/helpers.ts
+++ b/.agents/skills/xing-search/cli/tests/helpers.ts
@@ -1,0 +1,39 @@
+import { join } from "path";
+
+const CLI_PATH = join(import.meta.dir, "../src/cli.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export async function runCLI(args: string[]): Promise<CLIResult> {
+  const proc = Bun.spawn(["bun", "run", CLI_PATH, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+export function parseJSON<T = unknown>(result: CLIResult): T {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `CLI exited with code ${result.exitCode}. stderr: ${result.stderr}`
+    );
+  }
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    throw new Error(
+      `Failed to parse JSON. stdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  }
+}

--- a/.agents/skills/xing-search/cli/tsconfig.json
+++ b/.agents/skills/xing-search/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/.agents/skills/xing-search/url-reference.md
+++ b/.agents/skills/xing-search/url-reference.md
@@ -1,0 +1,122 @@
+# Xing Jobs URL Reference
+
+## Access rules (checked live, 2026-09-11)
+
+`https://www.xing.com/robots.txt` has three relevant blocks:
+
+```
+User-agent: *
+...
+Disallow: /search/
+Disallow: /jobs/search/
+Disallow: /jobs/search?*
+...
+Disallow: /graphql/
+Disallow: /graphql/api
+Disallow: /xas/api/
+
+User-agent: GPTBot
+User-agent: GPTUser
+User-agent: ClaudeBot
+User-agent: Claude-User
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+Allow: /jobs/search/
+Allow: /jobs/search?*
+...
+Disallow: /graphql/api
+Disallow: /graphql/
+```
+
+The named-AI-crawler block carves out `/jobs/search/` specifically, but that page
+(`GET https://www.xing.com/jobs/search?keywords=...`, 301→`/jobs/search/ki?...`) is a
+client-rendered React SPA — the raw HTML response is only loading skeletons, no job
+data. The real search results load client-side via Xing's GraphQL API, which is
+`Disallow`'d for **every** user-agent group, AI carve-out included. So the carve-out
+doesn't unlock anything usable; there is no way to reach Xing's actual keyword search
+without violating `robots.txt`.
+
+**Neither `/jobs/<slug>` (detail pages) nor `/jobs/sitemap.xml.gz` (or its shards)
+appear in any `Disallow` rule for `User-agent: *`.** That's the path this skill
+uses — it is open to any honest crawler, no AI-specific UA needed. The CLI's
+User-Agent is the repo's normal convention (`Mozilla/5.0 (compatible;
+xing-search-cli/1.0)`), not an AI-crawler identity.
+
+## Sitemap (used for "search")
+
+```
+GET https://www.xing.com/jobs/sitemap.xml.gz
+```
+
+Returns a gzipped `<sitemapindex>` of per-category sitemaps. Only the numeric shards
+(`https://www.xing.com/jobs/<N>-sitemap.xml.gz`, `N` = 1..13 as of 2026-09) are
+individual job-posting URLs; the others (`jobs_roles_sitemap`, `jobs_skills_sitemap`,
+`jobs_locations_sitemap`, `jobs_companies_sitemap`, `jobs_employment_types_sitemap`,
+etc.) are category/faceting sitemaps, not postings, and the CLI filters them out.
+
+Each shard is a gzipped `<urlset>` of ~50,000 `<url><loc>...</loc><lastmod>...</lastmod></url>`
+entries, e.g.:
+
+```
+<url><loc>https://www.xing.com/jobs/koeln-ot-cyber-security-senior-consultant-122981029</loc><lastmod>2026-09-09T20:13:03+00:00</lastmod></url>
+```
+
+**`<lastmod>` is not the posting date and must never be used as one.** Verified live:
+a posting with `<lastmod>2026-09-09...` carried `datePosted: 2024-07-22...` in its own
+detail page's JSON-LD — over a year older. `<lastmod>` only reflects when Xing's
+sitemap generator last touched the entry.
+
+The trailing digits in the slug (e.g. `122981029`) are a much better recency proxy —
+Xing's job IDs are issued roughly sequentially (verified live: two postings ~900k IDs
+apart were ~24 days apart in `datePosted`) — but it's still only a sort heuristic for
+deciding which candidates to probe first, never a substitute for the real
+`datePosted`/`validThrough` on the candidate's own detail page.
+
+~650,000 URLs total across all shards as of 2026-09-11 (13 shards × ~50,000). The CLI
+downloads and caches the full set (`cli/.cache/sitemap-cache.json`, gitignored,
+~50MB) for 24h, then matches the query as an AND-substring test against each URL's
+slug (see `slugify()` in `cli/src/helpers.ts` — lowercase, `äöüß` → `ae/oe/ue/ss`,
+everything else → `-`, matching Xing's own transliteration).
+
+## Detail page
+
+```
+GET https://www.xing.com/jobs/<slug>-<id>
+```
+
+Server-rendered. The response's `<head>` carries exactly one
+`<script type="application/ld+json">` block, a `schema.org` `JobPosting`:
+
+```json
+{
+  "@type": "JobPosting",
+  "title": "...",
+  "description": "<HTML fragment, entity-escaped>",
+  "datePosted": "2024-07-22T21:31:42Z",
+  "validThrough": "2025-01-21T12:26:18Z",
+  "employmentType": "FULL_TIME",
+  "industry": "Beratung, Consulting",
+  "hiringOrganization": { "name": "...", "url": "...", "logo": "..." },
+  "jobLocation": [{ "address": { "addressLocality": "...", "addressRegion": "...", "addressCountry": "DE" } }]
+}
+```
+
+The CLI parses this block directly (`extractJobPosting` / `parseJobDetail` in
+`cli/src/helpers.ts`) rather than scraping visible markup — it's the same data Xing
+serves to search engines, and far more stable than CSS class names.
+
+**A bare numeric ID does not resolve reliably.** Verified live:
+`https://www.xing.com/jobs/122981029` (no slug words) returned HTTP 200 with a
+**completely different job** than
+`https://www.xing.com/jobs/koeln-ot-cyber-security-senior-consultant-122981029`. Always
+pass the full slug (or full URL) as returned by `search` — never just the trailing
+digits.
+
+A removed/expired-from-index posting returns **HTTP 410** (verified live on a
+deliberately bogus slug), not 404. The CLI's `fetchText` treats both as "not found."
+
+## Notes
+
+- No authentication required anywhere in this flow.
+- Respect rate limits — the CLI backs off on 429/5xx with the same exponential-backoff-with-jitter convention as the other portal skills.
+- If Xing changes its sitemap-index structure, its per-shard count, or the JSON-LD shape, update the regexes/paths above accordingly — this file is the map for that.

--- a/.claude/skills/job-scraper/search-queries.md
+++ b/.claude/skills/job-scraper/search-queries.md
@@ -12,14 +12,14 @@ The `site:` query templates in this file are the **WebSearch fallback** — for 
 
 ## Search Sites
 
-Primary (your market's job boards - scaffold one with `/add-portal`):
-- **[YOUR_JOB_BOARD]** - your market's largest general job board
-- **linkedin.com/jobs** - LinkedIn job listings (filter: [YOUR_COUNTRY] / [YOUR_CITY]); also covered by `linkedin-search` CLI
-- **[YOUR_INDUSTRY_JOB_BOARD]** - a niche/industry board for your field (optional)
-- **[YOUR_ADDITIONAL_JOB_BOARD]** - another major board for your market (optional)
+Primary:
+- **linkedin.com/jobs** - LinkedIn job listings (filter: Germany / remote); also covered by `linkedin-search` CLI
+- **freehire-search** CLI - general country-agnostic coverage
+- **arbeitsagentur-search** CLI - Bundesagentur für Arbeit (Germany's official employment agency job board), added via `/add-portal`. Has a `--remote` flag (filters on each posting's own home-office flag) and a `--radius` flag for distance-based search around a city - useful for the remote-first, then Fulda/Frankfurt/Munich location preference. StepStone.de and Indeed Germany remain ruled out: each explicitly disallows automated search access in its own `robots.txt`.
+- **xing-search** CLI - Xing (xing.com), the DACH-market professional network, added via `/add-portal`. Xing's own job-search page and GraphQL API are `robots.txt`-disallowed for every crawler, so this works differently from every other portal here: it caches Xing's public job-URL sitemap and verifies keyword matches against each candidate's server-rendered detail page rather than hitting a real search endpoint. See `.agents/skills/xing-search/url-reference.md` for the full access-rules writeup. Because the sitemap mixes years-old expired postings with current ones, a search can return fewer results than requested - that's expected, not a bug.
 
 Secondary (company career pages via Google):
-- Direct Google searches with `site:` filters for known target companies
+- Direct Google searches with `site:` filters for known target companies (none specified yet - candidate is open to any non-automotive sector)
 
 ## Query Categories
 
@@ -27,54 +27,71 @@ Queries are grouped by priority. Write **each category in every language from yo
 
 **Organize by function, not job title.** The same underlying work carries different titles across companies and markets (a "Data Scientist" role at one employer may be posted as "Insights Analyst" or "Data Consultant" at another). Name each priority category after the function it covers, and list several plausible job titles as query variants within that category rather than betting an entire priority tier on one exact title string.
 
-### Priority 1: [YOUR_PRIMARY_ROLE_TYPE]
+### Priority 1: Project / Technical Leadership
 
-These match your strongest and most desired career direction.
-
-```
-site:[YOUR_JOB_BOARD] "[YOUR_PRIMARY_JOB_TITLE_1]" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_PRIMARY_JOB_TITLE_2]" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_KEY_SKILL]" [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_PRIMARY_JOB_TITLE_1]" [YOUR_COUNTRY]
-```
-
-### Priority 2: [YOUR_DOMAIN_EXPERTISE]
-
-These match your domain expertise.
+These match the strongest and most desired career direction: a full Project Lead role, owning delivery end-to-end (not just Scrum facilitation).
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] OR [YOUR_REGION]
-site:[YOUR_JOB_BOARD] [YOUR_DOMAIN_KEYWORD_2] [YOUR_COUNTRY]
-site:linkedin.com/jobs [YOUR_DOMAIN_KEYWORD_1] [YOUR_CITY] [YOUR_COUNTRY]
+site:linkedin.com/jobs "Project Lead" Germany
+site:linkedin.com/jobs "Technical Project Lead" Germany
+site:linkedin.com/jobs "Projektleiter" Deutschland
+"Project Lead" remote Germany
+"Projektleiter" Softwareentwicklung remote
 ```
 
-### Priority 3: [YOUR_ADJACENT_ROLE_TYPE]
+### Priority 2: Senior Embedded / C Engineering
 
-Adjacent roles you could pivot into.
+These match deep technical domain expertise - the alternative target lane to Priority 1.
 
 ```
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_1]" [YOUR_KEY_SKILL] [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "[YOUR_ADJACENT_TITLE_2]" [YOUR_KEY_SKILL] [YOUR_CITY]
+site:linkedin.com/jobs "Senior Embedded Engineer" Germany
+site:linkedin.com/jobs "Senior C Engineer" OR "Senior C Developer" Germany
+"embedded" "bare-metal" OR "low-level" C engineer remote
+"Embedded Software Engineer" bare-metal Germany
+"Eingebettete Systeme" Entwickler C remote
 ```
+
+### Priority 3: Non-Automotive Sector Pivot (semiconductor, industrial, medtech, energy)
+
+Sector-first queries rather than title-first, aimed squarely at the "leave automotive" goal - semiconductor (echoing the AMD/AIXTRON/Arm candidates found this session), industrial automation, medical devices, and energy are the sectors that have surfaced the strongest non-automotive matches so far.
+
+```
+site:linkedin.com/jobs "embedded" OR "firmware" semiconductor Germany
+site:linkedin.com/jobs C engineer "medical device" OR "medizintechnik" Germany
+"Embedded Software" Halbleiter OR semiconductor remote Germany
+"Firmware Engineer" Germany -automotive
+```
+
+**Note:** this replaced a former "Agile / Scrum Leadership" category. The candidate does not want to work as a Scrum Master - see the Deal-breakers note below and `04-job-evaluation.md`'s Career goals. Scrum/SAFe remains a genuine skill worth mentioning in a cover letter for a Technical Lead role, but is no longer a search target on its own.
 
 ### Priority 4: Broader Technical / Consulting
 
-Wider net for general technical roles.
+Wider net for general technical roles, explicitly outside the automotive sector (see career goal in `01-candidate-profile.md` / `04-job-evaluation.md`).
 
 ```
-site:[YOUR_JOB_BOARD] [YOUR_KEY_SKILL] developer [YOUR_CITY]
-site:linkedin.com/jobs "[YOUR_KEY_SKILL] developer" [YOUR_CITY]
-site:[YOUR_JOB_BOARD] "technical consultant" [YOUR_DOMAIN] [YOUR_CITY]
+"C developer" remote Germany -automotive
+"technical consultant" embedded OR "low-level" Germany
+site:linkedin.com/jobs "software engineer" C bare-metal -automotive
 ```
+
+**Sector note:** the candidate has an explicit goal to leave the automotive industry after 8+ years in it. Deprioritize postings at automotive OEMs/Tier-1 suppliers unless the role is fully remote or otherwise a clearly strong match; a non-automotive sector is itself a positive signal in `04-job-evaluation.md`'s Career Alignment dimension.
+
+**Skill note - C, not C++:** the candidate is expert-level in C but a self-assessed beginner in C++. Do not add "C++" as a search term on its own - a posting whose title or core requirement is C++ (e.g. "C++ Developer", "modern C++", "C++14/17/20") is a real skill gap, not a synonym for C. A posting listing "C or C++" or "C/C++" as an either/or requirement is fine to include, since C alone covers it; one requiring strong, independent C++ ownership is not, even if C also appears on the CV.
 
 ## Location Filter
 
-When evaluating results, verify the job location is within reasonable commute distance from your home. Define acceptable areas:
-- [YOUR_CITY] and surrounding areas
-- [ACCEPTABLE_AREA_1]
-- [ACCEPTABLE_AREA_2]
-- [BORDERLINE_AREA] (borderline - ~X min by transit)
-- [TOO_FAR_AREA] (too far)
+When evaluating results, verify the job location matches the candidate's preference. Define acceptable areas:
+- **Fully remote** - top preference, any location in Germany (or EU with compatible time zone)
+- Fulda and surrounding area
+- Frankfurt am Main
+- Munich (acceptable, implies relocation)
+- Any other location requiring relocation, without remote/hybrid flexibility (too far - deal-breaker, see `04-job-evaluation.md`)
+
+Also treat a **hard-required 5 days/week in-office policy** and a **significant/frequent travel requirement** as deal-breakers regardless of city - see `04-job-evaluation.md`'s Location & Logistics dimension.
+
+**Role-type note - not a Scrum Master.** The candidate does not want to work as a Scrum Master or Agile Coach, even though it is part of his current job title and a genuine skill. Do not search for or score up "Scrum Master" / "Agile Coach" as a target role on its own - see `04-job-evaluation.md`'s Career goals and Motivation filter.
+
+**Sector exclusion - not defense.** The candidate does not want to work in the defense/military sector, even at a company that also has acceptable civilian divisions. Deprioritize and flag roles involving secure/military communications, cryptographic devices for government/military use, avionics/airborne defense, or weapons systems - and companies whose core business is defense (Rheinmetall, HENSOLDT, Helsing, Diehl, etc.) outright. See `04-job-evaluation.md`'s Motivation filter.
 
 ## Language Filter
 

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ company_research/*.json
 .agents/**/node_modules/
 .agents/**/*.log
 .agents/usage/
+# xing-search's locally-synced job sitemap cache (~50MB, rebuilt from Xing's
+# public sitemap on demand - not something to commit).
+.agents/**/.cache/
 
 # Brainstorm mockups (superpowers visual companion) - never ship
 .superpowers/


### PR DESCRIPTION
## Summary
- Adds `xing-search`, a new `/add-portal`-style CLI skill for Xing (xing.com), the DACH-market professional network.
- Xing's `/jobs/search` page and GraphQL API are `robots.txt`-disallowed for every crawler (including the `ClaudeBot`/`GPTBot`/`PerplexityBot` carve-out that otherwise permits `/jobs/search/` — that page turns out to be an empty client-rendered shell with no server-side job data anyway). Job detail pages and the public job-URL sitemap are unrestricted for any crawler under the generic `User-agent: *` block, so this CLI works differently from every other portal in the repo: it caches Xing's sitemap (~650k URLs, 13 shards, 24h TTL) locally, keyword-matches the query against each URL's slug, then verifies the most-likely-newest matches against their real server-rendered detail pages (`schema.org` `JobPosting` JSON-LD).
- Full access-rules writeup, with live-verified evidence, in `.agents/skills/xing-search/url-reference.md`.
- Registers the new CLI's coverage in `.claude/skills/job-scraper/search-queries.md` (previously noted Xing as ruled out entirely) and updates the old blanket "search-queries.md" `[YOUR_JOB_BOARD]`-note accordingly; adds the sitemap cache dir to `.gitignore`.

## Notes for review
- Live-tested: `search -q "Embedded Software Engineer"` and `detail <slug>` both verified against the real site during development (see PR discussion / session for sample output) — real, current postings with correctly decoded German text.
- Because the sitemap mixes years-old expired postings with current ones, `search` can return fewer results than `--limit` if its bounded detail-fetch probe budget (15–30 per call) runs out before enough live matches turn up. This is documented as expected behavior, not a bug.
- `detail` requires the full slug/URL as returned by `search` — a bare numeric Xing job ID does not reliably resolve to the same posting (verified live).
- Typecheck and the full test suite (16 tests, unit + CLI-contract) pass.

## Test plan
- [x] `bun install && bun run typecheck` in `.agents/skills/xing-search/cli`
- [x] `bun run test` (16/16 passing)
- [x] Live `search` smoke test with a real query, verified real/fresh results
- [x] Live `detail` smoke test on a search result, verified readable decoded description
- [ ] User review of the robots.txt/access-rules tradeoffs in `url-reference.md` before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)