### PR TITLE
chore(agents): add runtime discovery pointers

### DIFF
--- a/.agents/skills/job-application-assistant/SKILL.md
+++ b/.agents/skills/job-application-assistant/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: job-application-assistant
+description: >
+  Evaluate job postings, tailor CVs, write cover letters, and prepare for
+  interviews using the canonical job-application workflow.
+---
+
+# Job Application Assistant
+
+This is a discovery pointer for agent runtimes that scan `.agents/skills/`.
+
+Before acting, read and follow the canonical specification at
+`.claude/skills/job-application-assistant/SKILL.md`. Load any companion files it
+references from that same canonical directory. Treat `.claude/` as the single
+source of truth; do not copy or modify the workflow here.

--- a/.agents/skills/job-scraper/SKILL.md
+++ b/.agents/skills/job-scraper/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: job-scraper
+description: >
+  Find, deduplicate, assess, and track job postings using the canonical scraper
+  workflow and installed portal-search CLIs.
+---
+
+# Job Scraper
+
+This is a discovery pointer for agent runtimes that scan `.agents/skills/`.
+
+Before acting, read and follow the canonical specification at
+`.claude/skills/job-scraper/SKILL.md`. Load `search-queries.md` and other files
+from that canonical directory. Treat `.claude/` as the single source of truth;
+do not copy or modify the workflow here.

--- a/.agents/skills/source-command-expand/SKILL.md
+++ b/.agents/skills/source-command-expand/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: source-command-expand
+description: Run the canonical competency-expansion workflow for `/expand`.
+---
+
+# Expand Command
+
+This is a discovery pointer for agent runtimes that scan `.agents/skills/`.
+
+Before acting, read and follow `.claude/commands/expand.md` exactly. Treat that
+file as the single source of truth; do not copy or modify the workflow here.

--- a/.agents/skills/source-command-html-report/SKILL.md
+++ b/.agents/skills/source-command-html-report/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: source-command-html-report
+description: Run the canonical application-dashboard workflow for `/html-report`.
+---
+
+# HTML Report Command
+
+This is a discovery pointer for agent runtimes that scan `.agents/skills/`.
+
+Before acting, read and follow `.claude/commands/html-report.md` exactly. Treat
+that file as the single source of truth; do not copy or modify the workflow
+here.

--- a/.agents/skills/upskill/SKILL.md
+++ b/.agents/skills/upskill/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: upskill
+description: >
+  Analyze tracked jobs for skill gaps and create a prioritized learning plan
+  using the canonical `/upskill` workflow.
+---
+
+# Upskill
+
+This is a discovery pointer for agent runtimes that scan `.agents/skills/`.
+
+Before acting, read and follow the canonical specification at
+`.claude/skills/upskill/SKILL.md`. Treat `.claude/` as the single source of
+truth; do not copy or modify the workflow here.

--- a/.codex/agents/gemini-research-expert.toml
+++ b/.codex/agents/gemini-research-expert.toml
@@ -1,0 +1,7 @@
+name = "gemini-research-expert"
+description = "Use this agent for web research, external-source gathering, and evidence synthesis."
+developer_instructions = """
+Before acting, read and follow `.claude/agents/gemini-research-expert.md`.
+Treat that file as the canonical specification and single source of truth.
+Ignore only its Claude-specific frontmatter fields; follow the instruction body.
+"""


### PR DESCRIPTION
## Summary
- add portable discovery pointers for job-application, scraper, upskill, and migrated command workflows
- add a Codex research-agent definition that delegates to the canonical Claude specification
- preserve `.claude/` as the single source of truth and avoid duplicated workflow content

## Verification
- `uv run --with pytest pytest --tb=short -q` — 426 passed, 6 skipped, 154 subtests passed
- `python tools/lint_skills.py` — passed
- validated TOML/YAML syntax and all canonical pointer targets
- independent Codex review found no blockers